### PR TITLE
example on how to run the test suite locally on chrome

### DIFF
--- a/__test__/DirectGift.test.js
+++ b/__test__/DirectGift.test.js
@@ -55,9 +55,9 @@ describe('direct gift', () => {
     await driver.wait(until.elementLocated(By.xpath("//*[text()='Thank You']"))).getText().then((title) => {
       expect(title).toBe('Thank You');
       if (title.includes('Thank You')) {
-        driver.executeScript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed","reason": "Title contains header!"}}');
+        //driver.executeScript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed","reason": "Title contains header!"}}');
       } else {
-        driver.executeScript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed","reason": "Title does not contain header!"}}');
+        //driver.executeScript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed","reason": "Title does not contain header!"}}');
       }
     });
     await driver.quit();

--- a/__test__/GiftTrees.test.js
+++ b/__test__/GiftTrees.test.js
@@ -55,9 +55,9 @@ describe('Gift Trees', () => {
     await driver.wait(until.elementLocated(By.xpath("//*[text()='Thank You']"))).getText().then((title) => {
       expect(title).toBe('Thank You');
       if (title.includes('Thank You')) {
-        driver.executeScript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed","reason": "Title contains header!"}}');
+        //driver.executeScript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed","reason": "Title contains header!"}}');
       } else {
-        driver.executeScript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed","reason": "Title does not contain header!"}}');
+        //driver.executeScript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed","reason": "Title does not contain header!"}}');
       }
     });
     await driver.quit();

--- a/__test__/Pages/index.js
+++ b/__test__/Pages/index.js
@@ -1,5 +1,5 @@
 import { until } from 'selenium-webdriver-3';
-import { driver, defaultTimeout } from '../helper';
+import { driver } from '../helper';
 
 const rootSelector = { css: '.theme-light' };
 
@@ -7,5 +7,6 @@ export const root = () => driver.findElement(rootSelector);
 
 export const load = async () => {
   await driver.get(`${__baseUrl__}`);
-  await driver.wait(until.elementLocated(root), defaultTimeout);
+  await driver.manage().window().maximize();
+  await driver.wait(until.elementLocated(root));
 };

--- a/__test__/RemoveDirectGift.test.js
+++ b/__test__/RemoveDirectGift.test.js
@@ -16,7 +16,7 @@ describe('remove', () => {
     await driver.findElement(By.id('singleGiftRemoveId')).click();
     await driver.wait(until.elementLocated(By.name('checkedA')));
     await driver.findElement(By.name('checkedA')).click().then(() => {
-      driver.executeScript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed","reason": "Action successful"}}');
+      //driver.executeScript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed","reason": "Action successful"}}');
     });
     await driver.quit();
   });

--- a/__test__/helper.js
+++ b/__test__/helper.js
@@ -1,4 +1,5 @@
 import webdriver from 'selenium-webdriver-3'
+import chrome from 'selenium-webdriver-3/chrome'
 
 const capabilities = {
   'os_version' : '10',
@@ -16,10 +17,12 @@ const capabilities = {
 
 export const driver = new webdriver.Builder()
   .forBrowser('chrome')
-  .usingServer('https://hub-cloud.browserstack.com/wd/hub')
-  .withCapabilities(capabilities)
+// install 'chromedriver' and add it to your PATH environment
+//.usingServer('https://hub-cloud.browserstack.com/wd/hub')
+//.withCapabilities(capabilities)
+  .setChromeOptions(new chrome.Options()
+    .addArguments('--lang=en,en-US')
+    .setUserPreferences({'intl.accept_languages': 'en,en_US'})
+  )
   .build();
-  
-driver.manage().window().maximize() 
 
-export const defaultTimeout = 10e9;

--- a/__test__/homePage.test.js
+++ b/__test__/homePage.test.js
@@ -53,9 +53,9 @@ describe('hompage', () => {
     await driver.wait(until.elementLocated(By.xpath("//*[text()='Thank You']"))).getText().then((title) => {
       expect(title).toBe('Thank You');
       if (title.includes('Thank You')) {
-        driver.executeScript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed","reason": "Title contains header!"}}');
+        //driver.executeScript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed","reason": "Title contains header!"}}');
       } else {
-        driver.executeScript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed","reason": "Title does not contain header!"}}');
+        //driver.executeScript('browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed","reason": "Title does not contain header!"}}');
       }
     });
     await driver.quit();

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+require('dotenv').config({ path: '.env' });
 
 module.exports = {
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],


### PR DESCRIPTION
Changes in this pull request:
- changed tests & test configuration to run locally with Chrome browser

Requirements
- install Chrome
- install [Chrome driver](https://chromedriver.chromium.org/downloads) and add it to the PATH environment to be able to start from a shell
- make sure to have all Browserstack enviroment variables set in a file named `.env` as following as we still use the BROWSERSTACK_TEST_URL to define the URL for the test while the other variables are not used for local testing):
```
BROWSERSTACK_USERNAME=planetit1
BROWSERSTACK_ACCESS_KEY=***
BROWSERSTACK_BUILD_NAME=plant-webapp-local
BROWSERSTACK_PROJECT_NAME=plant-webapp-local
BROWSERSTACK_TEST_URL=http://localhost:3000
```
- run local tests with `npm run test` or only one test with e.g. `npm run test __test__/RemoveDirectGift.test.js` 

This branch should not be merged (as otherwise tests could not run on Browserstack anymore)