### PR TITLE
set Auth0 language to selected user language

### DIFF
--- a/src/features/common/Layout/Navbar/index.tsx
+++ b/src/features/common/Layout/Navbar/index.tsx
@@ -65,7 +65,7 @@ export default function NavbarComponent(props: any) {
     } else {
       //----------------- To do - redirect to slug -----------------
       // Currently we cannot do that because we don't know the slug of the user
-      loginWithRedirect({ redirectUri: `${process.env.NEXTAUTH_URL}/login` });
+      loginWithRedirect({ redirectUri: `${process.env.NEXTAUTH_URL}/login`, ui_locales: localStorage.getItem('language') || 'en' });
     }
   }
 

--- a/src/features/common/Layout/RedeemPopup/index.tsx
+++ b/src/features/common/Layout/RedeemPopup/index.tsx
@@ -14,7 +14,7 @@ export default function RedeemPopup() {
   const { isLoading, isAuthenticated, loginWithRedirect } = useAuth0();
 
   const sendUserToLogin = () => {
-    loginWithRedirect({ redirectUri: `${process.env.NEXTAUTH_URL}/login` });
+    loginWithRedirect({ redirectUri: `${process.env.NEXTAUTH_URL}/login`, ui_locales: localStorage.getItem('language') || 'en' });
   };
 
   React.useEffect(() => {

--- a/src/features/common/VerifyEmail/VerifyEmail.tsx
+++ b/src/features/common/VerifyEmail/VerifyEmail.tsx
@@ -28,7 +28,7 @@ function VerifyEmailComponent({ }: Props): ReactElement {
             <span style={{ fontStyle: 'italic', marginTop: '12px' }}>
                 {t('common:verifyEmailInfo')}
             </span>
-            <div onClick={()=>loginWithRedirect({redirectUri:`${process.env.NEXTAUTH_URL}/login`})} className={styles.continueButton}>
+            <div onClick={() => loginWithRedirect({redirectUri: `${process.env.NEXTAUTH_URL}/login`, ui_locales: localStorage.getItem('language') || 'en' })} className={styles.continueButton}>
                 {t('common:continueToLogin')}
             </div>
         </div>

--- a/src/features/user/CompleteSignup/index.tsx
+++ b/src/features/user/CompleteSignup/index.tsx
@@ -40,7 +40,7 @@ export default function CompleteSignup() {
       const token = await getAccessTokenSilently();
       setToken(token);
       if(!token){
-        loginWithRedirect({redirectUri:`${process.env.NEXTAUTH_URL}/login`});
+        loginWithRedirect({redirectUri:`${process.env.NEXTAUTH_URL}/login`, ui_locales: localStorage.getItem('language') || 'en' });
       }
       const userExistsInDB = getUserExistsInDB();
       if (token && userExistsInDB) {
@@ -118,7 +118,7 @@ export default function CompleteSignup() {
         logout({ returnTo: `${process.env.NEXTAUTH_URL}/` });
 
         removeUserExistsInDB()
-        loginWithRedirect({redirectUri:`${process.env.NEXTAUTH_URL}/login`});
+        loginWithRedirect({redirectUri:`${process.env.NEXTAUTH_URL}/login`, ui_locales: localStorage.getItem('language') || 'en' });
       } else {
         setSnackbarMessage(ready ? t('login:profileCreationFailed') : '');
         setSeverity("error")


### PR DESCRIPTION
Changes in this pull request:
- overrides the browser language for Auth0 pages with the user language of our website

Also (in Auth0):
- changed all mail templates on Auth0 tenant `pftp` (development) to support German next to the default English language (subject + body).
- changed the _Pre User Registration_ hook named `email-verification-hook` to  store the UI language in the Auth0 user's metadata, so all the mail templates are using the same language the user is using in the Auth0 browser dialogs influenced by this PR

TODO:
- If the user is changing the language in our web app, this is only changed in the localStorage of the browser - we also need to change the language in the user profile with an API call in order to be able to send it to Auth0 on login afterwards to also change the language there for future mails (e.g. password forgotten et al.)
