### PR TITLE
format and parse the tree cost of a project in user language

### DIFF
--- a/src/features/user/ManageProjects/components/BasicDetails.tsx
+++ b/src/features/user/ManageProjects/components/BasicDetails.tsx
@@ -13,6 +13,7 @@ import {
   putAuthenticatedRequest,
 } from '../../../../utils/apiRequests/api';
 import addServerErrors from '../../../../utils/apiRequests/addServerErrors';
+import { getFormattedNumber, parseNumber } from '../../../../utils/getFormattedNumber';
 
 const { useTranslation } = i18next;
 
@@ -130,7 +131,7 @@ export default function BasicDetails({
         website: projectDetails.website,
         description: projectDetails.description,
         acceptDonations: projectDetails.acceptDonations,
-        treeCost: projectDetails.treeCost,
+        treeCost: getFormattedNumber(i18n.language, projectDetails.treeCost || 0),
         publish: projectDetails.publish,
         visitorAssistance: projectDetails.visitorAssistance,
         enablePlantLocations: projectDetails.enablePlantLocations,
@@ -156,8 +157,6 @@ export default function BasicDetails({
   }, [projectDetails]);
 
   const onSubmit = (data: any) => {
-    // console.log('data.treeCost', data.treeCost.replace(/,/g, '.'));
-
     setIsUploadingData(true);
     let submitData = {
       name: data.name,
@@ -174,7 +173,7 @@ export default function BasicDetails({
       website: data.website,
       description: data.description,
       acceptDonations: data.acceptDonations,
-      treeCost: data.treeCost ? Number(data.treeCost.replace(/,/g, '.')) : 0,
+      treeCost: parseNumber(i18n.language, data.treeCost),
       currency: 'EUR',
       visitorAssistance: data.visitorAssistance,
       publish: data.publish,
@@ -429,18 +428,11 @@ export default function BasicDetails({
                       value: true,
                       message: t('manageProjects:treeCostValidaitonRequired'),
                     },
-                    validate: (value) => parseFloat(value) > 0 && parseFloat(value) <= 100,
-                    pattern: {
-                      value: /^[+]?[0-9]{1,3}(?:[0-9]*(?:[.,][0-9]{2})?|(?:,[0-9]{3})*(?:\.[0-9]{1,2})?|(?:\.[0-9]{3})*(?:,[0-9]{1,2})?)$/,
-                      message: t('manageProjects:treeCostValidationInvalid'),
-                    }
+                    validate: (value) => parseNumber(i18n.language, value) > 0 && parseNumber(i18n.language, value) <= 100,
                   })}
                   label={t('manageProjects:treeCost')}
                   variant="outlined"
                   name="treeCost"
-                  onInput={(e) => {
-                    e.target.value = e.target.value.replace(/[^0-9,.]/g, '');
-                  }}
                   placeholder={'0'}
                   InputProps={{
                     startAdornment: (

--- a/src/features/user/ManageProjects/components/ProjectSpending.tsx
+++ b/src/features/user/ManageProjects/components/ProjectSpending.tsx
@@ -72,8 +72,8 @@ export default function ProjectSpending({ handleBack, token, handleNext, userLan
 
     const onSubmit = (pdf: any) => {
         setIsUploadingData(true)
-        const updatedAmount = getValues("amount");
-        const year = getValues("year");
+        const updatedAmount = getValues('amount');
+        const year = getValues('year');
 
         const submitData = {
             year: year.getFullYear(),
@@ -82,7 +82,6 @@ export default function ProjectSpending({ handleBack, token, handleNext, userLan
         }
 
         postAuthenticatedRequest(`/app/projects/${projectGUID}/expenses`, submitData, token).then((res) => {
-
             if (!res.code) {
                 let newUploadedFiles = uploadedFiles;
                 newUploadedFiles.push(res);
@@ -204,8 +203,7 @@ export default function ProjectSpending({ handleBack, token, handleNext, userLan
                             <div className={`${styles.formFieldHalf}`}>
                                 <MaterialTextField
                                     inputRef={register({
-                                        validate: (value) =>
-                                            parseFloat(value) > 0,
+                                        validate: (value) => parseInt(value) > 0,
                                         required: {
                                             value: true,
                                             message: t('manageProjects:spendingAmountValidation')
@@ -215,9 +213,9 @@ export default function ProjectSpending({ handleBack, token, handleNext, userLan
                                     placeholder={0}
                                     variant="outlined"
                                     name="amount"
-                                    onChange={(e) => setAmount(e.target.value)}
                                     onInput={(e) => {
-                                        e.target.value = e.target.value.replace(/[^0-9,.]/g, '');
+                                      e.target.value = e.target.value.replace(/[^0-9]/g, '');
+                                      setAmount(e.target.value);
                                     }}
                                     InputProps={{
                                         startAdornment: (

--- a/src/utils/getFormattedNumber.ts
+++ b/src/utils/getFormattedNumber.ts
@@ -1,3 +1,22 @@
+class NumberParser {
+  constructor(locale) {
+    const format = new Intl.NumberFormat(locale);
+    const parts = format.formatToParts(12345.6);
+    const numerals = Array.from({ length: 10 }).map((_, i) => format.format(i));
+    const index = new Map(numerals.map((d, i) => [d, i]));
+    this._group = new RegExp(`[${parts.find(d => d.type === "group").value}]`, "g");
+    this._decimal = new RegExp(`[${parts.find(d => d.type === "decimal").value}]`);
+    this._numeral = new RegExp(`[${numerals.join("")}]`, "g");
+    this._index = d => index.get(d);
+  }
+  parse(string) {
+    return (string = string.trim()
+      .replace(this._group, "")
+      .replace(this._decimal, ".")
+      .replace(this._numeral, this._index)) ? +string : NaN;
+  }
+}
+
 // change 'de-disabled' to 'de' if you want to enable custom abbreviations for German
 const localizedAbbr = {
   'en': {
@@ -52,3 +71,10 @@ export function getFormattedNumber(
   return formatter.format(number);
 }
 
+export function parseNumber(
+  langCode: string,
+  number: number
+) {
+  const parser = new NumberParser(langCode);
+  return parser.parse(number);
+}


### PR DESCRIPTION
Fixes #679

Changes in this pull request:
- format and parse the tree cost of a project in user language
- changed project spending to integer as backend rounds anyway
