### PR TITLE
made setCurrencyCode function optional at selecting language and country

### DIFF
--- a/src/features/common/Layout/Footer/SelectLanguageAndCountry.tsx
+++ b/src/features/common/Layout/Footer/SelectLanguageAndCountry.tsx
@@ -32,7 +32,7 @@ interface TransitionsModalProps {
   setSelectedCurrency: Function,
   selectedCountry: any,
   setSelectedCountry: Function,
-  setCurrencyCode: Function,
+  setCurrencyCode?: Function,
 }
 export default function TransitionsModal({
     openModal,
@@ -74,7 +74,7 @@ export default function TransitionsModal({
     if (currencyCode) {
       window.localStorage.setItem('currencyCode', currencyCode);
       setSelectedCurrency(currencyCode);
-      setCurrencyCode(currencyCode)
+      if (setCurrencyCode) setCurrencyCode(currencyCode)
     }
     handleModalClose();
   }


### PR DESCRIPTION
Fixes crash at:

<img width="1680" alt="Bildschirmfoto 2021-02-22 um 10 30 39" src="https://user-images.githubusercontent.com/1532418/108690721-f5d5af00-74fa-11eb-8148-d5721ca4023c.png">

Changes in this pull request:
- made setCurrencyCode function optional at selecting language and country as not used at https://github.com/Plant-for-the-Planet-org/planet-webapp/blob/a391ba777a9f23ee97d4da6b3e823fe943bae0f8/src/features/common/Layout/Footer/index.tsx#L217-L225