### PR TITLE
handle 401 response for payment of backend

### DIFF
--- a/src/features/donations/components/treeDonation/PaymentFunctions.ts
+++ b/src/features/donations/components/treeDonation/PaymentFunctions.ts
@@ -49,8 +49,16 @@ export async function payDonation(data: any, id: any, token:any) {
     body: JSON.stringify(data),
     headers:headers ,
   });
-  const contribution = await res.json();
-  return contribution;
+  // having to patch this as API returns only a text error message on 401
+  if (res.status === 401) {
+    return {
+      code: res.status,
+      message: await res.json(),
+    }
+  } else {
+    const contribution = await res.json();
+    return contribution;
+  }
 }
 
 export function getPaymentType(paymentType: String) {
@@ -169,7 +177,7 @@ export function payWithCard({
 
         payDonation(payDonationData, res.id, token)
           .then(async (res) => {
-            if (res.code === 400) {
+            if (res.code === 400 || res.code === 401) {
               setIsPaymentProcessing(false);
               setPaymentError(res.message);
               return;

--- a/src/features/donations/screens/PaymentDetails.tsx
+++ b/src/features/donations/screens/PaymentDetails.tsx
@@ -309,7 +309,7 @@ function PaymentDetails({
 
     createDonation(createDonationData, token)
       .then((res) => {
-        if (res.code === 400) {
+        if (res.code === 400 || res.code === 401) {
           setIsPaymentProcessing(false);
           setPaymentError(res.message);
           setPaypalProcessing(false)

--- a/src/features/legacyDonations/index.tsx
+++ b/src/features/legacyDonations/index.tsx
@@ -98,7 +98,7 @@ function LegacyDonations({ paymentData }: Props): ReactElement {
 
     payDonation(payDonationData, paymentData.guid, null)
       .then(async (res) => {
-        if (res.code === 400) {
+        if (res.code === 400 || res.code === 401) {
           setIsPaymentProcessing(false);
           setPaymentError(res.message);
           return;


### PR DESCRIPTION
Changes in this pull request:
- as the backend API only returns a string error message for status 401 we have to handle it specially
