### PR TITLE
fixed Regex for zipcode of Denmark

### DIFF
--- a/src/utils/countryZipCode/index.js
+++ b/src/utils/countryZipCode/index.js
@@ -212,7 +212,7 @@ const COUNTRY_ADDRESS_POSTALS = [{
 }, {
   abbrev: 'DK',
   name: 'Denmark',
-  postal: /^[0-9]{5}$/,
+  postal: /^[0-9]{4}$/,
 }, {
   abbrev: 'DJ',
   name: 'Djibouti',


### PR DESCRIPTION
Changes in this pull request:
- fixed Regex for zipcode of Denmark
