### PR TITLE
load config (to fill local storage) for every kind of page

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,6 +14,7 @@ import getConfig from 'next/config';
 import Layout from '../src/features/common/Layout';
 import MapLayout from '../src/features/projects/components/MapboxMap';
 import { useRouter } from 'next/router';
+import storeConfig from '../src/utils/storeConfig';
 
 if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
   const config = getConfig();
@@ -47,6 +48,9 @@ export default function PlanetWeb({ Component, pageProps, err }: any) {
 
   const [initialized, setInitialized] = React.useState(false);
 
+  React.useEffect(() => {
+    storeConfig();
+  }, []);
   React.useEffect(() => {
     i18next.initPromise.then(() => setInitialized(true));
   }, []);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,6 @@ import ProjectsList from '../src/features/projects/screens/Projects';
 import GetAllProjectsMeta from '../src/utils/getMetaTags/GetAllProjectsMeta';
 import getStoredCurrency from '../src/utils/countryCurrency/getStoredCurrency';
 import { getRequest } from '../src/utils/apiRequests/api';
-import storeConfig from '../src/utils/storeConfig';
 import DirectGift from '../src/features/donations/components/treeDonation/DirectGift';
 
 interface Props {
@@ -31,9 +30,6 @@ export default function Donate({
   const router = useRouter();
   const [directGift, setDirectGift] = React.useState(null);
   const [showdirectGift, setShowDirectGift] = React.useState(true);
-  React.useEffect(() => {
-    storeConfig();
-  }, []);
 
   React.useEffect(() => {
     const getdirectGift = localStorage.getItem('directGift');


### PR DESCRIPTION
Fixes #486
Fixes #484

Changes in this pull request:
- load config (to fill local storage) for every kind of page

As the existence of the `countryCode` and `currencyCode` values in the local storage is critical for the current version of the app, it should be loaded for all kind of pages and not just for some of them. If I understood it correctly `_app.tsx` is executed for every page of the app, it it? So it would be the logical place to load the config.

Of course the config API request could also be triggered dynamically if the values are requested, but do not exists in the local storage. For that we would need to abstract the fetching of values from the local storage and add a fallback to trigger the config API call is case of missing values. I am not sure what solution is more elegant.

Last we should also consider if there are clients not supporting local storage (maybe because of a full disk) which would fail to work if our application does not also keep the config values in memory, but only relies on local storage!