### PR TITLE
switch off gift option when removing direct gift recipient

### DIFF
--- a/src/features/donations/index.tsx
+++ b/src/features/donations/index.tsx
@@ -211,6 +211,7 @@ function DonationsPopup({
         receipients: null,
       });
     } else {
+      setIsGift(false);
       setGiftDetails({
         type: null,
         recipientName: null,


### PR DESCRIPTION
Fixes #730

Changes in this pull request:
- switch off gift option when removing direct gift recipient (I switched of the gift option as the type value was set to `null` while the user still could input some recipient like if the type would have been `invitation`.)
