### PR TITLE
Zoom control buttons on small device in landscape mode overlap with satellite mode button fixed

### DIFF
--- a/src/features/projects/styles/ProjectsMap.module.scss
+++ b/src/features/projects/styles/ProjectsMap.module.scss
@@ -606,7 +606,7 @@ fill: $primaryFontColor;
 //   }
 // }
 
-@include xsPhoneView {
+@media screen and (max-height:315px), (max-width:481px){
   .mapNavigation {
     display: none;
   }


### PR DESCRIPTION
fixed #1204 