### PR TITLE
enabled German translations for showing large number abbreviations

### DIFF
--- a/src/utils/getFormattedNumber.ts
+++ b/src/utils/getFormattedNumber.ts
@@ -18,12 +18,11 @@ class NumberParser {
   }
 }
 
-// change 'de-disabled' to 'de' if you want to enable custom abbreviations for German
 const localizedAbbr = {
   'en': {
     'b': 'b', 'm': 'm', 'k': 'k',
   },
-  'de-disabled': {
+  'de': {
     'b': 'Mrd.', 'm': 'Mio.', 'k': 'Tsd.',
   },
 };
@@ -53,7 +52,7 @@ export function getFormattedRoundedNumber(
   fractionDigits: number,
 ) {
   // console.log("getFormattedRoundedNumber", langCode, number, fractionDigits);
-  if (Math.round(number) === Math.round(number*fractionDigits*10)/(fractionDigits*10)) 
+  if (Math.round(number) === Math.round(number*fractionDigits*10)/(fractionDigits*10))
     fractionDigits = 0;
   const formatter = new Intl.NumberFormat(langCode, {
     // These options are needed to round to whole numbers if that's what you want.

--- a/src/utils/getFormattedNumber.ts
+++ b/src/utils/getFormattedNumber.ts
@@ -40,8 +40,8 @@ export function localizedAbbreviatedNumber(
     return getFormattedRoundedNumber(langCode, number/1000000000, fractionDigits) + getLocalizedAbbreviation(langCode, 'b');
   if (number >= 1000000)
     return getFormattedRoundedNumber(langCode, number/1000000, fractionDigits) + getLocalizedAbbreviation(langCode, 'm');
-  if (number >= 1000)
-    return getFormattedRoundedNumber(langCode, number/1000, fractionDigits) + getLocalizedAbbreviation(langCode, 'k');
+  //if (number >= 1000)
+  //  return getFormattedRoundedNumber(langCode, number/1000, fractionDigits) + getLocalizedAbbreviation(langCode, 'k');
 
   return getFormattedRoundedNumber(langCode, number, fractionDigits);
 }


### PR DESCRIPTION
Fixes request of @felixfinkbeiner 

Changes in this pull request:
- enabled German translations for showing large number abbreviations

<img width="332" alt="Bildschirmfoto 2021-03-31 um 14 19 52" src="https://user-images.githubusercontent.com/1532418/113143265-3af0ad80-922c-11eb-9cc8-acce9c6570f0.png">
<img width="826" alt="Bildschirmfoto 2021-03-31 um 14 20 11" src="https://user-images.githubusercontent.com/1532418/113143273-3e843480-922c-11eb-83ee-61aab8f0dd5c.png">


- disabled abbreviation for thousands (in all languages):

<img width="372" alt="Bildschirmfoto 2021-03-31 um 13 56 28" src="https://user-images.githubusercontent.com/1532418/113140692-0a5b4480-9229-11eb-9c95-84d567faee56.png">
