### PR TITLE
Feature/allow tenant config to reduce supported languages

### DIFF
--- a/src/features/common/Layout/Footer/SelectLanguageAndCountry.tsx
+++ b/src/features/common/Layout/Footer/SelectLanguageAndCountry.tsx
@@ -15,9 +15,14 @@ import { ThemeContext } from '../../../../theme/themeContext';
 import GreenRadio from '../../InputTypes/GreenRadio';
 let styles = require('./SelectLanguageAndCountry.module.scss');
 import i18next from '../../../../../i18n';
+import tenantConfig from '../../../../../tenant.config';
 
+const config = tenantConfig();
 const { useTranslation } = i18next;
 
+// reduce the allowed languages to the languages listed in the tenants config file
+const selectableLanguages = supportedLanguages.filter(lang => config.languages.includes(lang.langCode));
+        
 export default function TransitionsModal(props) {
   const {
     openModal,
@@ -29,7 +34,7 @@ export default function TransitionsModal(props) {
     setSelectedCountry,
   } = props;
   const [modalLanguage, setModalLanguage] = useState('en');
-  const [selectedModalCountry, setSelectedModalCountry] = useState('AF');
+  const [selectedModalCountry, setSelectedModalCountry] = useState('US');
 
   const { i18n } = useTranslation();
   const { t } = useTranslation(['common', 'country']);
@@ -167,7 +172,7 @@ function MapLanguage(props) {
         onChange={handleChange}
         className={styles.currencyGrid}
       >
-        {supportedLanguages.map((lang) => (
+        {selectableLanguages.map((lang) => (
           <FormControlLabel
             key={lang.langCode}
             value={lang.langCode}


### PR DESCRIPTION
Fixes #

Changes in this pull request:
- allow the tenant config languages definition to override the supported languages, e.g. limit tenant to English only
- changing default country to United States