### PR TITLE
always display selected and default country first in chooser dialog

### DIFF
--- a/src/features/common/Layout/Footer/SelectLanguageAndCountry.tsx
+++ b/src/features/common/Layout/Footer/SelectLanguageAndCountry.tsx
@@ -10,6 +10,7 @@ import {
   getCountryDataBy,
   sortCountriesByTranslation,
 } from '../../../../utils/countryCurrency/countryUtils';
+import { getStoredConfig } from '../../../../utils/storeConfig';
 import supportedLanguages from '../../../../utils/language/supportedLanguages.json';
 import { ThemeContext } from '../../../../theme/themeContext';
 import GreenRadio from '../../InputTypes/GreenRadio';
@@ -136,8 +137,10 @@ export default function TransitionsModal(props) {
 function MapCountry(props) {
   const { t, i18n, ready } = useTranslation(['country']);
   
-  const { value, handleChange } = props;
-  const sortedCountriesData = ready ? sortCountriesByTranslation(t, i18n.language) : {};
+  const { value, handleChange } = props;  
+  const country = getStoredConfig('country');
+  const priorityCountries = country === value ? [ value ] : [ value, country ];
+  const sortedCountriesData = ready ? sortCountriesByTranslation(t, i18n.language, priorityCountries) : {};
   return ready ? (
     <FormControl component="fieldset">
       <RadioGroup

--- a/src/features/donations/components/treeDonation/SelectCurrencyModal.tsx
+++ b/src/features/donations/components/treeDonation/SelectCurrencyModal.tsx
@@ -11,6 +11,7 @@ import {
   getCountryDataBy,
   sortCountriesByTranslation,
 } from '../../../../utils/countryCurrency/countryUtils';
+import { getStoredConfig } from '../../../../utils/storeConfig';
 import { ThemeContext } from '../../../../theme/themeContext';
 import GreenRadio from '../../../common/InputTypes/GreenRadio';
 import i18next from '../../../../../i18n';
@@ -44,20 +45,22 @@ export default function TransitionsModal(props: any) {
   const [importantList, setImportantList] = React.useState<Array<Object>>([]);
 
   React.useEffect(() => {
-    // sets two default country as important country which is US(United States)
-    // and DE (Germany)
-    let impCountryList = [
-      getCountryDataBy('countryCode', 'US'),
-      getCountryDataBy('countryCode', 'DE'),
-    ];
+    // sets two default country as important country which is US(United States) and DE (Germany)
+    let impCountryList = ['US','DE'];
 
     // if the selected country is other than US and DE then add that country to important country list
-    if (country != 'US' && country != 'DE') {
-      impCountryList.push(getCountryDataBy('countryCode', country));
+    if (country && country != 'US' && country != 'DE') {
+      impCountryList.push(country);
+    }
+    // if there is a default country given in the config, also add that country
+    const countryConfig = getStoredConfig('country');
+    if (countryConfig && countryConfig != 'US' && countryConfig != 'DE') {
+      impCountryList.push(countryConfig);
     }
 
     // adds the important country list to state
     setImportantList(impCountryList);
+
     setSelectedModalValue(`${country},${currency}`);
   }, [currency]);
 
@@ -88,16 +91,10 @@ export default function TransitionsModal(props: any) {
           <div className={styles.modal}>
             <div className={styles.radioButtonsContainer}>
               <p className={styles.sectionHead}>{t('donate:selectCurrency')}</p>
-              {/* maps the radio button for currency */}
-              <MapCurrency
-                sortedCountriesData={importantList}
-                // this is selectedValue, country wala object
-                value={selectedModalValue}
-                handleChange={handleCurrencyChange}
-              />
               <hr style={{ margin: '0px 20px' }} />
               <MapCurrency
                 // this is selectedValue, country wala object
+                priorityCountries={importantList}
                 value={selectedModalValue}
                 handleChange={handleCurrencyChange}
               />
@@ -131,8 +128,8 @@ const FormControlNew = withStyles({
 function MapCurrency(props: any) {
   const { t, i18n, ready } = useTranslation(['country']);
   
-  const { value, handleChange } = props;
-  const sortedCountriesData = ready ? sortCountriesByTranslation(t, i18n.language) : {};
+  const { priorityCountries, value, handleChange } = props;
+  const sortedCountriesData = ready ? sortCountriesByTranslation(t, i18n.language, priorityCountries) : {};
   return ready ? (
     <FormControlNew component="fieldset">
       <RadioGroup

--- a/src/utils/countryCurrency/countriesData.json
+++ b/src/utils/countryCurrency/countriesData.json
@@ -816,14 +816,6 @@
     "languageCode": "en"
   },
   {
-    "countryName": "Congo Republic of the Democratic",
-    "countryCode": "CG",
-    "currencyName": "CFA Franc BEAC",
-    "currencyCode": "XAF",
-    "currencyCountryFlag": "XA",
-    "languageCode": "en"
-  },
-  {
     "countryName": "Equatorial Guinea",
     "countryCode": "GQ",
     "currencyName": "CFA Franc BEAC",
@@ -885,14 +877,6 @@
     "currencyName": "Comoran Franc",
     "currencyCode": "KMF",
     "currencyCountryFlag": "KM",
-    "languageCode": "en"
-  },
-  {
-    "countryName": "Congo-Brazzaville",
-    "countryCode": "CD",
-    "currencyName": "Congolese Frank",
-    "currencyCode": "CDF",
-    "currencyCountryFlag": "CD",
     "languageCode": "en"
   },
   {
@@ -1917,14 +1901,6 @@
     "currencyName": "Manx pound",
     "currencyCode": "GBP",
     "currencyCountryFlag": "GB",
-    "languageCode": "en"
-  },
-  {
-    "countryName": "Macao S.A.R.",
-    "countryCode": "MO",
-    "currencyName": "Macanese pataca",
-    "currencyCode": "MOP",
-    "currencyCountryFlag": "MO",
     "languageCode": "en"
   },
   {

--- a/src/utils/countryCurrency/countryUtils.js
+++ b/src/utils/countryCurrency/countryUtils.js
@@ -43,11 +43,24 @@ export function sortCountriesData(sortBy) {
 /**
  * Sorts the countries array for the translated country name
  * @param {Function} t - translation function
+ * @param {String} language - language to get country names for
+ * @param {Array} priorityCountries - country code to always show first in given order
  */
-export function sortCountriesByTranslation(t, language) {
-  if (!sortedCountries[language]) {
-    // returns a sorted array
-    sortedCountries[language] = countriesData.sort((a, b) => {
+export function sortCountriesByTranslation(t, language, priorityCountryCodes) {
+  const key = `${language}.${priorityCountryCodes}`;
+  if (!sortedCountries[key]) {
+    const priorityCountries = [];
+    // filter priority countries from list
+    const filteredCountries = countriesData.filter(function(value, index, arr) {
+      if (priorityCountryCodes.includes(value.countryCode)) {
+        priorityCountries.push(value);
+        return false;
+      } else {
+        return true;
+      }
+    });
+    // sort array of countries
+    sortedCountries[key] = priorityCountries.concat(filteredCountries.sort((a, b) => {
       const nameA = t(`country:${a.countryCode.toLowerCase()}`);
       const nameB = t(`country:${b.countryCode.toLowerCase()}`);
       if (nameA > nameB) {
@@ -56,7 +69,7 @@ export function sortCountriesByTranslation(t, language) {
         return -1;
       }
       return 0;
-    });
+    }));
   }
-  return sortedCountries[language];
+  return sortedCountries[key];
 }

--- a/src/utils/countryCurrency/getExchange.js
+++ b/src/utils/countryCurrency/getExchange.js
@@ -2,5 +2,8 @@ import countryExchange from './countryExchangeForMinimumDonationAmount.json';
 
 export const getMinimumAmountForCurrency = (curreny) => {
   const exchange = countryExchange.find((element) => element.currencyCode === curreny);
-  return (Math.round(exchange.value) * 2);
+  if (exchange)
+    return (Math.round(exchange.value) * 2);
+  else 
+    return -1;
 };


### PR DESCRIPTION
Fixes #

Changes in this pull request:
- always display selected and default country first in chooser dialog in country & language chooser
- always display DE and US and selected and default country first in chooser dialog in currency chooser
- removed duplicates from `src/utils/countryCurrency/countriesData.json`
- avoid crash if currency has no min value defined (also crashes in the `develop` branch)
