### PR TITLE
changed menu item to adapt to planet tenant

### DIFF
--- a/public/tenants/ttc/config.ts
+++ b/public/tenants/ttc/config.ts
@@ -35,7 +35,7 @@ const config = {
         visible: false,
       },
       leaderboard: {
-        title: 'leaderboard',
+        title: 'leaders',
         onclick: '/all',
         visible: true,
       },


### PR DESCRIPTION
Fixes #752

Changes in this pull request:
- changed menu item to adapt to planet tenant from "Leaderboard" ("Bestenliste") to "Leaders" ("Spitzenreiter")

TODO:
- [x] The change of the German translation for the Wordpress-Websites https://a.plant-for-the-planet.org/ (also https://blog.plant-for-the-planet.org/) will have to be done at Wordpress.