### PR TITLE
adding files for deep links of native apps

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,18 @@
+{
+    "applinks": {
+        "apps": [],
+        "details": [
+            {
+                "appID": "UYRJ8SA699.org.plant-for-the-planet.app",
+                "paths": [ "/", "/imprint*", "/edit-profile*", "/login*",
+                    "/password-sent*", "/signup*", "/my-trees*", "/forgot-password*", "/account-activation*",
+                    "/faq*", "/about_us*", "/license_info_list*", "/data-protection-policy*",
+                    "/redeem*", "/claim*", "/edit-trees*", "/target*", "/challenge*",
+                    "/app_gift_projects*", "/account-activate*", "/home*", "/register-trees*",
+                    "/competitions*", "/donate-trees*", "/gift-trees*", "/competition*",
+                    "/edit-competition*", "/app_donate_detail*", "/select-project*", "/reset-password*",
+                    "/t/*", "/project/*" ]
+            }
+        ]
+    }
+}

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "org.pftp",
+      "sha256_cert_fingerprints": [
+        "33:F3:D2:3E:5D:82:AF:5D:4B:26:51:68:94:31:C4:DC:46:AB:7B:19:E3:13:E4:7E:F6:E7:2D:70:D9:D9:CA:6E"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
Changes in this pull request:
- adding files for deep links of native apps

Actually I think not all urls listed in the attached files are _real_ deep links as only a few open a special screen within the app.
The deep links doing more then opening the app mostly can be found at the following source code in the Treecounter-App: https://github.com/Plant-for-the-Planet-org/treecounter-app/blob/d52ae1189c808481dd886fa5a45cfa0ac8a0551e/app/components/Menu/index.native.js#L94-L187

I tried to read them from the source code as following: `signup`, `account-activate`, `reset-password`, `competition`, `t`, `project` and `donate-trees`, e.g.:
- https://www.trilliontreecampaign.org/signup
- https://www.trilliontreecampaign.org/signup/vodafone
- https://www.trilliontreecampaign.org/account-activate/xxxxxxxxx
- https://www.trilliontreecampaign.org/reset-password/xxxxxxxxx
- https://www.trilliontreecampaign.org/competition/137
- https://www.trilliontreecampaign.org/t/norbert-schuler
- https://www.trilliontreecampaign.org/project/1
- https://www.trilliontreecampaign.org/t/donate-trees
- https://www.trilliontreecampaign.org/t/donate-trees/1

Disclaimer: This patch does not help to support these routes in the app.