### PR TITLE
Fix project tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,5 @@
 {
-    "chromeWebSecurity": false
+    "chromeWebSecurity": false,
+    "viewportWidth": 1280,
+    "viewportHeight": 1024
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -30,7 +30,7 @@
 Cypress.Commands.add('BasicDonation', () => {
     cy.visit(Cypress.env('TEST_SERVER') + '/yucatan')
     cy.skipIntroVideo()
-    cy.wait(5000)
+    cy.wait(15000) // wait a little longer for tests running on 'npm run dev' instances
     cy.get('[data-test-id="donateButton"]').click()
     cy.contactForm("Peter", "Payer", "peter.payer@gmail.com", "Unbekannt 1", "Uffing am Staffelsee", "Germany{enter}", "82449")
 })
@@ -195,7 +195,7 @@ Cypress.Commands.add("projectDetails", () => {
     cy.wait(5000)
     cy.get('[data-test-id="siteName"]').type(randomstring)
     cy.get('[data-test-id="siteStatus"]').click()
-    cy.contains("Planting").click()
+    cy.contains("Planted").click()
     cy.get('[data-test-id="projSitesCont"]').click()
     cy.wait(5000)
     cy.get('[data-test-id="projSpendingCont"]').click()


### PR DESCRIPTION
Fixes #1328

Changes in this pull request:
- use wider viewport to avoid test errors due to non visible elements
- first test is waiting longer in case using a `npm run dev` (which takes longer to compile for the first time)
- clicking the first element in the dropdown as the first sometimes is not visible for Cypress :-(