### PR TITLE
added translations for navigation elements using item.title as translation keys

### DIFF
--- a/public/static/locales/de/common.json
+++ b/public/static/locales/de/common.json
@@ -9,7 +9,11 @@
   "contact": "Kontakt",
   "supportUs": "Unterstütze uns",
   "leaders": "Spitzenreiter",
+  "leaderboard": "Bestenliste",
   "me": "Ich",
+  "home": "Start",
+  "donate_gift": "Spenden/Schenken",
+  "plant": "Pflanzen",
   "donate": "Spenden",
   "gift": "Schenken",
   "continue": "Weiter",
@@ -19,5 +23,6 @@
   "cancel": "Abbrechen",
   "thankYou": "Vielen Dank",
   "privacyPolicyNotice": "Durch die Nutzung dieser Website akzeptierst Du unsere",
-  "privacyPolicy": "Datenschutz-Erklärung"
+  "privacyPolicy": "Datenschutz-Erklärung",
+  "about_pftp": "Über Plant-for-the-Planet"
 }

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -9,7 +9,11 @@
   "contact": "Contact",
   "supportUs": "Support Us",
   "leaders": "Leaders",
+  "leaderboard": "Leaderboard",
   "me": "Me",
+  "home": "Home",
+  "donate_gift": "Donate/Gift",
+  "plant": "Plant",
   "donate": "Donate",
   "gift": "Gift",
   "continue": "Continue",
@@ -19,5 +23,6 @@
   "cancel": "Cancel",
   "thankYou": "Thank You",
   "privacyPolicyNotice": "By using this website, you agree to our",
-  "privacyPolicy": "privacy policy"
+  "privacyPolicy": "privacy policy",
+  "about_pftp": "About Plant-for-the-Planet"
 }

--- a/public/tenants/planet/config.ts
+++ b/public/tenants/planet/config.ts
@@ -19,28 +19,28 @@ const config = {
     items: [
       {
         id: 1,
-        title: 'Home',
+        title: 'home',
         onclick: '/home',
         visible: false,
         key: 'home',
       },
       {
         id: 2,
-        title: 'Donate/Gift',
+        title: 'donate_gift',
         onclick: '/',
         visible: true,
         key: 'donate',
       },
       {
         id: 3,
-        title: 'Leaders',
+        title: 'leaderboard',
         onclick: '/leaderboard',
         visible: true,
         key: 'leaderboard',
       },
       {
         id: 4,
-        title: 'Me',
+        title: 'me',
         onclick: '/me',
         visible: true,
         key: 'me',

--- a/public/tenants/planet/configBeta.ts
+++ b/public/tenants/planet/configBeta.ts
@@ -18,21 +18,21 @@ const config = {
     items: [
       {
         id: 1,
-        title: 'Home',
+        title: 'home',
         onclick: '/home',
         visible: false,
         key: 'home',
       },
       {
         id: 2,
-        title: 'Donate/Gift',
+        title: 'donate_gift',
         onclick: '/',
         visible: true,
         key: 'donate',
       },
       {
         id: 3,
-        title: 'Leaders',
+        title: 'leaderboard',
         onclick: '/',
         visible: false,
         key: 'leaderboard',
@@ -40,7 +40,7 @@ const config = {
 
       {
         id: 4,
-        title: 'Me',
+        title: 'me',
         onclick: '/me',
         visible: false,
         key: 'me',

--- a/public/tenants/salesforce/config.ts
+++ b/public/tenants/salesforce/config.ts
@@ -17,28 +17,28 @@ const config = {
     items: [
       {
         id: 1,
-        title: 'Home',
+        title: 'home',
         onclick: '/home',
         visible: true,
         key: 'home',
       },
       {
         id: 3,
-        title: 'Donate/Gift',
+        title: 'donate_gift',
         onclick: '/',
         visible: true,
         key: 'donate',
       },
       {
         id: 2,
-        title: 'Leaders',
+        title: 'leaderboard',
         onclick: '/',
         visible: false, // Leaders is false for Salesforce
         key: 'leaderboard',
       },
       {
         id: 4,
-        title: 'Me',
+        title: 'me',
         onclick: '/me',
         visible: false, // Me is false for Salesforce
         key: 'me',

--- a/public/tenants/stern/config.ts
+++ b/public/tenants/stern/config.ts
@@ -25,28 +25,28 @@ const config = {
     items: [
       {
         id: 1,
-        title: 'Home',
+        title: 'home',
         onclick: '/home',
         visible: true,
         key: 'home',
       },
       {
         id: 2,
-        title: 'Pflanzen',
+        title: 'plant',
         onclick: '/',
         visible: true,
         key: 'donate',
       },
       {
         id: 3,
-        title: 'Leaderboard',
+        title: 'leaderboard',
         onclick: '/leaderboard',
         visible: false,
         key: 'leaderboard',
       },
       {
         id: 4,
-        title: 'Me',
+        title: 'me',
         onclick: '/me',
         visible: false,
         key: 'me',

--- a/src/features/common/Layout/Footer/index.tsx
+++ b/src/features/common/Layout/Footer/index.tsx
@@ -121,7 +121,7 @@ export default function Footer() {
               <a href="http://www.plant-for-the-planet.org/" target="_blank">
                 <img
                   src={`${process.env.CDN_URL}/logo/svg/planet.svg`}
-                  alt="About Plant-for-the-Planet"
+                  alt={t('common:about_pftp')}
                 />
               </a>
             </div>

--- a/src/features/common/Layout/Navbar/index.tsx
+++ b/src/features/common/Layout/Navbar/index.tsx
@@ -12,10 +12,14 @@ import Me from '../../../../../public/assets/images/navigation/Me';
 import MeSelected from '../../../../../public/assets/images/navigation/MeSelected';
 import { ThemeContext } from '../../../../theme/themeContext';
 import styles from './Navbar.module.scss';
+import i18next from '../../../../../i18n';
 
+
+const { useTranslation } = i18next;
 const config = tenantConfig();
 
 export default function NavbarComponent(props: any) {
+  const { t } = useTranslation(['common']);
   const router = useRouter();
 
   const { toggleTheme } = React.useContext(ThemeContext);
@@ -46,7 +50,7 @@ export default function NavbarComponent(props: any) {
                   <a href="https://www.plant-for-the-planet.org">
                     <img
                       src={`${process.env.CDN_URL}/logo/svg/planet.svg`}
-                      alt="About Plant-for-the-Planet"
+                      alt={t('common:about_pftp')}
                     />
                   </a>
                 </div>
@@ -62,7 +66,7 @@ export default function NavbarComponent(props: any) {
                     <a href="https://www.plant-for-the-planet.org">
                       <img
                         src={`${process.env.CDN_URL}/logo/svg/planet.svg`}
-                        alt="About Plant-for-the-Planet"
+                        alt={t('common:about_pftp')}
                       />
                     </a>
                   </div>
@@ -90,7 +94,7 @@ export default function NavbarComponent(props: any) {
                               : ''
                           }
                         >
-                          {item.title}
+                          {t('common:'+ item.title)}
                         </p>
                       </div>
                     </Link>
@@ -112,7 +116,7 @@ export default function NavbarComponent(props: any) {
                               : ''
                           }
                         >
-                          {item.title}
+                          {t('common:'+ item.title)}
                         </p>
                       </div>
                     </Link>
@@ -136,7 +140,7 @@ export default function NavbarComponent(props: any) {
                               : ''
                           }
                         >
-                          {item.title}
+                          {t('common:'+ item.title)}
                         </p>
                       </div>
                   </Link>
@@ -159,7 +163,7 @@ export default function NavbarComponent(props: any) {
                               : ''
                           }
                         >
-                          {item.title}
+                          {t('common:'+ item.title)}
                         </p>
                       </div>
                   </Link>


### PR DESCRIPTION
Changes in this pull request:
- using title of navigation item as a translation key to support i18n for the navigation items
- translated some alt text of images

@
