### PR TITLE
added redirect for /donate-tree, /my-trees, /redeem

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,11 @@
   status = 301
   force = false
 [[redirects]]
+  from = "/donate-tree"
+  to = "/open-app"
+  status = 301
+  force = false
+[[redirects]]
   from = "/donate-trees"
   to = "/open-app"
   status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -27,8 +27,18 @@
   status = 301
   force = false
 [[redirects]]
+  from = "/my-tress"
+  to = "/login"
+  status = 301
+  force = false
+[[redirects]]
   from = "/project/*"
   to = "/open-app"
+  status = 301
+  force = false
+[[redirects]]
+  from = "/redeem"
+  to = "/login"
   status = 301
   force = false
 [[redirects]]

--- a/next.config.js
+++ b/next.config.js
@@ -164,8 +164,18 @@ module.exports = withPlugins(
           permanent: true,
         },
         {
+          source: '/my-trees',
+          destination: '/login',
+          permanent: true,
+        },
+        {
           source: '/project/:slug*',
           destination: '/open-app',
+          permanent: true,
+        },
+        {
+          source: '/redeem',
+          destination: '/login',
           permanent: true,
         },
         {

--- a/next.config.js
+++ b/next.config.js
@@ -149,6 +149,11 @@ module.exports = withPlugins(
           permanent: true,
         },
         {
+          source: '/donate-tree',
+          destination: '/open-app',
+          permanent: true,
+        },
+        {
           source: '/donate-trees',
           destination: '/open-app',
           permanent: true,


### PR DESCRIPTION
Changes in this pull request:
- added redirect for `/donate-tree`, `/my-trees`, `/redeem` as maybe people try to access it - these redirects then are active for all tenants and can be removed as page rule from CF

Question:
- I have not added `/gift-trees` -> `/`, `/support/*` -> `/s/*` or `/explore` -> `/` as I think we do not want support these links in the future.