### PR TITLE
add bottom padding to project polygon on mobile

### DIFF
--- a/src/utils/maps/zoomToProjectSite.ts
+++ b/src/utils/maps/zoomToProjectSite.ts
@@ -21,7 +21,7 @@ export default function zoomToProjectSite(
     {
       padding: {
         top: 50,
-        bottom: isMobile ? 120 : 50,
+        bottom: isMobile ? 300 : 50,
         left: isMobile ? 50 : 400,
         right: isMobile ? 50 : 100,
       },


### PR DESCRIPTION
Changes in this pull request:
- add padding at the bottom of the project polygon

Before -
![image](https://user-images.githubusercontent.com/27153515/129707514-16678170-fe1c-4ab6-b457-5701bcf807e5.png)

After -
![image](https://user-images.githubusercontent.com/27153515/129707610-dea8b803-95d9-4549-9281-dea3ee9d1fba.png)

