### PR TITLE
HOTFIX: hide sample trees, alter the order of satellite map loading

### DIFF
--- a/pages/[p].tsx
+++ b/pages/[p].tsx
@@ -34,6 +34,7 @@ export default function Donate({
     setPlantLocations,
     selectedPl,
     hoveredPl,
+    setPlantLocationsLoaded
   } = React.useContext(ProjectPropsContext);
 
   React.useEffect(() => {
@@ -67,8 +68,10 @@ export default function Donate({
 
   React.useEffect(() => {
     async function loadPl() {
+      setPlantLocationsLoaded(false);
       const newPlantLocations = await getAllPlantLocations(project.id);
       setPlantLocations(newPlantLocations);
+      setPlantLocationsLoaded(true);
     }
     if (project) {
       loadPl();

--- a/src/features/common/Layout/ProjectPropsContext.tsx
+++ b/src/features/common/Layout/ProjectPropsContext.tsx
@@ -76,6 +76,8 @@ export const ProjectPropsContext = React.createContext({
   setFilteredProjects:(value: []) => {},
   filtersOpen:false,
   setFilterOpen:(value:boolean) => {},
+  plantLocationsLoaded: false,
+  setPlantLocationsLoaded: (value: boolean) => {},
 });
 
 function ProjectPropsProvider({ children }: any): ReactElement {
@@ -103,6 +105,7 @@ function ProjectPropsProvider({ children }: any): ReactElement {
   const [satellite, setSatellite] = React.useState(false);
   const [filteredProjects, setFilteredProjects] = React.useState(null);
   const [filtersOpen, setFilterOpen] = React.useState(false);
+  const [plantLocationsLoaded, setPlantLocationsLoaded] = React.useState(false);
 
   const mapRef = React.useRef(null);
   const EMPTY_STYLE = {
@@ -281,7 +284,9 @@ function ProjectPropsProvider({ children }: any): ReactElement {
         filteredProjects, 
         setFilteredProjects,
         filtersOpen,
-        setFilterOpen
+        setFilterOpen,
+        plantLocationsLoaded,
+        setPlantLocationsLoaded,
       }}
     >
       {children}

--- a/src/features/projects/components/maps/PlantLocations.tsx
+++ b/src/features/projects/components/maps/PlantLocations.tsx
@@ -92,7 +92,7 @@ export default function PlantLocations({}: Props): ReactElement {
       return t('today');
     } else if (differenceInDays < 2) {
       return t('yesterday');
-    } else if (differenceInDays < 30) {
+    } else if (differenceInDays <= 10) {
       return t('daysAgo', {
         days: localizedAbbreviatedNumber(i18n.language, differenceInDays, 0),
       });
@@ -167,6 +167,7 @@ export default function PlantLocations({}: Props): ReactElement {
                     )}
                   </Source>
                   {pl &&
+                  pl.id === selectedPl?.id &&
                     pl.samplePlantLocations &&
                     pl.samplePlantLocations
                       .filter((item: any) => {

--- a/src/features/projects/components/maps/Sites.tsx
+++ b/src/features/projects/components/maps/Sites.tsx
@@ -22,7 +22,8 @@ export default function Sites({}: Props): ReactElement {
     selectedMode,
     rasterData,
     satellite,
-    setSiteViewPort
+    setSiteViewPort,
+    plantLocationsLoaded
   } = React.useContext(ProjectPropsContext);
 
   React.useEffect(() => {
@@ -40,7 +41,7 @@ export default function Sites({}: Props): ReactElement {
     <>
       {selectedMode === 'location' && (
         <>
-          {satellite && <SatelliteLayer />}
+          {plantLocationsLoaded && satellite && <SatelliteLayer />}
           {/* <ProjectPolygon id="locationPolygon" geoJson={geoJson} /> */}
         </>
       )}


### PR DESCRIPTION
- [x]  show sample trees if polygon is selected
- [x]  show n days ago only for last 10 days
- [x]  load satellite map after plant location are loaded