### PR TITLE
get rid of router pathname in console

### DIFF
--- a/src/features/common/Layout/Navbar/getNavBarIcon.tsx
+++ b/src/features/common/Layout/Navbar/getNavBarIcon.tsx
@@ -16,8 +16,6 @@ interface Props {
 }
 
 function GetNavBarIcon({mainKey,router,item}: Props):ReactElement {
-
-    console.log('router.pathname',router.pathname);
     
     const HomeLink =()=>{
         return(


### PR DESCRIPTION
Get rid of annoying router pathname in console
![image](https://user-images.githubusercontent.com/27153515/116191868-aa35c080-a74a-11eb-94e3-653880bfd37e.png)
