### PR TITLE
removed deep link /login from iOS deep link description file

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -4,7 +4,7 @@
         "details": [
             {
                 "appID": "UYRJ8SA699.org.plant-for-the-planet.app",
-                "paths": [ "/", "/imprint*", "/edit-profile*", "/login*",
+                "paths": [ "/", "/imprint*", "/edit-profile*",
                     "/password-sent*", "/signup*", "/my-trees*", "/forgot-password*", "/account-activation*",
                     "/faq*", "/about_us*", "/license_info_list*", "/data-protection-policy*",
                     "/redeem*", "/claim*", "/edit-trees*", "/target*", "/challenge*",


### PR DESCRIPTION
Fixes #584

Changes in this pull request:
- removed deep link /login from iOS deep link description file
- Android deep link has to be removed within the app code: https://github.com/Plant-for-the-Planet-org/treecounter-app/pull/3036