### PR TITLE
Fix loading contributions for private profiles

### DIFF
--- a/pages/t/[id].tsx
+++ b/pages/t/[id].tsx
@@ -36,7 +36,7 @@ export default function PublicUser(initialized: Props) {
     getAccessTokenSilently,
     logout
   } = useAuth0();
- 
+
   // This effect is used to get and update UserInfo if the isAuthenticated changes
   React.useEffect(() => {
     async function loadFunction() {
@@ -55,6 +55,7 @@ export default function PublicUser(initialized: Props) {
     changeForceReload,
     forceReload,
     authenticatedType,
+    token,
   };
 
   const logoutUser = () => {
@@ -69,24 +70,23 @@ export default function PublicUser(initialized: Props) {
       setReady(true);
     }
   }, [router]);
-  
-  
+
   useEffect(() => {
     async function loadUserData() {
       // For loading user data we first have to decide whether user is trying to load their own profile or someone else's
       // To do this we first try to fetch the slug from the local storage
       // If the slug matches and also there is token in the session we fetch the user's private data, else the public data
-      
+
       if (typeof Storage !== 'undefined') {
-        let token = null; 
+        let token = null;
         if (isAuthenticated) {
           token = await getAccessTokenSilently();
         }
         const userInfo = await getLocalUserInfo()
         const currentUserSlug = userInfo?.slug ? userInfo.slug : null;
-        
+
         // some user logged in and slug matches -> private profile
-        if (!isLoading && token && currentUserSlug === slug) {          
+        if (!isLoading && token && currentUserSlug === slug) {
           try {
             const res = await getAccountInfo(token)
             if (res.status === 200) {
@@ -146,7 +146,7 @@ export default function PublicUser(initialized: Props) {
         </>
       );
     }
-    
+
   }
 
   if (initialized && (userprofile) && ready) {

--- a/src/features/user/UserProfile/components/MyTrees/MyTrees.tsx
+++ b/src/features/user/UserProfile/components/MyTrees/MyTrees.tsx
@@ -1,7 +1,10 @@
 import React, { ReactElement } from 'react';
 import styles from '../../styles/MyTrees.module.scss';
 import dynamic from 'next/dynamic';
-import { getRequestWithoutRedirecting } from '../../../../../utils/apiRequests/api';
+import {
+  getRequestWithoutRedirecting,
+  getAuthenticatedRequestWithoutRedirecting
+} from '../../../../../utils/apiRequests/api';
 import TreeIcon from '../../../../../../public/assets/images/icons/TreeIcon';
 import TreesIcon from '../../../../../../public/assets/images/icons/TreesIcon';
 import formatDate from '../../../../../utils/countryCurrency/getFormattedDate';
@@ -17,20 +20,31 @@ const { useTranslation } = i18next;
 interface Props {
   profile: any;
   authenticatedType: any;
+  token: any;
 }
 
-export default function MyTrees({ profile, authenticatedType }: Props) {
+export default function MyTrees({ profile, authenticatedType, token }: Props) {
   const { t, i18n, ready } = useTranslation(['country', 'me']);
   const [contributions, setContributions] = React.useState();
   React.useEffect(() => {
     async function loadFunction() {
-      getRequestWithoutRedirecting(`/app/profiles/${profile.id}/contributions`)
-        .then((result: any) => {
-          setContributions(result);
-        })
-        .catch((e: any) => {
-          console.log('error occured :', e);
-        });
+      if (token) {
+        getAuthenticatedRequestWithoutRedirecting(`/app/profiles/${profile.id}/contributions`, token)
+          .then((result: any) => {
+            setContributions(result);
+          })
+          .catch((e: any) => {
+            console.log('error occured :', e);
+          });
+      } else {
+        getRequestWithoutRedirecting(`/app/profiles/${profile.id}/contributions`)
+          .then((result: any) => {
+            setContributions(result);
+          })
+          .catch((e: any) => {
+            console.log('error occured :', e);
+          });
+      }
     }
     loadFunction();
   }, [profile]);

--- a/src/features/user/UserProfile/components/MyTrees/MyTrees.tsx
+++ b/src/features/user/UserProfile/components/MyTrees/MyTrees.tsx
@@ -29,7 +29,7 @@ export default function MyTrees({ profile, authenticatedType, token }: Props) {
   React.useEffect(() => {
     async function loadFunction() {
       if (token) {
-        getAuthenticatedRequestWithoutRedirecting(`/app/profiles/${profile.id}/contributions`, token)
+        getAuthenticatedRequestWithoutRedirecting(`/app/profile/contributions`, token)
           .then((result: any) => {
             setContributions(result);
           })

--- a/src/features/user/UserProfile/screens/IndividualProfile.tsx
+++ b/src/features/user/UserProfile/screens/IndividualProfile.tsx
@@ -13,6 +13,7 @@ export default function IndividualProfile({
   changeForceReload,
   forceReload,
   authenticatedType,
+  token,
 }: any) {
   // settings modal
   const [settingsModalOpen, setSettingsModalOpen] = React.useState(false);
@@ -83,7 +84,7 @@ export default function IndividualProfile({
           />
         </LandingSection>
 
-        <MyTrees authenticatedType={authenticatedType} profile={userprofile} />
+        <MyTrees authenticatedType={authenticatedType} profile={userprofile} token={token} />
       </main>
 
       {/* add target modal */}

--- a/src/features/user/UserProfile/screens/TpoProfile.tsx
+++ b/src/features/user/UserProfile/screens/TpoProfile.tsx
@@ -13,6 +13,7 @@ export default function TpoProfile({
   authenticatedType,
   changeForceReload,
   forceReload,
+  token
 }: any) {
   // settings modal
   const [settingsModalOpen, setSettingsModalOpen] = React.useState(false);
@@ -87,7 +88,7 @@ export default function TpoProfile({
       />
 
       {authenticatedType === 'private' ? (
-        <MyTrees authenticatedType={authenticatedType} profile={userprofile} />
+        <MyTrees authenticatedType={authenticatedType} profile={userprofile} token={token} />
       ) : null}
 
       {/* add target modal */}

--- a/src/utils/apiRequests/api.ts
+++ b/src/utils/apiRequests/api.ts
@@ -220,3 +220,25 @@ export async function getRequestWithoutRedirecting(url: any) {
     .catch((err) => console.log(`Something went wrong: ${err}`));
   return result;
 }
+
+export async function getAuthenticatedRequestWithoutRedirecting(url: any, token: any) {
+  let result;
+  await fetch(`${process.env.API_ENDPOINT}` + url, {
+    headers: {
+      'tenant-key': `${process.env.TENANTID}`,
+      'X-SESSION-ID': await getsessionId(),
+      Authorization: `OAuth ${token}`,
+      'x-locale': `${
+        localStorage.getItem('language')
+          ? localStorage.getItem('language')
+          : 'en'
+      }`,
+    },
+  })
+    .then(async (res) => {
+      result = res.status === 200 ? await res.json() : res.status;
+      return result;
+    })
+    .catch((err) => console.log(`Something went wrong: ${err}`));
+  return result;
+}


### PR DESCRIPTION
Fixes #914

Changes in this pull request:
- try to load the user contributions with Authorization header

To-Do: 
- [x]  implement another authenticated API call `/app/profile/contributions` to fit into the other existing ones:

```
/**
 * Class UserProfileController
 * @package App\Controller\App
 *
 *   Method & URL                              | authentication    | serialization
 *   -----------------------------------------------------------------------------------
 *   GET  /profiles/{slugOrGuid}               | not authenticated | profile-v2-public
 *   GET  /profiles/{slugOrGuid}/contributions | not authenticated | custom response
 *
 *   GET  /profile                             | authenticated     | profile-v2-private
 *   POST /profile                             | not authenticated | profile-v2-private
 *   PUT  /profile                             | authenticated     | profile-v2-private
 *
 *   GET  /profile/contributions               | authenticated     | custom response    <--- NEW
 *
 *   GET  /profile/projects                    | authenticated     | custom response
 *   GET  /profiles/{guid}/projects            | not authenticated | custom response
 */
```