### PR TITLE
use a release version for external GitHub action instead of the master branch

### DIFF
--- a/.github/workflows/browser-stack.yml
+++ b/.github/workflows/browser-stack.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
       - name: Wait for Vercel deployment # ${{ steps.waitForVercel.outputs.url }} should return the Vercel deployment url
-        uses: patrickedqvist/wait-for-vercel-preview@master
+        uses: patrickedqvist/wait-for-vercel-preview@v1.0.6
         id: waitForVercel
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/browser-stack.yml
+++ b/.github/workflows/browser-stack.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
       - name: Wait for Vercel deployment # ${{ steps.waitForVercel.outputs.url }} should return the Vercel deployment url
-        uses: patrickedqvist/wait-for-vercel-preview@v1.0.6
+        uses: patrickedqvist/wait-for-vercel-preview@v1.0.5
         id: waitForVercel
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/browser-stack.yml
+++ b/.github/workflows/browser-stack.yml
@@ -15,7 +15,7 @@ jobs:
         id: waitForVercel
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 300
+          max_timeout: 600
 
       - name: 'BrowserStack Env Setup'  # Invokes the setup-env action
         uses: browserstack/github-actions/setup-env@master

--- a/.github/workflows/browser-stack.yml
+++ b/.github/workflows/browser-stack.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
       - name: Wait for Vercel deployment # ${{ steps.waitForVercel.outputs.url }} should return the Vercel deployment url
-        uses: patrickedqvist/wait-for-vercel-preview@v1.0.5
+        uses: patrickedqvist/wait-for-vercel-preview@v1.0.4
         id: waitForVercel
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #

Changes in this pull request:
- use a release version for patrickedqvist/wait-for-vercel-preview and not the master branch