### PR TITLE
adapted stats in Leaderboard, fixed rounding bug

### DIFF
--- a/public/static/locales/de/planet.json
+++ b/public/static/locales/de/planet.json
@@ -1,6 +1,6 @@
 {
   "treesDonated": "Gespendete Bäume seit 2019",
-  "plantedByTPO": "Gepflanzt von den 130+ teilnehmenden Projekten",
+  "plantedByTPO": "Gepflanzt von den {{projects}}+ teilnehmenden Projekten",
   "plantedGlobally": "An uns gemeldete Bäume seit 2006",
   "forestLoss": "Netto-Waldverlust pro Jahr",
   "estimateOf": "Schätzung des jährlichen Baumverlusts nach",

--- a/public/static/locales/en/planet.json
+++ b/public/static/locales/en/planet.json
@@ -1,6 +1,6 @@
 {
   "treesDonated": "Trees donated since 2019",
-  "plantedByTPO": "Planted by the 130+ participating projects",
+  "plantedByTPO": "Planted by the {{projects}}+ participating projects",
   "plantedGlobally": "Trees reported to us since 2006",
   "forestLoss": "Net tree loss per year",
   "estimateOf": "Estimate of annual tree loss by",

--- a/public/static/locales/es/planet.json
+++ b/public/static/locales/es/planet.json
@@ -1,6 +1,6 @@
 {
   "treesDonated": "Árboles donados desde 2019",
-  "plantedByTPO": "Plantado por las 101 organizaciones participantes",
+  "plantedByTPO": "Plantado por las {{projects}}+ organizaciones participantes",
   "plantedGlobally": "Árboles que nos fueron notificados desde 2006",
   "forestLoss": "Pérdida neta de bosques en los últimos 12 meses",
   "estimateOf": "Estimación de la pérdida anual de árboles por",

--- a/public/static/locales/fr/planet.json
+++ b/public/static/locales/fr/planet.json
@@ -1,6 +1,6 @@
 {
   "treesDonated": "Arbres donnés depuis 2019",
-  "plantedByTPO": "Planté par plus de 130 projets participants",
+  "plantedByTPO": "Planté par plus de {{projects}}+ projets participants",
   "plantedGlobally": "Arbres qui nous sont signalés depuis 2006",
   "forestLoss": "Perte nette d'arbres par an",
   "estimateOf": "Estimation de la perte annuelle d'arbres par",

--- a/public/static/locales/pt-BR/planet.json
+++ b/public/static/locales/pt-BR/planet.json
@@ -1,6 +1,6 @@
 {
   "treesDonated": "Árvores doadas desde 2019",
-  "plantedByTPO": "Plantado pelas 101 organizações participantes",
+  "plantedByTPO": "Plantado pelas {{projects}}+ organizações participantes",
   "plantedGlobally": "Árvores registradas na plataforma desde 2006",
   "forestLoss": "Perda florestal líquida nos últimos 12 meses",
   "estimateOf": "Estimativa da perda anual de árvores por",

--- a/src/tenants/planet/LeaderBoard/components/Stats.tsx
+++ b/src/tenants/planet/LeaderBoard/components/Stats.tsx
@@ -26,12 +26,12 @@ export default function Stats({tenantScore}: Props): ReactElement {
     <div className={styles.wrapper}>
       <div className={styles.container}>
         <div className={styles.statCard}>
-          <h2 className={styles.statNumber}>{localizedAbbreviatedNumber(i18n.language, Number(14760000), 2)}</h2>
+          <h2 className={styles.statNumber}>{localizedAbbreviatedNumber(i18n.language, Number(32020000), 2)}</h2>
           <h3 className={styles.statText}>{t('planet:treesDonated')}</h3>
         </div>
         <div className={styles.statCard}>
-          <h2 className={styles.statNumber}> {localizedAbbreviatedNumber(i18n.language, Number(63000000), 2)} </h2>
-          <h3 className={styles.statText}>{t('planet:plantedByTPO')}</h3>
+          <h2 className={styles.statNumber}> {localizedAbbreviatedNumber(i18n.language, Number(77060000), 2)} </h2>
+          <h3 className={styles.statText}>{t('planet:plantedByTPO', { projects: 160 })}</h3>
         </div>
         <div className={styles.statCard}>
           <h2 className={styles.statNumber}>{localizedAbbreviatedNumber(i18n.language, Number(tenantScore.total), 2)}</h2>


### PR DESCRIPTION
Fixes #

Changes in this pull request:
- adapted stats in Leaderboard (this is just one static one-time update)

<img width="872" alt="Bildschirmfoto 2021-06-04 um 16 57 30" src="https://user-images.githubusercontent.com/1532418/120821660-f815c380-c555-11eb-982e-8c4fda8f8c52.png">
