### PR TITLE
added session to payDonation function calls

### DIFF
--- a/src/features/donations/components/treeDonation/PaymentFunctions.ts
+++ b/src/features/donations/components/treeDonation/PaymentFunctions.ts
@@ -1,7 +1,7 @@
 import getsessionId from '../../../../utils/apiRequests/getSessionId';
 import { PayWithCardTypes } from '../../../common/types/donations';
 
-export async function createDonation(data: any,token:any) {
+export async function createDonation(data: any, token:any) {
   let headers = {
     'Content-Type': 'application/json',
     'tenant-key': `${process.env.TENANTID}`,
@@ -27,7 +27,7 @@ export async function createDonation(data: any,token:any) {
   return donation;
 }
 
-export async function payDonation(data: any, id: any,token:any) {
+export async function payDonation(data: any, id: any, token:any) {
   let headers = {
     'Content-Type': 'application/json',
     'tenant-key': `${process.env.TENANTID}`,
@@ -38,7 +38,7 @@ export async function payDonation(data: any, id: any,token:any) {
         : 'en'
     }`,
   }
-  if(token && token !== ''){
+  if (token && token !== '') {
     headers = {
       ...headers,
       'Authorization': `OAuth ${token}`
@@ -140,7 +140,7 @@ export function payWithCard({
   }
   }
 
-  createDonation(createDonationData,token)
+  createDonation(createDonationData, token)
     .then((res) => {
       // Code for Payment API
 
@@ -167,7 +167,7 @@ export function payWithCard({
           },
         };
 
-        payDonation(payDonationData, res.id,token)
+        payDonation(payDonationData, res.id, token)
           .then(async (res) => {
             if (res.code === 400) {
               setIsPaymentProcessing(false);
@@ -215,7 +215,7 @@ export function payWithCard({
                         },
                       },
                     };
-                    payDonation(payDonationData, donationID,token).then((res) => {
+                    payDonation(payDonationData, donationID, token).then((res) => {
                       if (res.paymentStatus === 'success') {
                         setIsPaymentProcessing(false);
                         setDonationStep(4);

--- a/src/features/donations/screens/PaymentDetails.tsx
+++ b/src/features/donations/screens/PaymentDetails.tsx
@@ -219,7 +219,7 @@ function PaymentDetails({
       paymentMethod,
       donorDetails,
       taxDeductionCountry: isTaxDeductible ? country : null,
-      token:token?token : null
+      token: token
     };
     payWithCard({ ...payWithCardProps });
   };

--- a/src/features/donations/screens/PaymentDetails.tsx
+++ b/src/features/donations/screens/PaymentDetails.tsx
@@ -307,7 +307,7 @@ function PaymentDetails({
       }
     }
 
-    createDonation(createDonationData, session)
+    createDonation(createDonationData, token)
       .then((res) => {
         if (res.code === 400) {
           setIsPaymentProcessing(false);
@@ -350,7 +350,7 @@ function PaymentDetails({
         },
       };
 
-      payDonation(payDonationData, donationID, null)
+      payDonation(payDonationData, donationID, token)
         .then(async (res) => {
           if (res.code === 400) {
             setIsPaymentProcessing(false);
@@ -400,7 +400,7 @@ function PaymentDetails({
                       },
                     },
                   };
-                  payDonation(payDonationData, donationID, null).then((res) => {
+                  payDonation(payDonationData, donationID, token).then((res) => {
                     if (res.paymentStatus === 'success') {
                       setIsPaymentProcessing(false);
                       setPaymentType('Paypal')


### PR DESCRIPTION
Fixes failing Paypal payments for logged in users.

Changes in this pull request:
- added session to payDonation function calls

TODO:
- [x] check if missing `session` in https://github.com/Plant-for-the-Planet-org/planet-webapp/blob/develop/src/features/legacyDonations/index.tsx is a problem (e.g. if the user is accidentally logged in in the web browser opened by the native app) -> **We won't add the Authorization header with the session to the API call of the legacy donations as that would require the users of the native apps to login into their smartphone browsers if they are logged in on the native apps.**
- [x] check and solve these errors also in https://github.com/Plant-for-the-Planet-org/planet-webapp/pull/498

@harshvitra 
