### PR TITLE
set yucatan link redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -189,6 +189,11 @@ module.exports = withPlugins([[withBundleAnalyzer], [withSourceMaps]], {
         destination: '/open-app',
         permanent: true,
       },
+      {
+        source: '/yucatan-reforestation',
+        destination: '/yucatan',
+        permanent: true,
+      },
     ];
   },
   assetPrefix: hasAssetPrefix ? `${scheme}://${process.env.ASSET_PREFIX}` : '',


### PR DESCRIPTION
**P1**

The slug for project Yucatan Reforestation changed from `/yucatan-reforestation` to `/yucatan` . This hotfix is to redirect the old URL to the new one.

Note: this change in only on the production backend so, anyone testing please use Production API endpoint.