### PR TITLE
added missing translations for account history navigation and titles

### DIFF
--- a/pages/profile/history.tsx
+++ b/pages/profile/history.tsx
@@ -92,7 +92,7 @@ function AccountHistory({ }: Props): ReactElement {
       )}
       <UserLayout>
         <Head>
-          <title>{t('donations')}</title>
+          <title>{t('history')}</title>
         </Head>
         <History {...HistoryProps} />
         {/* <UnderMaintenance/> */}

--- a/pages/profile/recurrency.tsx
+++ b/pages/profile/recurrency.tsx
@@ -68,7 +68,7 @@ function RecurrentDonations({ }: Props): ReactElement {
       )}
       <UserLayout>
         <Head>
-          <title>{t('Recurrency')}</title>
+          <title>{t('recurrency')}</title>
         </Head>
         <Recurrency {...RecurrencyProps} />
       </UserLayout>

--- a/public/static/locales/de/me.json
+++ b/public/static/locales/de/me.json
@@ -114,6 +114,8 @@
   "taxReceipt": "Spendenbescheinigung",
   "history": "Historie",
   "recurrency": "Dauerspenden",
+  "new": "Neu",
+  "beta": "Beta",
   "date": "Datum",
   "treemapper": "TreeMapper",
   "register-trees": "Bäume registrieren",

--- a/public/static/locales/en/me.json
+++ b/public/static/locales/en/me.json
@@ -114,6 +114,8 @@
   "taxReceipt": "Tax Receipt",
   "history": "History",
   "recurrency": "Recurring Donations",
+  "new": "New",
+  "beta": "Beta",
   "date": "Date",
   "treemapper": "TreeMapper",
   "register-trees": "Register Trees",

--- a/src/features/common/Layout/UserLayout/UserLayout.tsx
+++ b/src/features/common/Layout/UserLayout/UserLayout.tsx
@@ -30,6 +30,7 @@ function UserLayout(props: any): ReactElement {
       title: t('me:profile'),
       path: '/profile',
       icon: <UserIcon />,
+      // Localize with translations if you ever activate this!!
       // subMenu: [
       //   // {
       //   //   title: 'Profile',
@@ -56,19 +57,20 @@ function UserLayout(props: any): ReactElement {
       title: t('me:payments'),
       // path: '/profile/history',
       icon: <DonateIcon />,
-      flag: 'New',
+      flag: t('me:new'),
       // hideSubMenu: true,
       subMenu: [
         {
-          title: 'History',
+          title: t('me:history'),
           path: '/profile/history',
           // hideItem: true,
         },
         {
-          title: 'Recurring Donations',
+          title: t('me:recurrency'),
           path: '/profile/recurrency',
           // hideItem: true,
         },
+        // Localize with translations if you ever activate this!!
         // {
         //   title: 'Payouts',
         //   path: '/profile/payouts', // Only for Tpos
@@ -79,13 +81,7 @@ function UserLayout(props: any): ReactElement {
         // },
       ],
     },
-    // {
-    //   key: 4,
-    //   title: t('me:recurrency'),
-    //   path: '/profile/recurrency',
-    //   icon: <DonateIcon />,
-    //   flag: 'Beta',
-    // },
+    // Localize with translations if you ever activate this!!
     // {
     //   title: 'TreeCash',
     //   path: '/profile/treecash',
@@ -106,7 +102,7 @@ function UserLayout(props: any): ReactElement {
       title: t('treeMapper'),
       path: '/profile/treemapper',
       icon: <TreeMappperIcon />,
-      flag: 'Beta',
+      flag: t('me:beta'),
     },
     {
       key: 5,
@@ -134,6 +130,7 @@ function UserLayout(props: any): ReactElement {
           title: t('me:deleteProfile'),
           path: '/profile/delete-account',
         },
+        // Localize with translations if you ever activate this!!
         // {
         //   title: 'Setup 2Factor Authentication',
         //   path: '/profile/2fa', // Only for Tpos


### PR DESCRIPTION
Changes in this pull request:
- adding missing translations for account history
   - added `New`, `Beta`
   - use `history` and `recurrency` where no translation was used
   - changed `donations` to `history` as title on account history screen

Open question:
- why got the existing resource `accountHistory` replaced with `history` and is unused now?
