### PR TITLE
added number localization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14241,19 +14241,6 @@
         "debug": "^4.1.0"
       }
     },
-    "sugar": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/sugar/-/sugar-2.0.6.tgz",
-      "integrity": "sha512-s0P2/pjJtAD9VA44+2Gqm3NdC4v+08melA6YubOxzshu628krTbn95/M2GWMrI9rYspZMpYBIrChR46fjQ7xsQ==",
-      "requires": {
-        "sugar-core": "^2.0.0"
-      }
-    },
-    "sugar-core": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/sugar-core/-/sugar-core-2.0.6.tgz",
-      "integrity": "sha512-YmLFysR3Si6RImqL1+aB6JH81EXxvXn5iXhPf2PsjfoUYEwCxFDYCQY+zC3WqviuGWzxFaSkkJvkUE05Y03L5Q=="
-    },
     "supercluster": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "react-player": "^2.6.2",
     "read-more-react": "^1.0.10",
     "styled-jsx": "^3.3.1",
-    "sugar": "^2.0.6",
     "uuid": "^8.3.1",
     "viewport-mercator-project": "^6.1.1",
     "vizzuality-components": "^3.0.3"

--- a/src/features/common/TreeCounter/TreeCounter.tsx
+++ b/src/features/common/TreeCounter/TreeCounter.tsx
@@ -3,10 +3,10 @@ import CircularProgress, {
 } from '@material-ui/core/CircularProgress';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import React from 'react';
-import Sugar from 'sugar';
 import treeCounterStyles from './TreeCounter.module.scss';
 import i18next from '../../../../i18n';
 import EditIcon from '../../../../public/assets/images/icons/manageProjects/Pencil';
+import { localizedAbbreviatedNumber } from '../../../utils/getFormattedNumber';
 
 const { useTranslation } = i18next;
 
@@ -48,7 +48,7 @@ function FacebookCircularProgress(props: CircularProgressProps) {
 export default function TpoProfile(props: any) {
   const [progress, setProgress] = React.useState(0);
 
-  const { t } = useTranslation(['me']);
+  const { t, i18n } = useTranslation(['me']);
   React.useEffect(() => {
     let percentage = 0;
     if (props.target > 0) {
@@ -80,13 +80,13 @@ export default function TpoProfile(props: any) {
       <div className={treeCounterStyles.backgroundCircle} />
       <div className={treeCounterStyles.treeCounterData}>
         <div className={treeCounterStyles.treeCounterDataField}>
-          <h1>{Sugar.Number.abbr(Number(props.planted), 1)}</h1>
+          <h1>{localizedAbbreviatedNumber(i18n.language, Number(props.planted), 1)}</h1>
           <h2>{t('me:treesPlanted')}</h2>
         </div>
         
         {props.target ? (
           <div className={treeCounterStyles.treeCounterDataField}>
-            <h1>{Sugar.Number.abbr(Number(props.target), 1)}</h1>
+            <h1>{localizedAbbreviatedNumber(i18n.language, Number(props.target), 1)}</h1>
             <div className={treeCounterStyles.target}>
               <h2
                 className={

--- a/src/features/donations/screens/ContactDetails.tsx
+++ b/src/features/donations/screens/ContactDetails.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react';
 import { useForm } from 'react-hook-form';
-import Sugar from 'sugar';
 import BackArrow from '../../../../public/assets/images/icons/headerIcons/BackArrow';
 import AnimatedButton from '../../common/InputTypes/AnimatedButton';
 import AutoCompleteCountry from '../../common/InputTypes/AutoCompleteCountry';
@@ -10,6 +9,7 @@ import { ContactDetailsPageProps } from '../../common/types/donations';
 import styles from '../styles/ContactDetails.module.scss';
 import i18next from '../../../../i18n/';
 import getFormatedCurrency from '../../../utils/countryCurrency/getFormattedCurrency';
+import { getFormattedNumber } from '../../../utils/getFormattedNumber';
 import COUNTRY_ADDRESS_POSTALS from '../../../utils/countryZipCode';
 
 const { useTranslation } = i18next;
@@ -234,7 +234,7 @@ function ContactDetails({
           </div>
           <div className={styles.totalCostText}>
             {t('donate:fortreeCountTrees', {
-              treeCount: Sugar.Number.format(Number(treeCount)),
+              treeCount: getFormattedNumber(i18n.language, Number(treeCount)),
             })}
           </div>
         </div>

--- a/src/features/donations/screens/PaymentDetails.tsx
+++ b/src/features/donations/screens/PaymentDetails.tsx
@@ -9,7 +9,6 @@ import {
   useStripe,
 } from '@stripe/react-stripe-js';
 import React, { ReactElement } from 'react';
-import Sugar from 'sugar';
 import CreditCard from '../../../../public/assets/images/icons/donation/CreditCard';
 import BackArrow from '../../../../public/assets/images/icons/headerIcons/BackArrow';
 import { getCardBrand } from '../../../utils/stripe/stripeHelpers';
@@ -20,6 +19,7 @@ import styles from './../styles/PaymentDetails.module.scss';
 import { createDonation, payDonation, payWithCard } from '../components/treeDonation/PaymentFunctions';
 import i18next from '../../../../i18n/';
 import getFormatedCurrency from '../../../utils/countryCurrency/getFormattedCurrency';
+import { getFormattedNumber } from '../../../utils/getFormattedNumber';
 import PaypalIcon from '../../../../public/assets/images/icons/donation/PaypalIcon';
 import Paypal from '../../legacyDonations/components/Paypal';
 import { paypalCurrencies } from '../../../utils/paypalCurrencies';
@@ -446,7 +446,7 @@ function PaymentDetails({
           </div>
           <div className={styles.totalCostText}>
             {t('donate:fortreeCountTrees', {
-              treeCount: Sugar.Number.format(Number(treeCount)),
+              treeCount: getFormattedNumber(i18n.language, Number(treeCount)),
             })}
           </div>
         </div>

--- a/src/features/donations/screens/ThankYou.tsx
+++ b/src/features/donations/screens/ThankYou.tsx
@@ -1,7 +1,6 @@
 import Snackbar from '@material-ui/core/Snackbar';
 import MuiAlert, { AlertProps } from '@material-ui/lab/Alert';
 import React, { ReactElement } from 'react';
-import Sugar from 'sugar';
 import tenantConfig from '../../../../tenant.config';
 import Close from '../../../../public/assets/images/icons/headerIcons/close';
 import { ThankYouProps } from '../../common/types/donations';
@@ -10,6 +9,7 @@ import ShareOptions from '../components/ShareOptions';
 import { getPaymentType } from '../components/treeDonation/PaymentFunctions';
 import i18next from '../../../../i18n/';
 import getFormatedCurrency from '../../../utils/countryCurrency/getFormattedCurrency';
+import { getFormattedNumber } from '../../../utils/getFormattedNumber';
 
 const { useTranslation } = i18next;
 
@@ -81,7 +81,7 @@ function ThankYou({
           })}
 {' '}
         {t('donate:yourTreesPlantedByOnLocation', {
-          treeCount: Sugar.Number.format(Number(treeCount)),
+          treeCount: getFormattedNumber(i18n.language, Number(treeCount)),
           projectName: project.name,
           location: t('country:' + project.country.toLowerCase()),
         })}
@@ -101,7 +101,7 @@ function ThankYou({
           </div>
             <p className={styles.tempDonationCount}>
               {t('donate:myTreesPlantedByOnLocation', {
-                treeCount: Sugar.Number.format(Number(treeCount)),
+                treeCount: getFormattedNumber(i18n.language, Number(treeCount)),
                 location: t('country:' + project.country.toLowerCase()),
               })}
             </p>
@@ -118,7 +118,7 @@ function ThankYou({
           </div>
           <div className={styles.donationCount}>
             {t('donate:myTreesPlantedByOnLocation', {
-              treeCount: Sugar.Number.format(Number(treeCount)),
+              treeCount: getFormattedNumber(i18n.language, Number(treeCount)),
               location: t('country:' + project.country.toLowerCase()),
             })}
             <p className={styles.donationTenant}>

--- a/src/features/donations/screens/TreeDonation.tsx
+++ b/src/features/donations/screens/TreeDonation.tsx
@@ -1,6 +1,5 @@
 import { motion } from 'framer-motion';
 import React, { ReactElement } from 'react';
-import Sugar from 'sugar';
 import DownArrow from '../../../../public/assets/images/icons/DownArrow';
 import Close from '../../../../public/assets/images/icons/headerIcons/close';
 import { formatAmountForStripe } from '../../../utils/stripe/stripeHelpers';
@@ -17,6 +16,7 @@ import DirectGiftForm from '../components/treeDonation/DirectGiftForm';
 import { payWithCard } from '../components/treeDonation/PaymentFunctions';
 import i18next from '../../../../i18n/';
 import getFormatedCurrency from '../../../utils/countryCurrency/getFormattedCurrency';
+import { getFormattedNumber } from '../../../utils/getFormattedNumber';
 
 const { useTranslation } = i18next;
 
@@ -319,7 +319,7 @@ function TreeDonation({
           </div>
           <div className={styles.totalCostText}>
             {t('donate:fortreeCountTrees', {
-              treeCount: Sugar.Number.format(Number(treeCount)),
+              treeCount: getFormattedNumber(i18n.language, Number(treeCount)),
             })}
           </div>
         </div>

--- a/src/features/legacyDonations/components/CardPayments.tsx
+++ b/src/features/legacyDonations/components/CardPayments.tsx
@@ -219,7 +219,7 @@ function CardPayments({
         </div>
         <div className={styles.totalCostText}>
           {t('donate:fortreeCountTrees', {
-            treeCount: Sugar.Number.format(Number(treeCount)),
+            treeCount: getFormattedNumber(i18n.language, Number(treeCount)),
           })}
         </div>
       </div> */}

--- a/src/features/legacyDonations/index.tsx
+++ b/src/features/legacyDonations/index.tsx
@@ -9,7 +9,7 @@ import { formatAmountForStripe } from '../../utils/stripe/stripeHelpers';
 import { getRequest } from '../../utils/apiRequests/api';
 import i18next from '../../../i18n/';
 import getFormatedCurrency from '../../utils/countryCurrency/getFormattedCurrency';
-import Sugar from 'sugar';
+import { getFormattedNumber } from '../../utils/getFormattedNumber';
 import { payDonation } from '../donations/components/treeDonation/PaymentFunctions';
 import PaymentProgress from '../common/ContentLoaders/Donations/PaymentProgress';
 import ThankYou from '../donations/screens/ThankYou';
@@ -243,7 +243,7 @@ const paypalSuccess =(data:any)=>{
           </div>
           <div className={styles.totalCostText}>
             {t('donate:fortreeCountTrees', {
-              treeCount: Sugar.Number.format(Number(treeCount)),
+              treeCount: getFormattedNumber(i18n.language, Number(treeCount)),
             })}
           </div>
         </div>

--- a/src/features/projects/components/PopupProject.tsx
+++ b/src/features/projects/components/PopupProject.tsx
@@ -1,13 +1,14 @@
 import Modal from '@material-ui/core/Modal';
 import { Elements } from '@stripe/react-stripe-js';
 import React, { ReactElement, Ref } from 'react';
-import Sugar from 'sugar';
 import getImageUrl from '../../../utils/getImageURL';
 import getStripe from '../../../utils/stripe/getStripe';
 import { ThemeContext } from '../../../theme/themeContext';
 import DonationsPopup from '../../donations';
 import i18next from '../../../../i18n/'
 import getFormatedCurrency from '../../../utils/countryCurrency/getFormattedCurrency';
+import { localizedAbbreviatedNumber } from '../../../utils/getFormattedNumber';
+import { truncateString } from '../../../utils/TruncateText';
 
 const { useTranslation } = i18next;
 interface Props {
@@ -71,7 +72,7 @@ export default function PopupProject({
               </div> */}
 
           <div className={'projectName'}>
-            {Sugar.String.truncate(project.properties.name, 54)}
+            {truncateString(project.properties.name, 54)}
           </div>
         </div>
       </div>
@@ -86,7 +87,7 @@ export default function PopupProject({
         <div className={'projectData'}>
           <div className={'targetLocation'}>
             <div className={'target'}>
-              {Sugar.Number.abbr(Number(project.properties.countPlanted), 1)}{' '}
+              {localizedAbbreviatedNumber(i18n.language, Number(project.properties.countPlanted), 1)}{' '}
               {t('common:planted')} •{' '}
               <span style={{ fontWeight: 400 }}>
               {t('country:' + project.properties.country.toLowerCase())}

--- a/src/features/projects/components/ProjectSnippet.tsx
+++ b/src/features/projects/components/ProjectSnippet.tsx
@@ -1,7 +1,6 @@
 import Modal from '@material-ui/core/Modal';
 import { Elements } from '@stripe/react-stripe-js';
 import React, { ReactElement } from 'react';
-import Sugar from 'sugar';
 import getImageUrl from '../../../utils/getImageURL';
 import getStripe from '../../../utils/stripe/getStripe';
 import { ThemeContext } from '../../../theme/themeContext';
@@ -11,6 +10,8 @@ import i18next from '../../../../i18n/';
 import getFormatedCurrency from '../../../utils/countryCurrency/getFormattedCurrency';
 import EditIcon from '../../../../public/assets/images/icons/manageProjects/Pencil';
 import Link from 'next/link';
+import { localizedAbbreviatedNumber } from '../../../utils/getFormattedNumber';
+import { truncateString } from '../../../utils/TruncateText';
 
 const { useTranslation } = i18next;
 interface Props {
@@ -92,7 +93,7 @@ export default function ProjectSnippet({
                 {GetProjectClassification(project.classification)}
               </div> */}
           <div className={'projectName'}>
-            {Sugar.String.truncate(project.name, 54)}
+            {truncateString(project.name, 54)}
           </div>
         </div>
       </div>
@@ -107,7 +108,7 @@ export default function ProjectSnippet({
         <div className={'projectData'}>
           <div className={'targetLocation'}>
             <div className={'target'}>
-              {Sugar.Number.abbr(Number(project.countPlanted), 1)}{' '}
+              {localizedAbbreviatedNumber(i18n.language, Number(project.countPlanted), 1)}{' '}
               {t('common:planted')} •{' '}
               <span style={{ fontWeight: 400 }}>
                 {t('country:' + project.country.toLowerCase())}

--- a/src/features/user/UserProfile/components/UserInfo.tsx
+++ b/src/features/user/UserProfile/components/UserInfo.tsx
@@ -3,7 +3,7 @@ import styles from '../styles/UserInfo.module.scss';
 import TreeCounter from './../../../common/TreeCounter/TreeCounter';
 import UserProfileOptions from './UserProfileOptions';
 import UserShareAndSupport from './UserShareAndSupport';
-import trimwords from '../../../../utils/TruncateText';
+import { trimwords } from '../../../../utils/TruncateText';
 
 export default function UserInfo({
   userprofile,

--- a/src/tenants/common/LeaderBoard/index.tsx
+++ b/src/tenants/common/LeaderBoard/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import Sugar from 'sugar';
 import styles from './LeaderBoard.module.scss';
 import i18next from '../../../../i18n';
+import { getFormattedNumber } from '../../../utils/getFormattedNumber';
 
 interface Props {
   leaderboard: any;
@@ -11,7 +11,7 @@ export default function LeaderBoardSection(leaderboard: Props) {
   const [selectedTab, setSelectedTab] = React.useState('recent');
   const leaderboardData = leaderboard.leaderboard;
   const { useTranslation } = i18next;
-  const { t } = useTranslation(['leaderboard', 'common']);
+  const { t, i18n } = useTranslation(['leaderboard', 'common']);
 
   return (
     <section className={styles.leaderBoardSection}>
@@ -51,7 +51,7 @@ export default function LeaderBoardSection(leaderboard: Props) {
                       {leader.donorName}
                     </p>
                     <p className={styles.leaderBoardDonorTrees}>
-                      {Sugar.Number.format(Number(leader.treeCount))} {t('common:trees')}
+                      {getFormattedNumber(i18n.language, Number(leader.treeCount))} {t('common:trees')}
                     </p>
                     {/* <p className={styles.leaderBoardDonorTime}>
                           {leader.created}
@@ -67,7 +67,7 @@ export default function LeaderBoardSection(leaderboard: Props) {
                       {leader.donorName}
                     </p>
                     <p className={styles.leaderBoardDonorTrees}>
-                      {Sugar.Number.format(Number(leader.treeCount))} {t('common:trees')}
+                      {getFormattedNumber(i18n.language, Number(leader.treeCount))} {t('common:trees')}
                     </p>
                   </div>
                 ))}

--- a/src/tenants/planet/LeaderBoard/components/Score.tsx
+++ b/src/tenants/planet/LeaderBoard/components/Score.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import Sugar from 'sugar';
 import styles from './LeaderBoard.module.scss';
 import i18next from '../../../../../i18n';
+import getFormattedNumber from '../../../../utils/getFormattedNumber';
 
 interface Props {
   leaderboard: any;
@@ -11,7 +11,7 @@ export default function LeaderBoardSection(leaderboard: Props) {
   const [selectedTab, setSelectedTab] = React.useState('recent');
   const leaderboardData = leaderboard.leaderboard;
   const { useTranslation } = i18next;
-  const { t } = useTranslation(['leaderboard', 'common']);
+  const { t, i18n } = useTranslation(['leaderboard', 'common']);
 
   return (
     <section className={styles.leaderBoardSection}>
@@ -51,7 +51,7 @@ export default function LeaderBoardSection(leaderboard: Props) {
                         {leader.donorName}
                       </p>
                       <p className={styles.leaderBoardDonorTrees}>
-                        {Sugar.Number.format(Number(leader.treeCount))}
+                        {getFormattedNumber(i18n.language, Number(leader.treeCount))}
                         {' '}
                         {t('common:trees')}
                       </p>
@@ -69,7 +69,7 @@ export default function LeaderBoardSection(leaderboard: Props) {
                           {leader.donorName}
                         </p>
                         <p className={styles.leaderBoardDonorTrees}>
-                          {Sugar.Number.format(Number(leader.treeCount))}
+                          {getFormattedNumber(i18n.language, Number(leader.treeCount))}
                           {' '}
                           {t('common:trees')}
                         </p>

--- a/src/tenants/planet/LeaderBoard/components/Score.tsx
+++ b/src/tenants/planet/LeaderBoard/components/Score.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './LeaderBoard.module.scss';
 import i18next from '../../../../../i18n';
-import getFormattedNumber from '../../../../utils/getFormattedNumber';
+import { getFormattedNumber } from '../../../../utils/getFormattedNumber';
 
 interface Props {
   leaderboard: any;

--- a/src/tenants/planet/LeaderBoard/components/Stats.module.scss
+++ b/src/tenants/planet/LeaderBoard/components/Stats.module.scss
@@ -36,7 +36,7 @@
 
 .statNumber {
   font-family: $primaryFontFamily;
-  font-size: 49px;
+  font-size: 38px;
   font-weight: bold;
   color: #68b030;
 }

--- a/src/tenants/planet/LeaderBoard/components/Stats.tsx
+++ b/src/tenants/planet/LeaderBoard/components/Stats.tsx
@@ -4,7 +4,7 @@ import InfoIcon from '../../../../../public/assets/images/icons/InfoIcon';
 import styles from './Stats.module.scss';
 import StatsInfoModal from './StatsInfoModal';
 import i18next from '../../../../../i18n';
-import { getFormattedNumber } from '../../../../utils/getFormattedNumber';
+import { localizedAbbreviatedNumber } from '../../../../utils/getFormattedNumber';
 
 interface Props {}
 
@@ -23,15 +23,15 @@ export default function Stats({}: Props): ReactElement {
     <div className={styles.wrapper}>
       <div className={styles.container}>
         <div className={styles.statCard}>
-          <h2 className={styles.statNumber}>{getFormattedNumber(i18n.language, 14.76) + 'm'}</h2>
+          <h2 className={styles.statNumber}>{localizedAbbreviatedNumber(i18n.language, Number(14760000), 2)}</h2>
           <h3 className={styles.statText}>{t('planet:treesDonated')}</h3>
         </div>
         <div className={styles.statCard}>
-          <h2 className={styles.statNumber}>{getFormattedNumber(i18n.language, 63) + 'm'}</h2>
+          <h2 className={styles.statNumber}>{localizedAbbreviatedNumber(i18n.language, Number(63000000), 2)}</h2>
           <h3 className={styles.statText}>{t('planet:plantedByTPO')}</h3>
         </div>
         <div className={styles.statCard}>
-          <h2 className={styles.statNumber}>{getFormattedNumber(i18n.language, 13.48) + 'b'}</h2>
+          <h2 className={styles.statNumber}>{localizedAbbreviatedNumber(i18n.language, Number(13480000000), 2)}</h2>
           <h3 className={styles.statText}>{t('planet:plantedGlobally')}</h3>
           <div
             onClick={() => {
@@ -45,7 +45,7 @@ export default function Stats({}: Props): ReactElement {
         </div>
         <div className={styles.statCard}>
           <h2 className={styles.statNumber} style={{ color: '#E86F56' }}>
-            {getFormattedNumber(i18n.language, 10) + 'b'}
+            {localizedAbbreviatedNumber(i18n.language, Number(10000000000), 2)}
           </h2>
           <h3 className={styles.statText}>{t('planet:forestLoss')}</h3>
           <div

--- a/src/tenants/planet/LeaderBoard/components/Stats.tsx
+++ b/src/tenants/planet/LeaderBoard/components/Stats.tsx
@@ -4,7 +4,7 @@ import InfoIcon from '../../../../../public/assets/images/icons/InfoIcon';
 import styles from './Stats.module.scss';
 import StatsInfoModal from './StatsInfoModal';
 import i18next from '../../../../../i18n';
-import getFormattedNumber from '../../../../utils/getFormattedNumber';
+import { getFormattedNumber } from '../../../../utils/getFormattedNumber';
 
 interface Props {}
 

--- a/src/tenants/planet/LeaderBoard/components/Stats.tsx
+++ b/src/tenants/planet/LeaderBoard/components/Stats.tsx
@@ -4,13 +4,14 @@ import InfoIcon from '../../../../../public/assets/images/icons/InfoIcon';
 import styles from './Stats.module.scss';
 import StatsInfoModal from './StatsInfoModal';
 import i18next from '../../../../../i18n';
+import getFormattedNumber from '../../../../utils/getFormattedNumber';
 
 interface Props {}
 
 export default function Stats({}: Props): ReactElement {
   const [infoExpanded, setInfoExpanded] = React.useState(null);
   const { useTranslation } = i18next;
-  const { t } = useTranslation(['leaderboard', 'common', 'planet']);
+  const { t, i18n } = useTranslation(['leaderboard', 'common', 'planet']);
   const [openModal, setModalOpen] = React.useState(false);
   const handleModalClose = () => {
     setModalOpen(false);
@@ -22,15 +23,15 @@ export default function Stats({}: Props): ReactElement {
     <div className={styles.wrapper}>
       <div className={styles.container}>
         <div className={styles.statCard}>
-          <h2 className={styles.statNumber}>14.76m</h2>
+          <h2 className={styles.statNumber}>{getFormattedNumber(i18n.language, 14.76) + 'm'}</h2>
           <h3 className={styles.statText}>{t('planet:treesDonated')}</h3>
         </div>
         <div className={styles.statCard}>
-          <h2 className={styles.statNumber}>63m</h2>
+          <h2 className={styles.statNumber}>{getFormattedNumber(i18n.language, 63) + 'm'}</h2>
           <h3 className={styles.statText}>{t('planet:plantedByTPO')}</h3>
         </div>
         <div className={styles.statCard}>
-          <h2 className={styles.statNumber}>13.48b</h2>
+          <h2 className={styles.statNumber}>{getFormattedNumber(i18n.language, 13.48) + 'b'}</h2>
           <h3 className={styles.statText}>{t('planet:plantedGlobally')}</h3>
           <div
             onClick={() => {
@@ -44,7 +45,7 @@ export default function Stats({}: Props): ReactElement {
         </div>
         <div className={styles.statCard}>
           <h2 className={styles.statNumber} style={{ color: '#E86F56' }}>
-            10b
+            {getFormattedNumber(i18n.language, 10) + 'b'}
           </h2>
           <h3 className={styles.statText}>{t('planet:forestLoss')}</h3>
           <div

--- a/src/tenants/salesforce/Home/components/LeaderBoardSection.tsx
+++ b/src/tenants/salesforce/Home/components/LeaderBoardSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import Sugar from 'sugar';
 import styles from './../styles/LeaderBoardSection.module.scss';
 import i18next from '../../../../../i18n';
+import { getFormattedNumber } from '../../../../utils/getFormattedNumber';
 
 interface Props {
   leaderboard: any;
@@ -11,7 +11,7 @@ export default function LeaderBoardSection(leaderboard: Props) {
   const [selectedTab, setSelectedTab] = React.useState('recent');
   const leaderboardData = leaderboard.leaderboard;
   const { useTranslation } = i18next;
-  const { t } = useTranslation(['leaderboard', 'common']);
+  const { t, i18n } = useTranslation(['leaderboard', 'common']);
 
   return (
     <section className={styles.leaderBoardSection}>
@@ -53,7 +53,7 @@ export default function LeaderBoardSection(leaderboard: Props) {
                         {leader.donorName}
                       </p>
                       <p className={styles.leaderBoardDonorTrees}>
-                        {Sugar.Number.format(Number(leader.treeCount))} {t('common:trees')}
+                        {getFormattedNumber(i18n.language, Number(leader.treeCount))} {t('common:trees')}
                       </p>
                       {/* <p className={styles.leaderBoardDonorTime}>
                           {leader.created}
@@ -71,7 +71,7 @@ export default function LeaderBoardSection(leaderboard: Props) {
                         {leader.donorName}
                       </p>
                       <p className={styles.leaderBoardDonorTrees}>
-                        {Sugar.Number.format(Number(leader.treeCount))} {t('common:trees')}
+                        {getFormattedNumber(i18n.language, Number(leader.treeCount))} {t('common:trees')}
                       </p>
                     </div>
                   );

--- a/src/tenants/salesforce/TreeCounter/TreeCounter.tsx
+++ b/src/tenants/salesforce/TreeCounter/TreeCounter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import Sugar from 'sugar';
 import treeCounterStyles from './TreeCounter.module.scss';
+import { getFormattedNumber } from '../../../utils/getFormattedNumber';
 
 export default function TpoProfile(props: any) {
   return (
@@ -8,7 +8,7 @@ export default function TpoProfile(props: any) {
       <div className={treeCounterStyles.backgroundCircle}>
         <div className={treeCounterStyles.treeCounterDataField}>
           <h2 className={treeCounterStyles.countNumber}>
-            {Sugar.Number.format(Number(props.planted))}
+            {getFormattedNumber('en', Number(props.planted))}
           </h2>
           <h2 className={treeCounterStyles.countLabel}>
           trees supported by the Salesforce community through the projects on this platform

--- a/src/utils/TruncateText.js
+++ b/src/utils/TruncateText.js
@@ -1,4 +1,11 @@
-export default function trimwords(str, num, readmore) {
+export function truncateString(str, num) {
+  if (str.length <= num) {
+    return str
+  }
+  return str.slice(0, num) + '...'
+}
+
+export function trimwords(str, num, readmore) {
   if (readmore) {
     return str;
   }

--- a/src/utils/getFormattedNumber.ts
+++ b/src/utils/getFormattedNumber.ts
@@ -7,17 +7,21 @@ const localizedAbbr = {
   },
 };
 
+function getLocalizedAbbreviation(langCode: string, abbr: string) {
+  return localizedAbbr[langCode] ? localizedAbbr[langCode][abbr] : localizedAbbr['en'][abbr];
+}
+
 export function localizedAbbreviatedNumber(
   langCode: string,
   number: number,
   fractionDigits: number,
 ) {
   if (number >= 1000000000)
-    return getFormattedRoundedNumber(langCode, number/1000000000, fractionDigits) + localizedAbbr[langCode]['b'];
+    return getFormattedRoundedNumber(langCode, number/1000000000, fractionDigits) + getLocalizedAbbreviation(langCode, 'b');
   if (number >= 1000000)
-    return getFormattedRoundedNumber(langCode, number/1000000, fractionDigits) + localizedAbbr[langCode]['m'];
+    return getFormattedRoundedNumber(langCode, number/1000000, fractionDigits) + getLocalizedAbbreviation(langCode, 'm');
   if (number >= 1000)
-    return getFormattedRoundedNumber(langCode, number/1000, fractionDigits) + localizedAbbr[langCode]['k'];
+    return getFormattedRoundedNumber(langCode, number/1000, fractionDigits) + getLocalizedAbbreviation(langCode, 'k');
 
   return getFormattedRoundedNumber(langCode, number, fractionDigits);
 }

--- a/src/utils/getFormattedNumber.ts
+++ b/src/utils/getFormattedNumber.ts
@@ -1,19 +1,48 @@
+const localizedAbbr = {
+  'en': {
+    'b': 'b', 'm': 'm', 'k': 'k',
+  },
+  'de': {
+    'b': 'Mrd.', 'm': 'Mio.', 'k': 'Tsd.',
+  },
+};
+
+export function localizedAbbreviatedNumber(
+  langCode: string,
+  number: number,
+  fractionDigits: number,
+) {
+  if (number >= 1000000000)
+    return getFormattedRoundedNumber(langCode, number/1000000000, fractionDigits) + localizedAbbr[langCode]['b'];
+  if (number >= 1000000)
+    return getFormattedRoundedNumber(langCode, number/1000000, fractionDigits) + localizedAbbr[langCode]['m'];
+  if (number >= 1000)
+    return getFormattedRoundedNumber(langCode, number/1000, fractionDigits) + localizedAbbr[langCode]['k'];
+
+  return getFormattedRoundedNumber(langCode, number, fractionDigits);
+}
+
 export function getFormattedRoundedNumber(
   langCode: string,
-  number: number
+  number: number,
+  fractionDigits: number,
 ) {
+  // console.log("getFormattedRoundedNumber", langCode, number, fractionDigits);
+  if (Math.round(number) === Math.round(number*fractionDigits*10)/(fractionDigits*10)) 
+    fractionDigits = 0;
   const formatter = new Intl.NumberFormat(langCode, {
     // These options are needed to round to whole numbers if that's what you want.
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
   });
   return formatter.format(number);
 }
 
-export default function getFormattedNumber(
+export function getFormattedNumber(
   langCode: string,
   number: number
 ) {
+  // console.log("getFormattedNumber", langCode, number);
   const formatter = new Intl.NumberFormat(langCode);
   return formatter.format(number);
 }

--- a/src/utils/getFormattedNumber.ts
+++ b/src/utils/getFormattedNumber.ts
@@ -1,8 +1,9 @@
+// change 'de-disabled' to 'de' if you want to enable custom abbreviations for German
 const localizedAbbr = {
   'en': {
     'b': 'b', 'm': 'm', 'k': 'k',
   },
-  'de': {
+  'de-disabled': {
     'b': 'Mrd.', 'm': 'Mio.', 'k': 'Tsd.',
   },
 };

--- a/src/utils/getFormattedNumber.ts
+++ b/src/utils/getFormattedNumber.ts
@@ -1,0 +1,20 @@
+export function getFormattedRoundedNumber(
+  langCode: string,
+  number: number
+) {
+  const formatter = new Intl.NumberFormat(langCode, {
+    // These options are needed to round to whole numbers if that's what you want.
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  return formatter.format(number);
+}
+
+export default function getFormattedNumber(
+  langCode: string,
+  number: number
+) {
+  const formatter = new Intl.NumberFormat(langCode);
+  return formatter.format(number);
+}
+


### PR DESCRIPTION
Fixes #

Changes in this pull request:
- number localization
- replacing Sugar module completely
- using English abbreviation for number on Leaderboard now

TODO:

- [x] change all other usages of Sugar to format numbers
- [x] use correct number names, e.g. "Billion" vs. "Milliarde"  
- [x] add abbreviations for 'de', 'es', 'fr', 'it', 'pt-BR'? - fallback to 'en' abbreviations!