### PR TITLE
fixed plural form

### DIFF
--- a/public/static/locales/de/redeem.json
+++ b/public/static/locales/de/redeem.json
@@ -1,6 +1,6 @@
 {
-  "myPlantedTreesByOrg": "Mein {{count}} Baum wird von {{tpoName}} gepflanzt",
-  "myPlantedTreesByOrg_plural": "Meine {{count}} Bäume werden von {{tpoName}} gepflanzt",
+  "myPlantedTreesByOrg": "Mein {{formattedNumber}} Baum wird von {{tpoName}} gepflanzt",
+  "myPlantedTreesByOrg_plural": "Meine {{formattedNumber}} Bäume werden von {{tpoName}} gepflanzt",
   "congratulations": "Herzlichen Glückwunsch!",
   "addToMyTrees": "Zu meinen Bäumen hinzufügen",
   "validateCode": "Code prüfen",

--- a/public/static/locales/en/redeem.json
+++ b/public/static/locales/en/redeem.json
@@ -1,6 +1,6 @@
 {
-  "myPlantedTreesByOrg": "My {{count}} tree will be planted by {{tpoName}}",
-  "myPlantedTreesByOrg_plural": "My {{count}} trees will be planted by {{tpoName}}",
+  "myPlantedTreesByOrg": "My {{formattedNumber}} tree will be planted by {{tpoName}}",
+  "myPlantedTreesByOrg_plural": "My {{formattedNumber}} trees will be planted by {{tpoName}}",
   "congratulations": "Congratulations!",
   "addToMyTrees": "Add to my trees",
   "validateCode": "Validate Code",

--- a/src/features/user/UserProfile/components/RedeemModal.tsx
+++ b/src/features/user/UserProfile/components/RedeemModal.tsx
@@ -167,8 +167,9 @@ export default function RedeemModal({
                     <p dangerouslySetInnerHTML={{ __html: t('donate:thankyouHeaderText') }} />
                   </div>
                   <div className={styles.donationCount}>
-                    {t('redeem:myPlantedTreesByOrg', { 
-                      count: getFormattedNumber(i18n.language, Number(validCodeData.treeCount)), 
+                    {t('redeem:myPlantedTreesByOrg', {
+                      count: Number(validCodeData.treeCount),
+                      formattedNumber: getFormattedNumber(i18n.language, Number(validCodeData.treeCount)), 
                       tpoName:validCodeData.tpos[0].tpoName 
                     })}
                     <p className={styles.donationTenant}>
@@ -186,7 +187,8 @@ export default function RedeemModal({
                   </div>
                   <p className={styles.tempDonationCount}>
                     {t('redeem:myPlantedTreesByOrg', {
-                      count: getFormattedNumber(i18n.language, Number(validCodeData.treeCount)),
+                      count: Number(validCodeData.treeCount),
+                      formattedNumber: getFormattedNumber(i18n.language, Number(validCodeData.treeCount)),
                       tpoName:validCodeData.tpos[0].tpoName
                     })}
                   </p>


### PR DESCRIPTION
Fixes Jira Issue from customer support

Changes in this pull request:
- using a plural form in i18n requires a number value for `count` - a formatted string could spoil the automatic choice of the right form, please test! This is just the number after redeeming a voucher code - for all the other strings we currently always show the plural form also for 1 tree!