### PR TITLE
do not load video for custom tenants not seeing it

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -159,7 +159,12 @@ export default function PlanetWeb({ Component, pageProps, err }: any) {
               : { display: 'none' }
           }
         >
-          <VideoContainer setshowVideo={setshowVideo} />
+          {(config.tenantName === 'planet' || config.tenantName === 'ttc') ? (
+            <VideoContainer setshowVideo={setshowVideo} />
+            ) : (
+              <></>
+            )
+          }
         </div>
 
         <div


### PR DESCRIPTION
Changes in this pull request:
- do not load video for custom tenants not seeing it - saving megabytes of unused traffic :-)

This PR should also be merged into `tenant/treesforjane` by merging `develop` into it (after solving conflicts!).