### PR TITLE
added translations for subscription status

### DIFF
--- a/pages/profile/recurrency.tsx
+++ b/pages/profile/recurrency.tsx
@@ -30,11 +30,11 @@ function RecurrentDonations({ }: Props): ReactElement {
         (obj) => obj.status == 'active' || obj.status == 'trialing'
       );
       const pauseRecurrencies = recurrencies?.filter(
-        (obj) => obj.status == 'pause'
+        (obj) => obj.status == 'paused'
       );
       const otherRecurrencies = recurrencies?.filter(
         (obj) =>
-          obj.status != 'pause' &&
+          obj.status != 'paused' &&
           obj.status != 'active' &&
           obj.status != 'trialing'
       );

--- a/public/static/locales/de/me.json
+++ b/public/static/locales/de/me.json
@@ -197,10 +197,10 @@
   },
   "active": "aktiv",
   "canceled": "abgebrochen",
-  "incomplete": "unvollständig",
-  "incomplete_expired": "unvollständig & abgelaufen",
+  "incomplete": "ausstehend",
+  "incomplete_expired": "abgebrochen",
   "past_due": "überfällig",
   "unpaid": "unbezahlt",
-  "trialing": "überprüfend",
+  "trialing": "aktiv",
   "paused": "pausiert"
 }

--- a/public/static/locales/de/me.json
+++ b/public/static/locales/de/me.json
@@ -194,5 +194,13 @@
     "stripe-sepa_debit": "SEPA-Zahlungen dauern 2-14 Arbeitstage (normalerweise 3-5 Tage). Sobald deine Überweisung eintrifft, senden wir dir eine Bestätigungs-E-Mail mit deinen Belegen (und deinem Zertifikat).",
     "stripe-sofort": "SOFORT-Zahlungen dauern 2-14 Werktage (normalerweise 2-3 Tage). Sobald deine Überweisung eintrifft, senden wir dir eine Bestätigungs-E-Mail mit deinen Belegen (und deinem Zertifikat).",
     "in-dispute": "Deine Überweisung wurde angefochten. In der Regel werden von den Zahlungsanbietern $7 - $15.00 Gebühren erhoben. Bitte kontaktiere support@plant-for-the-planet.org für weitere Informationen."
-  }
+  },
+  "active": "aktiv",
+  "canceled": "abgebrochen",
+  "incomplete": "unvollständig",
+  "incomplete_expired": "unvollständig & abgelaufen",
+  "past_due": "überfällig",
+  "unpaid": "unbezahlt",
+  "trialing": "überprüfend",
+  "paused": "pausiert"
 }

--- a/public/static/locales/en/me.json
+++ b/public/static/locales/en/me.json
@@ -196,11 +196,11 @@
     "in-dispute": "Your transfer was disputed. Usually $7 - $15.00 dispute fee is charged by Payment Providers. Please Contact support@plant-for-the-planet.org for details."
   },
   "active": "active",
-  "canceled": "canceled",
-  "incomplete": "incomplete",
-  "incomplete_expired": "incomplete & expired",
+  "canceled": "cancelled",
+  "incomplete": "pending",
+  "incomplete_expired": "cancelled",
   "past_due": "past due",
   "unpaid": "unpaid",
-  "trialing": "trialing",
+  "trialing": "active",
   "paused": "paused"
 }

--- a/public/static/locales/en/me.json
+++ b/public/static/locales/en/me.json
@@ -194,5 +194,13 @@
     "stripe-sepa_debit": "SEPA payments take 2-14 business days (usually 3-5 days). As soon as your transfer arrives we will send you a confirmation email with your receipts (and your certificate).",
     "stripe-sofort": "SOFORT payments take 2-14 business days (usually 2-3 days). As soon as your transfer arrives we will send you a confirmation email with your receipts (and your certificate).",
     "in-dispute": "Your transfer was disputed. Usually $7 - $15.00 dispute fee is charged by Payment Providers. Please Contact support@plant-for-the-planet.org for details."
-  }
+  },
+  "active": "active",
+  "canceled": "canceled",
+  "incomplete": "incomplete",
+  "incomplete_expired": "incomplete & expired",
+  "past_due": "past due",
+  "unpaid": "unpaid",
+  "trialing": "trialing",
+  "paused": "paused"
 }

--- a/src/features/user/Account/components/RecurrencyRecord.tsx
+++ b/src/features/user/Account/components/RecurrencyRecord.tsx
@@ -139,7 +139,7 @@ export function RecordHeader({
               : styles.active
             }`}
         >
-          {record?.status === 'trialing' ? 'active' : record?.status}
+          {record?.status === 'trialing' ? 'active' : t(record?.status)}
         </p>
       </div>
     </div>


### PR DESCRIPTION
Fix #1355

Changes in this pull request:
- added translations for subscription status taken from backend at https://github.com/Plant-for-the-Planet-org/treecounter-platform/blob/374b26f1658ce20a020254aaf1941f525b62e312/src/Entity/PaymentRecurrency.php#L64-L72
- replaced non existing status `pause` with `paused` fixing sorting