### PR TITLE
open terms link in new window or tab

### DIFF
--- a/src/tenants/treesforjane/RegisterTrees/JaneRegisterTrees.tsx
+++ b/src/tenants/treesforjane/RegisterTrees/JaneRegisterTrees.tsx
@@ -412,7 +412,7 @@ export default function RegisterTrees({}: Props) {
             }}
           >
             {t('agreeTerms')}
-            <a href="https://pp.eco/legal/en/terms">{t('pftp')}</a>
+            <a href="https://pp.eco/legal/en/terms" target="_blank" rel="nofollow noreferrer">{t('pftp')}</a>
           </label>
         </div>
         <div className={styles.nextButton}>


### PR DESCRIPTION
Fixes losing input for registration if clicking on terms link.

Changes in this pull request:
- open terms link in new window or tab
