### PR TITLE
adapted the package.json dependencies of i18n to the main package.json

### DIFF
--- a/i18n/package.json
+++ b/i18n/package.json
@@ -6,8 +6,9 @@
   "main": "./server.js",
   "browser": "./client.js",
   "dependencies": {
-    "next-i18next": "^6.0.2",
-    "i18next": "^19.7.0",
-    "i18next-browser-languagedetector": "^6.0.1"
+    "next-i18next": "^6.0.3",
+    "i18next": "^19.8.3",
+    "i18next-browser-languagedetector": "^6.0.1",
+    "react-i18next": "^11.7.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2237,28 +2237,6 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "@sentry/core": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.26.0.tgz",
-      "integrity": "sha512-Ubrw7K52orTVsaxpz8Su40FPXugKipoQC+zPrXcH+JIMB+o18kutF81Ae4WzuUqLfP7YB91eAlRrP608zw0EXA==",
-      "requires": {
-        "@sentry/hub": "5.26.0",
-        "@sentry/minimal": "5.26.0",
-        "@sentry/types": "5.26.0",
-        "@sentry/utils": "5.26.0",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/hub": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.26.0.tgz",
-      "integrity": "sha512-lAYeWvvhGYS6eQ5d0VEojw0juxGc3v4aAu8VLvMKWcZ1jXD13Bhc46u9Nvf4qAY6BAQsJDQcpEZLpzJu1bk1Qw==",
-      "requires": {
-        "@sentry/types": "5.26.0",
-        "@sentry/utils": "5.26.0",
-        "tslib": "^1.9.3"
-      }
-    },
     "@sentry/integrations": {
       "version": "5.27.0",
       "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-5.27.0.tgz",
@@ -2284,16 +2262,6 @@
             "tslib": "^1.9.3"
           }
         }
-      }
-    },
-    "@sentry/minimal": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.26.0.tgz",
-      "integrity": "sha512-mdFo3FYaI1W3KEd8EHATYx8mDOZIxeoUhcBLlH7Iej6rKvdM7p8GoECrmHPU1l6sCCPtBuz66QT5YeXc7WILsA==",
-      "requires": {
-        "@sentry/hub": "5.26.0",
-        "@sentry/types": "5.26.0",
-        "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
@@ -2406,20 +2374,6 @@
             "tslib": "^1.9.3"
           }
         }
-      }
-    },
-    "@sentry/types": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.26.0.tgz",
-      "integrity": "sha512-ugpa1ePOhK55pjsyutAsa2tiJVQEyGYCaOXzaheg/3+EvhMdoW+owiZ8wupfvPhtZFIU3+FPOVz0d5k9K5d1rw=="
-    },
-    "@sentry/utils": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.26.0.tgz",
-      "integrity": "sha512-F2gnHIAWbjiowcAgxz3VpKxY/NQ39NTujEd/NPnRTWlRynLFg3bAV+UvZFXljhYJeN3b/zRlScNDcpCWTrtZGw==",
-      "requires": {
-        "@sentry/types": "5.26.0",
-        "tslib": "^1.9.3"
       }
     },
     "@sentry/webpack-plugin": {


### PR DESCRIPTION
Fixes #

Changes in this pull request:
- `npm run lint:errors` complained about `react-i18next` missing in the `i18n/package.json` file, so I added it and update the other packages to fit the version number of the main `package.json` file.

Question: Do we need an additional `i18n/package.json` file and if yes, do we have to specify the i18n npm modules twice here?