### PR TITLE
avoid crash when zooming to project site

### DIFF
--- a/src/features/projects/components/maps/Project.tsx
+++ b/src/features/projects/components/maps/Project.tsx
@@ -43,7 +43,14 @@ export default function Project({
   React.useEffect(() => {
     if (siteExists) {
       loadRasterData();
-      const isMobileTemp = window.innerWidth <= 767;
+      let isPortrait = true;
+      if (screen.orientation) {
+        isPortrait = screen.orientation.angle === 0 || screen.orientation.angle === 180;
+      } else if (window.orientation) {
+        isPortrait = window.orientation === 0 || window.orientation === 180;
+      }  
+      const isMobileTemp = window.innerWidth <= 767 && isPortrait;
+      //console.log("Projects-isMobileTemp", isMobileTemp, window.innerHeight, window.innerWidth, window.orientation, screen.orientation);
       zoomToProjectSite(
         {
           type: 'FeatureCollection',

--- a/src/features/projects/components/maps/Project.tsx
+++ b/src/features/projects/components/maps/Project.tsx
@@ -43,14 +43,6 @@ export default function Project({
   React.useEffect(() => {
     if (siteExists) {
       loadRasterData();
-      let isPortrait = true;
-      if (screen.orientation) {
-        isPortrait = screen.orientation.angle === 0 || screen.orientation.angle === 180;
-      } else if (window.orientation) {
-        isPortrait = window.orientation === 0 || window.orientation === 180;
-      }  
-      const isMobileTemp = window.innerWidth <= 767 && isPortrait;
-      //console.log("Projects-isMobileTemp", isMobileTemp, window.innerHeight, window.innerWidth, window.orientation, screen.orientation);
       zoomToProjectSite(
         {
           type: 'FeatureCollection',
@@ -58,7 +50,6 @@ export default function Project({
         },
         selectedSite,
         viewport,
-        isMobileTemp,
         setViewPort,
         setSiteViewPort,
         4000

--- a/src/features/projects/components/maps/Project.tsx
+++ b/src/features/projects/components/maps/Project.tsx
@@ -47,7 +47,7 @@ export default function Project({
       if (screen.orientation) {
         isPortrait = screen.orientation.angle === 0 || screen.orientation.angle === 180;
       } else if (window.orientation) {
-        isPortrait = window.orientation === 0 || window.orientation === 180;
+        isPortrait = window.orientation === 0 || window.orientation === 180;
       }  
       const isMobileTemp = window.innerWidth <= 767 && isPortrait;
       //console.log("Projects-isMobileTemp", isMobileTemp, window.innerHeight, window.innerWidth, window.orientation, screen.orientation);

--- a/src/features/projects/components/maps/Sites.tsx
+++ b/src/features/projects/components/maps/Sites.tsx
@@ -26,19 +26,10 @@ export default function Sites({}: Props): ReactElement {
   } = React.useContext(ProjectPropsContext);
 
   React.useEffect(() => {
-    let isPortrait = true;
-    if (screen.orientation) {
-      isPortrait = screen.orientation.angle === 0 || screen.orientation.angle === 180;
-    } else if (window.orientation) {
-      isPortrait = window.orientation === 0 || window.orientation === 180;
-    }  
-    const isMobileTemp = window.innerWidth <= 767 && isPortrait;
-    //console.log("Projects-isMobileTemp", isMobileTemp, window.innerHeight, window.innerWidth, window.orientation, screen.orientation);
     zoomToProjectSite(
       geoJson,
       selectedSite,
       viewport,
-      isMobileTemp,
       setViewPort,
       setSiteViewPort,
       4000

--- a/src/features/projects/components/maps/Sites.tsx
+++ b/src/features/projects/components/maps/Sites.tsx
@@ -26,7 +26,14 @@ export default function Sites({}: Props): ReactElement {
   } = React.useContext(ProjectPropsContext);
 
   React.useEffect(() => {
-    const isMobileTemp = window.innerWidth <= 767;
+    let isPortrait = true;
+    if (screen.orientation) {
+      isPortrait = screen.orientation.angle === 0 || screen.orientation.angle === 180;
+    } else if (window.orientation) {
+      isPortrait = window.orientation === 0 || window.orientation === 180;
+    }  
+    const isMobileTemp = window.innerWidth <= 767 && isPortrait;
+    //console.log("Projects-isMobileTemp", isMobileTemp, window.innerHeight, window.innerWidth, window.orientation, screen.orientation);
     zoomToProjectSite(
       geoJson,
       selectedSite,

--- a/src/features/projects/components/maps/Sites.tsx
+++ b/src/features/projects/components/maps/Sites.tsx
@@ -30,7 +30,7 @@ export default function Sites({}: Props): ReactElement {
     if (screen.orientation) {
       isPortrait = screen.orientation.angle === 0 || screen.orientation.angle === 180;
     } else if (window.orientation) {
-      isPortrait = window.orientation === 0 || window.orientation === 180;
+      isPortrait = window.orientation === 0 || window.orientation === 180;
     }  
     const isMobileTemp = window.innerWidth <= 767 && isPortrait;
     //console.log("Projects-isMobileTemp", isMobileTemp, window.innerHeight, window.innerWidth, window.orientation, screen.orientation);

--- a/src/utils/maps/zoomToProjectSite.ts
+++ b/src/utils/maps/zoomToProjectSite.ts
@@ -6,42 +6,60 @@ export default function zoomToProjectSite(
   geoJson: Object | null,
   selectedSite: number,
   viewport: Object,
-  isMobile: boolean,
   setViewPort: Function,
   setSiteViewPort: Function,
   duration = 1200
 ) {
-  const bbox = turf.bbox(geoJson.features[selectedSite]);
-  const { longitude, latitude, zoom } = new WebMercatorViewport(
-    viewport
-  ).fitBounds(
-    [
-      [bbox[0], bbox[1]],
-      [bbox[2], bbox[3]],
-    ],
-    {
-      padding: {
-        top: 50,
-        bottom: isMobile ? 300 : 50,
-        left: isMobile ? 50 : 400,
-        right: isMobile ? 50 : 100,
-      },
+  if (viewport.width && viewport.height) {
+    // decide which paddings to use (for mobile or normal)
+    let isPortrait = true;
+    if (screen.orientation) {
+      isPortrait = screen.orientation.angle === 0 || screen.orientation.angle === 180;
+    } else if (window.orientation) {
+      isPortrait = window.orientation === 0 || window.orientation === 180;
+    }  
+    const isMobile = window.innerWidth <= 767 && isPortrait;
+    //console.log("zoomToProjectSite", viewport, viewport.width, window.innerWidth, viewport.height, window.innerHeight);
+
+    const bbox = turf.bbox(geoJson.features[selectedSite]);
+    const { longitude, latitude, zoom } = new WebMercatorViewport(
+      viewport
+    ).fitBounds(
+      [
+        [bbox[0], bbox[1]],
+        [bbox[2], bbox[3]],
+      ],
+      {
+        padding: {
+          top: 50,
+          bottom: isMobile ? 300 : 50,
+          left: isMobile ? 50 : 400,
+          right: isMobile ? 50 : 100,
+        },
+      }
+    );
+    let defaultZoom = 15;
+    if(zoom < defaultZoom) {
+      defaultZoom = zoom;
     }
-  );
-  let defaultZoom = 15;
-  if(zoom < defaultZoom) {
-    defaultZoom = zoom;
+    
+    const newViewport = {
+      ...viewport,
+      longitude,
+      latitude,
+      zoom:defaultZoom,
+      transitionDuration: duration,
+      transitionInterpolator: new FlyToInterpolator(),
+      transitionEasing: d3.easeCubic,
+    };
+    setViewPort(newViewport);
+    setSiteViewPort({center:[longitude,latitude],zoom:defaultZoom});  
+  } else {
+    const newViewport = {
+      ...viewport,
+      height: window.innerHeight,
+      width: window.innerWidth,
+    };
+    setViewPort(newViewport);
   }
-  
-  const newViewport = {
-    ...viewport,
-    longitude,
-    latitude,
-    zoom:defaultZoom,
-    transitionDuration: duration,
-    transitionInterpolator: new FlyToInterpolator(),
-    transitionEasing: d3.easeCubic,
-  };
-  setViewPort(newViewport);
-  setSiteViewPort({center:[longitude,latitude],zoom:defaultZoom});
 }


### PR DESCRIPTION
Fix #1138

Changes in this pull request:
- added exception for not using bigger padding for mobile devices if in landscape mode
- added check if viewport.width and viewport.height exists and do not zoom without these values

Unfortunately window.orientation or screen.orientation are not available in all browser, e.g. Safari on MacOS.