### PR TITLE
added Android deep link support for treemapper app

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -8,5 +8,15 @@
         "33:F3:D2:3E:5D:82:AF:5D:4B:26:51:68:94:31:C4:DC:46:AB:7B:19:E3:13:E4:7E:F6:E7:2D:70:D9:D9:CA:6E"
       ]
     }
+  },
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "org.pftp.treemapper",
+      "sha256_cert_fingerprints": [
+        "33:F3:D2:3E:5D:82:AF:5D:4B:26:51:68:94:31:C4:DC:46:AB:7B:19:E3:13:E4:7E:F6:E7:2D:70:D9:D9:CA:6E"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Fixes https://github.com/Plant-for-the-Planet-org/treemapper/issues/218

Changes in this pull request:
- added Android deep link support for treemapper app
