### PR TITLE
only used the date part for conversion without time

### DIFF
--- a/src/features/projects/components/maps/PlantLocations.tsx
+++ b/src/features/projects/components/maps/PlantLocations.tsx
@@ -84,7 +84,7 @@ export default function PlantLocations({}: Props): ReactElement {
 
   const getDateDiff = (pl: any) => {
     const today = new Date();
-    const plantationDate = new Date(pl.plantDate);
+    const plantationDate = new Date(pl.plantDate?.substr(0,10));
     const differenceInTime = today.getTime() - plantationDate.getTime();
     const differenceInDays = differenceInTime / (1000 * 3600 * 24);
     if (differenceInDays < 1) {


### PR DESCRIPTION
Fixes https://github.com/Plant-for-the-Planet-org/planet-webapp/pull/1157#issuecomment-887852041

Finally I found the reason: Safari can not convert a value of kind “2021-07-23 00:00:00” into a date with new Date(string) as it needs a timezone or just a date like “2021-07-23" without the time value. So I truncated the value to the first 10 characters.

We should check our whole codebase for such errors. If we receive such date values from the API, we should not just try to convert them into Date objects!