### PR TITLE
correct giftCertificate i18n key

### DIFF
--- a/public/static/locales/de/me.json
+++ b/public/static/locales/de/me.json
@@ -163,7 +163,7 @@
   "targetSave": "Speichern",
   "targetErrorMessage": "Zahl muss größer als Null sein",
   "taxDeductibleReceipt": "Spendenbescheinigung",
-  "Gift Certificate": "Baumzertifikat",
+  "giftCertificate": "Baumzertifikat",
   "paypal-paypal": "Paypal",
   "stripe-": "Stripe",
   "unknown-method": "Unbekannt",

--- a/public/static/locales/en/me.json
+++ b/public/static/locales/en/me.json
@@ -163,7 +163,7 @@
   "targetSave": "Save",
   "targetErrorMessage": "Number must be greater than zero",
   "taxDeductibleReceipt": "Tax Deductible Receipt",
-  "Gift Certificate": "Gift Certificate",
+  "giftCertificate": "Gift Certificate",
   "paypal-paypal": "Paypal",
   "stripe-": "Stripe",
   "unknown-method": "Unknown",

--- a/public/static/locales/fr/me.json
+++ b/public/static/locales/fr/me.json
@@ -123,7 +123,7 @@
   "targetSave": "Sauvegarder",
   "targetErrorMessage": "Le nombre doit être supérieur à zéro",
   "taxDeductibleReceipt": "Reçu déductible des impôts",
-  "Gift Certificate": "Certificat de don",
+  "giftCertificate": "Certificat de don",
   "paypal-paypal": "Paypal",
   "stripe-": "Stripe",
   "unknown-method": "Inconnu",

--- a/public/static/locales/pt-BR/me.json
+++ b/public/static/locales/pt-BR/me.json
@@ -123,7 +123,7 @@
   "targetSave": "Salvar",
   "targetErrorMessage": "O número deve ser positivo ou maior que zero",
   "taxDeductibleReceipt": "Taxa Dedutível de Imposto",
-  "Gift Certificate": "Certificado do presente",
+  "giftCertificate": "Certificado do presente",
   "paypal-paypal": "Paypal",
   "stripe-": "Stripe",
   "unknown-method": "Desconhecido",


### PR DESCRIPTION
Fixes https://www.notion.so/plantfortheplanet/Fix-Payment-History-Gift-Certificate-Download-Text-translations-e04b17ed804248e7944636b98b37c429

Changes in this pull request:
- corrected the i18n key for giftCertificate so that we see "Gift Certificate" in the download link text seen in Payment History (as opposed to "giftCertificate")

Note:
- this will be seen only if the donation was a gift, and not otherwise (no change to code logic for this).
- Gift Certificate link will be visible only once this issue is resolved - https://github.com/Plant-for-the-Planet-org/planet-webapp/issues/1448

@ankitecd Could you review and merge if OK?