### PR TITLE
allow to upload source maps from Netlify to Sentry

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,14 +19,17 @@ const {
   VERCEL_GITLAB_COMMIT_SHA,
   VERCEL_BITBUCKET_COMMIT_SHA,
   SOURCE_VERSION,
+  COMMIT_REF,
   SITE_IMAGERY_API_URL,
 } = process.env;
 
+// allow source map uploads from Vercel, Heroku and Netlify deployments
 const COMMIT_SHA =
   VERCEL_GITHUB_COMMIT_SHA ||
   VERCEL_GITLAB_COMMIT_SHA ||
   VERCEL_BITBUCKET_COMMIT_SHA ||
-  SOURCE_VERSION;
+  SOURCE_VERSION ||
+  COMMIT_REF;
 
 process.env.SENTRY_DSN = SENTRY_DSN;
 const basePath = '';


### PR DESCRIPTION
Changes in this pull request:
- added env variable [`COMMIT_REF`](https://docs.netlify.com/configure-builds/environment-variables/#git-metadata) showing the actual GitHub commit SHA in order to allow uploading of source maps from Netlify - we need to test if Netlify now can builds source maps with the Sentry plugin if all the env variables which are preconditions for it exists at https://github.com/Plant-for-the-Planet-org/planet-webapp/blob/1a4308e94e6438a6c621655c9443ab57adb9fa42/next.config.js#L77-L84
