### PR TITLE
links for map, website, gmail implemented

### DIFF
--- a/src/features/public/Donations/components/projectDetails/ProjectContactDetails.tsx
+++ b/src/features/public/Donations/components/projectDetails/ProjectContactDetails.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react';
 import styles from './../../styles/ProjectDetails.module.scss';
-import Link from 'next/link';
 
 interface Props {
   contactDetails: Array<{
@@ -12,10 +11,6 @@ interface Props {
 }
 
 function ProjectContactDetails({ contactDetails }: Props): ReactElement {
-  React.useEffect(() => {
-    console.log('heree', contactDetails);
-  });
-
   return (
     <div className={styles.projectMoreInfo}>
       <div className={styles.infoTitle}>Contact Details</div>

--- a/src/features/public/Donations/components/projectDetails/ProjectContactDetails.tsx
+++ b/src/features/public/Donations/components/projectDetails/ProjectContactDetails.tsx
@@ -1,31 +1,45 @@
-import React, { ReactElement } from 'react'
-import styles from './../../styles/ProjectDetails.module.scss'
+import React, { ReactElement } from 'react';
+import styles from './../../styles/ProjectDetails.module.scss';
+import Link from 'next/link';
 
 interface Props {
-    contactDetails:Array<{
-        id: number;
-        icon: JSX.Element;
-        text: string;
-        link: string;
-    }> 
+  contactDetails: Array<{
+    id: number;
+    icon: JSX.Element;
+    text: string;
+    link: string;
+  }>;
 }
 
-function ProjectContactDetails({contactDetails}: Props): ReactElement {
-    return (
-        <div className={styles.projectMoreInfo}>
-            <div className={styles.infoTitle}>
-                Contact Details
-            </div>
-                {contactDetails.map((contactDetails) =>(
-                    <div key={contactDetails.id}>
-                            <div className={styles.infoText+" "+styles.contactDetailsRow}>
-                                {contactDetails.icon}
-                                <span style={{marginLeft:'20px',flexGrow:1}}>{contactDetails.text}</span>
-                            </div>
-                        </div>
-                ))}
+function ProjectContactDetails({ contactDetails }: Props): ReactElement {
+  React.useEffect(() => {
+    console.log('heree', contactDetails);
+  });
+
+  return (
+    <div className={styles.projectMoreInfo}>
+      <div className={styles.infoTitle}>Contact Details</div>
+      {contactDetails.map((contactDetails) => (
+        <div key={contactDetails.id}>
+          <div className={styles.infoText + ' ' + styles.contactDetailsRow}>
+            {contactDetails.icon}
+
+            {contactDetails.link ? (
+              <span style={{ marginLeft: '20px', flexGrow: 1 }}>
+                <a href={contactDetails.link} target="_blank">
+                  {contactDetails.text}
+                </a>
+              </span>
+            ) : (
+              <span style={{ marginLeft: '20px', flexGrow: 1 }}>
+                {contactDetails.text}
+              </span>
+            )}
+          </div>
         </div>
-    )
+      ))}
+    </div>
+  );
 }
 
-export default ProjectContactDetails
+export default ProjectContactDetails;

--- a/src/features/public/Donations/components/projectDetails/ProjectContactDetails.tsx
+++ b/src/features/public/Donations/components/projectDetails/ProjectContactDetails.tsx
@@ -20,7 +20,7 @@ function ProjectContactDetails({ contactDetails }: Props): ReactElement {
             {contactDetails.icon}
 
             {contactDetails.link ? (
-              <span style={{ marginLeft: '20px', flexGrow: 1 }}>
+              <span style={{ marginLeft: '16px', flexGrow: 1 }}>
                 <a href={contactDetails.link} target="_blank">
                   {contactDetails.text}
                 </a>

--- a/src/features/public/Donations/screens/ProjectDetails.tsx
+++ b/src/features/public/Donations/screens/ProjectDetails.tsx
@@ -18,23 +18,26 @@ interface Props {
 }
 
 function ProjectDetails({ project }: Props): ReactElement {
+
+
   const [rating, setRating] = React.useState<number | null>(2);
 
   const progressPercentage =
     (project.countPlanted / project.countTarget) * 100 + '%';
   const ImageSource = project.image
     ? getImageUrl('project', 'large', project.image)
-    : '';
+    : ''
+
   const contactDetails = [
-    { id: 1, icon: <BlackTree />, text: 'View Profile', link: '' },
-    { id: 2, icon: <WorldWeb />, text: 'edenprojects.org', link: '' },
+    { id: 1, icon: <BlackTree />, text: 'View Profile', link: null },
+    { id: 2, icon: <WorldWeb />, text: project.website ?  project.website : 'unavailable', link: project.website },
     {
       id: 3,
       icon: <Location />,
-      text: '303 W Foothill Blvd, Unit 13 Glendora, CA 91741, USA',
-      link: '',
+      text: project.tpo.address ? project.tpo.address: 'unavailable',
+      link: project.coordinates ? `https://maps.google.com/?q=${project.coordinates.lat},${project.coordinates.lon}` : null,
     },
-    { id: 4, icon: <Email />, text: 'projects@edenprojects.org', link: '' },
+    { id: 4, icon: <Email />, text: project.tpo.email ? project.tpo.email : 'unavailable', link: project.tpo.email ? `https://mail.google.com/mail/?view=cm&fs=1&tf=1&to=${project.tpo.email}` : null },
   ];
 
   const loadImageSource = (image: any) => {

--- a/src/features/public/Donations/screens/ProjectDetails.tsx
+++ b/src/features/public/Donations/screens/ProjectDetails.tsx
@@ -37,11 +37,11 @@ function ProjectDetails({ project }: Props): ReactElement {
       text: project.tpo.address ? project.tpo.address: 'unavailable',
       link: project.coordinates ? `https://maps.google.com/?q=${project.coordinates.lat},${project.coordinates.lon}` : null,
     },
-    { id: 4, icon: <Email />, text: project.tpo.email ? project.tpo.email : 'unavailable', link: project.tpo.email ? `https://mail.google.com/mail/?view=cm&fs=1&tf=1&to=${project.tpo.email}` : null },
+    { id: 4, icon: <Email />, text: project.tpo.email ? project.tpo.email : 'unavailable', link: project.tpo.email ? `mailto:${project.tpo.email}` : null },
   ];
 
   const loadImageSource = (image: any) => {
-    const ImageSource = getImageUrl('project', 'large', image);
+    const ImageSource = getImageUrl('project', 'medium', image);
     return ImageSource;
   };
 


### PR DESCRIPTION
Changes in this pull request:
In Single Project Details page:
- Link to respective locations in google maps
- Link to gmail with repsective receipent
- Link to its website
(shows 'unavailable' if any field is missing in the database)
<img src="https://user-images.githubusercontent.com/53833059/89070519-c4e13180-d392-11ea-8b62-b7eed1075c08.JPG" width="300" title="movies tab" hspace=20>

