### PR TITLE
restrict size of notification container on small devices

### DIFF
--- a/src/theme/global.scss
+++ b/src/theme/global.scss
@@ -295,7 +295,7 @@ button {
   max-width: 98%;
   pointer-events: all;
   z-index: 999;
-  height: 250px;
+  height: fit-content;
   background: transparent;
 }
 
@@ -311,7 +311,6 @@ button {
     bottom: 100px;
     max-width: 100%;
     border-radius: 0px;
-    max-height: 15%;
   }
 }
 

--- a/src/theme/global.scss
+++ b/src/theme/global.scss
@@ -311,6 +311,7 @@ button {
     bottom: 100px;
     max-width: 100%;
     border-radius: 0px;
+    max-height: 15%;
   }
 }
 


### PR DESCRIPTION
Fixes #986

Changes in this pull request:
- restrict size of notification container on small devices

I tried to limit the size of the notification container to max 15% of the screen size on smaller devices now, so it can not show big notifications any more, but it seems the notifications are shown anyway ignoring the size of the container:

<img width="1683" alt="Bildschirmfoto 2021-04-15 um 09 59 28" src="https://user-images.githubusercontent.com/1532418/114835083-803ae080-9dd1-11eb-8366-4c3120e248dd.png">

I am not sure if this work with all devices and thus solves the problem or creates a new one?