### PR TITLE
caught entering stripe test card by checking for existence of payment method

### DIFF
--- a/public/static/locales/en/donate.json
+++ b/public/static/locales/en/donate.json
@@ -72,5 +72,8 @@
   "supporting": "Supporting",
   "selectProject": "Select a project",
   "giftValidation": "Please enter gift details",
-  "minDonate": "Minimum donation amount is"
+  "minDonate": "Minimum donation amount is",
+  "noPaymentMethodError":"Could not process your payment, please try again.",
+  "somethingWentWrong":"Something went wrong please try again soon!",
+  "underMaintenance":"App is undergoing maintenance, please check status.plant-for-the-planet.org for details"
 }

--- a/src/features/donations/screens/PaymentDetails.tsx
+++ b/src/features/donations/screens/PaymentDetails.tsx
@@ -202,7 +202,10 @@ function PaymentDetails({
       paymentMethod = payload.paymentMethod;
       // Add payload error if failed
     }
-
+    if (!paymentMethod) {
+      setPaymentError('Could not process your payment, please try again.');
+      return;
+    }
 
     const payWithCardProps = {
       setDonationStep,

--- a/src/features/donations/screens/PaymentDetails.tsx
+++ b/src/features/donations/screens/PaymentDetails.tsx
@@ -170,7 +170,7 @@ function PaymentDetails({
       cardElement!.on('change', ({ error }) => {
         if (error) {
           // setPaymentError(error.message);
-          setPaymentError('Could not process your payment, please try again.');
+          setPaymentError(t('donate:noPaymentMethodError'));
           return;
         }
       });
@@ -180,7 +180,7 @@ function PaymentDetails({
           card: cardElement!,
         })
         .catch((error) => {
-          setPaymentError('Could not process your payment, please try again.');
+          setPaymentError(t('donate:noPaymentMethodError'));
           return;
         });
       paymentMethod = payload.paymentMethod;
@@ -203,7 +203,7 @@ function PaymentDetails({
       // Add payload error if failed
     }
     if (!paymentMethod) {
-      setPaymentError('Could not process your payment, please try again.');
+      setPaymentError(t('donate:noPaymentMethodError'));
       return;
     }
 
@@ -319,12 +319,12 @@ function PaymentDetails({
         } else if (res.code === 500) {
           setIsPaymentProcessing(false);
           setPaypalProcessing(false);
-          setPaymentError('Something went wrong please try again soon!');
+          setPaymentError(t('donate:somethingWentWrong'));
         } else if (res.code === 503) {
           setIsPaymentProcessing(false);
           setPaypalProcessing(false);
           setPaymentError(
-            'App is undergoing maintenance, please check status.plant-for-the-planet.org for details',
+            t('donate:underMaintenance'),
           );
         } else {
           setDonationID(res.id);
@@ -361,12 +361,12 @@ function PaymentDetails({
             return;
           } if (res.code === 500) {
             setIsPaymentProcessing(false);
-            setPaymentError('Something went wrong please try again soon!');
+            setPaymentError(t('donate:somethingWentWrong'));
             return;
           } if (res.code === 503) {
             setIsPaymentProcessing(false);
             setPaymentError(
-              'App is undergoing maintenance, please check status.plant-for-the-planet.org for details',
+              t('donate:underMaintenance'),
             );
             return;
           }

--- a/src/features/legacyDonations/components/CardPayments.tsx
+++ b/src/features/legacyDonations/components/CardPayments.tsx
@@ -116,7 +116,7 @@ function CardPayments({
       cardElement!.on('change', ({ error }) => {
         if (error) {
           // setPaymentError(error.message);
-          setPaymentError('Could not process your payment, please try again.');
+          setPaymentError(t('donate:noPaymentMethodError'));
           return;
         }
       });
@@ -126,7 +126,7 @@ function CardPayments({
           card: cardElement!,
         })
         .catch((error) => {
-          setPaymentError('Could not process your payment, please try again.');
+          setPaymentError(t('donate:noPaymentMethodError'));
           return;
         });
       paymentMethod = payload.paymentMethod;
@@ -135,7 +135,7 @@ function CardPayments({
     if (paymentMethod) {
       onPaymentFunction(paymentMethod);
     } else {
-      setPaymentError('Could not process your payment, please try again.');
+      setPaymentError(t('donate:noPaymentMethodError'));
       return;
     }
   };
@@ -241,7 +241,7 @@ function CardPayments({
           )}
 
       </div>
-  ) : null;
+  ) : <></>;
 }
 
 export default CardPayments;

--- a/src/features/legacyDonations/components/CardPayments.tsx
+++ b/src/features/legacyDonations/components/CardPayments.tsx
@@ -132,9 +132,12 @@ function CardPayments({
       paymentMethod = payload.paymentMethod;
       // Add payload error if failed
     }
-
-    onPaymentFunction(paymentMethod)
-    
+    if (paymentMethod) {
+      onPaymentFunction(paymentMethod);
+    } else {
+      setPaymentError('Could not process your payment, please try again.');
+      return;
+    }
   };
 
   const handleChange = (change) => {


### PR DESCRIPTION
Fixes #758 

Changes in this pull request:
- caught entering stripe test card by checking for existence of payment method

In order to test this you need to configure the production environment (API_ENDPOINT, NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY) into your local test environment and try to pay with the stripe test card data. You can then verify with some real credit card data that it is still working (if you enter a wrong CVC you avoid paying). For testing the legacy payment create a donation with the production native app first and copy the path from the mobile browser and adapt the URL to your local test environment.

(The good news: normal error reported by Stripe got already caught. This seems to be just a special edge case hopefully never occurred to someone on production yet.)