### PR TITLE
support external plant locations and improve get requests

### DIFF
--- a/src/features/user/TreeMapper/index.tsx
+++ b/src/features/user/TreeMapper/index.tsx
@@ -37,7 +37,7 @@ function TreeMapper({ }: Props): ReactElement {
     if (next && links?.next) {
       const response = await getAuthenticatedRequest(links.next, token, {},
         handleError,
-        '/profile');
+        '/profile', undefined, '1.0.4');
       if (response) {
         const newPlantLocations = response?.items;
         for (const itr in newPlantLocations) {
@@ -69,7 +69,9 @@ function TreeMapper({ }: Props): ReactElement {
         token,
         {},
         handleError,
-        '/profile'
+        '/profile',
+        undefined,
+        '1.0.4'
       );
       if (response) {
         const plantLocations = response?.items;

--- a/src/utils/apiRequests/api.ts
+++ b/src/utils/apiRequests/api.ts
@@ -1,4 +1,5 @@
 import { TENANT_ID } from '../constants/environment';
+import { getQueryString } from './getQueryString';
 import getsessionId from './getSessionId';
 import { validateToken } from './validateToken';
 
@@ -75,14 +76,13 @@ export async function getRequest(
   url: any,
   errorHandler?: Function,
   redirect?: string,
-  queryParams?: { [key: string]: string }
+  queryParams?: { [key: string]: string },
+  version?: string
 ) {
   let result;
   const lang = localStorage.getItem('language') || 'en';
   const query: any = { ...queryParams, locale: lang };
-  const queryString = Object.keys(query)
-    .map((key) => key + '=' + query[key])
-    .join('&');
+  const queryString = getQueryString(query);
   await fetch(`${process.env.API_ENDPOINT}${url}?${queryString}`, {
     method: 'GET',
     headers: {
@@ -93,6 +93,7 @@ export async function getRequest(
           ? localStorage.getItem('language')
           : 'en'
       }`,
+      'x-accept-versions': version ? version : '1.0.3',
     },
   })
     .then(async (res) => {
@@ -108,21 +109,23 @@ export async function getAuthenticatedRequest(
   token: any,
   header: any = null,
   errorHandler?: Function,
-  redirect?: string
+  redirect?: string,
+  queryParams?: { [key: string]: string },
+  version?: string
 ): Promise<any> {
   let result = {};
-  await fetch(`${process.env.API_ENDPOINT}` + url, {
+  const lang = localStorage.getItem('language') || 'en';
+  const query: any = { ...queryParams };
+  const queryString = getQueryString(query);
+
+  await fetch(`${process.env.API_ENDPOINT}${url}?${queryString}`, {
     method: 'GET',
     headers: {
       'tenant-key': `${TENANT_ID}`,
       'X-SESSION-ID': await getsessionId(),
       Authorization: `Bearer ${token}`,
-      'x-locale': `${
-        localStorage.getItem('language')
-          ? localStorage.getItem('language')
-          : 'en'
-      }`,
-      'x-accept-versions': '1.0.3',
+      'x-locale': `${lang}`,
+      'x-accept-versions': version ? version : '1.0.3',
     },
   })
     .then(async (res) => {

--- a/src/utils/apiRequests/getQueryString.ts
+++ b/src/utils/apiRequests/getQueryString.ts
@@ -1,0 +1,7 @@
+export const getQueryString = (queryParams: { [key: string]: string }) => {
+  return Object.keys(queryParams)
+    .map((key) => {
+      return `${key}=${queryParams[key]}`;
+    })
+    .join('&');
+};

--- a/src/utils/maps/plantLocations.ts
+++ b/src/utils/maps/plantLocations.ts
@@ -58,7 +58,8 @@ export async function getAllPlantLocations(
     '/',
     {
       _scope: 'extended',
-    }
+    },
+    '1.0.4'
   );
   if (result) {
     return result;


### PR DESCRIPTION
### Changes
- adapt `getRequest()` to accept version as a parameter
- query params request object in `getAuthenticatedRequest()`
- abstract `getQueryString()`
- use version `1.0.4` in plantLocation APIs to get external plant locations