### PR TITLE
calculate workers from Heroku env variable if available

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,7 +18,9 @@ if (!dev && cluster.isMaster) {
   console.log(`Node cluster master ${process.pid} is running`);
 
   // Fork workers.
-  for (let i = 0; i < numCPUs; i += 1) {
+  const WORKERS = process.env.WEB_CONCURRENCY || numCPUs;
+  console.log('Number of workers calculated:', WORKERS);
+  for (let i = 0; i < WORKERS; i++) {
     cluster.fork();
   }
 


### PR DESCRIPTION
Fixes #

Changes in this pull request:
- calculate workers from Heroku env variable if available
- requires env variable WEB_MEMORY to be set at Heroku as described at https://devcenter.heroku.com/articles/node-memory-use#running-multiple-processes

@sagararyal 