### PR TITLE
changed BrowserNotSupported screen

### DIFF
--- a/src/features/common/ErrorComponents/BrowserNotSupported.tsx
+++ b/src/features/common/ErrorComponents/BrowserNotSupported.tsx
@@ -1,20 +1,49 @@
-import Layout from '../Layout';
+import React from 'react';
 
 export default function BrowserNotSupported() {
+
+    const [url, setUrl] = React.useState('');
+
+    React.useEffect(() => {
+        if (typeof window !== 'undefined') {
+            let urlopen = window.location.href;
+            // credits for this code goes to https://urlopen.link/
+            setUrl(urlopen.replace(/^https?:\/\/((?:(?:[a-z\d_\-=]+\.)+[a-z\d]+)(\/[a-z\d_\-=\+\.\/:]*)?)(?:\?(.*))?$/i, function ($0, u, d, q): string {
+                let qs, i, kv, k, v, j;
+                if (!d) u += '/';
+                if (q) {
+                    qs = q.split('&');
+                    for (i = 0; i < qs.length; i++) {
+                        kv = qs[i].split('=');
+                        k = kv.shift();
+                        v = kv.join('=');
+                        if (/[^a-z\d_\-\.]/i.test(k)) return '';
+                        for (j = 0; j < v.length; j++) {
+                            if (v.charCodeAt(j) < 256 && /[^a-z\d_\-=\+\.\/]/i.test(v[j])) return '';
+                            if (v.charCodeAt(j) > 256 && encodeURIComponent(v[j]).length < 9) return '';
+                        }
+                    }
+                    u += '?' + q;
+                }
+                return ('https://urlopen.link/' + u);
+            }));
+        }
+    }, []);
+
     return (
-        <Layout>
-            <div
-                style={{
-                    margin: '20px',
-                    width: '100vw',
-                    height: '60vh',
-                    display: 'flex',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                }}
-            >
-                <p>Your browser is not supported. Please use a newer version or another browser.</p>
-            </div>
-        </Layout>
+        <div
+            style={{
+                margin: '20px',
+                width: '100vw',
+                height: '60vh',
+                justifyContent: 'center',
+                alignItems: 'center',
+            }}
+        >
+            <p>Your browser is not supported. Please use a newer version or another browser.</p>
+            <p>
+                <a href={url} rel="nofollow noreferrer">Try to open a compatible browser.</a>
+            </p>
+        </div>
     );
 }

--- a/src/features/common/ErrorComponents/BrowserNotSupported.tsx
+++ b/src/features/common/ErrorComponents/BrowserNotSupported.tsx
@@ -4,6 +4,14 @@ export default function BrowserNotSupported() {
 
     const [url, setUrl] = React.useState('');
 
+    const urlOpen = (url: string) => {
+        if (typeof window !== 'undefined') {
+            console.log(url);
+            window.location.href = url;
+        }
+        return false;
+    }
+
     React.useEffect(() => {
         if (typeof window !== 'undefined') {
             const urlopen = window.location.href;
@@ -42,7 +50,7 @@ export default function BrowserNotSupported() {
         >
             <p>Your browser is not supported. Please use a newer version or another browser.</p>
             <p>
-                <a href={url} rel="nofollow noreferrer">Try to open a compatible browser.</a>
+                <a href={url} onClick={() => urlOpen(url)} rel="nofollow noreferrer">Try to open a compatible browser.</a>
             </p>
         </div>
     );

--- a/src/features/common/ErrorComponents/BrowserNotSupported.tsx
+++ b/src/features/common/ErrorComponents/BrowserNotSupported.tsx
@@ -6,9 +6,9 @@ export default function BrowserNotSupported() {
 
     React.useEffect(() => {
         if (typeof window !== 'undefined') {
-            let urlopen = window.location.href;
+            const urlopen = window.location.href;
             // credits for this code goes to https://urlopen.link/
-            setUrl(urlopen.replace(/^https?:\/\/((?:(?:[a-z\d_\-=]+\.)+[a-z\d]+)(\/[a-z\d_\-=\+\.\/:]*)?)(?:\?(.*))?$/i, function ($0, u, d, q): string {
+            setUrl(urlopen.replace(/^https?:\/\/((?:(?:[a-z\d_\-=]+\.)+[a-z\d]+)(\/[a-z\d_\-=+./:]*)?)(?:\?(.*))?$/i, function ($0, u, d, q): string {
                 let qs, i, kv, k, v, j;
                 if (!d) u += '/';
                 if (q) {
@@ -17,9 +17,9 @@ export default function BrowserNotSupported() {
                         kv = qs[i].split('=');
                         k = kv.shift();
                         v = kv.join('=');
-                        if (/[^a-z\d_\-\.]/i.test(k)) return '';
+                        if (/[^a-z\d_\-.]/i.test(k)) return '';
                         for (j = 0; j < v.length; j++) {
-                            if (v.charCodeAt(j) < 256 && /[^a-z\d_\-=\+\.\/]/i.test(v[j])) return '';
+                            if (v.charCodeAt(j) < 256 && /[^a-z\d_\-=+./]/i.test(v[j])) return '';
                             if (v.charCodeAt(j) > 256 && encodeURIComponent(v[j]).length < 9) return '';
                         }
                     }


### PR DESCRIPTION
Changes in this pull request:
- simplified browser not support screen (as flex layout is also not supported on some older browsers)
- added a link with https://urlopen.link/ to open from InAppBrowser into another browser on the device

This does not work for me tested with an InAppBrowser in an QR Code scanner app on my Nexus 7 tablet as well as with the UC browser of a OnePlus 7 :-(