### PR TITLE
fix map not available issue in satellite mode

### DIFF
--- a/src/features/projects/components/maps/SatelliteLayer.tsx
+++ b/src/features/projects/components/maps/SatelliteLayer.tsx
@@ -12,9 +12,9 @@ export default function SatelliteLayer({ beforeId }: Props): ReactElement {
         id="satellite"
         type="raster"
         tiles={[
-          'https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+          'https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
         ]}
-        tileSize={128}
+        tileSize={256}
       >
         <Layer
           id="satellite-layer"


### PR DESCRIPTION
Fixes #1163

Changes in this pull request:
- change satellite map source to esri wayback which does not fail when map data is not available