### PR TITLE
fixed wrong query string handling

### DIFF
--- a/src/utils/apiRequests/api.ts
+++ b/src/utils/apiRequests/api.ts
@@ -92,7 +92,8 @@ export async function getRequest(
   const lang = localStorage.getItem('language') || 'en';
   const query: any = { ...queryParams, locale: lang };
   const queryString = getQueryString(query);
-  await fetch(`${process.env.API_ENDPOINT}${url}?${queryString}`, {
+  const queryStringSuffix = queryString ? '?' + queryString : ''
+  await fetch(`${process.env.API_ENDPOINT}${url}${queryStringSuffix}`, {
     method: 'GET',
     headers: {
       'tenant-key': `${TENANT_ID}`,
@@ -126,8 +127,8 @@ export async function getAuthenticatedRequest(
   const lang = localStorage.getItem('language') || 'en';
   const query: any = { ...queryParams };
   const queryString = getQueryString(query);
-
-  await fetch(`${process.env.API_ENDPOINT}${url}?${queryString}`, {
+  const queryStringSuffix = queryString ? '?' + queryString : ''
+  await fetch(`${process.env.API_ENDPOINT}${url}${queryStringSuffix}`, {
     method: 'GET',
     headers: {
       'tenant-key': `${TENANT_ID}`,


### PR DESCRIPTION
Fixes https://www.notion.so/plantfortheplanet/Fix-API-to-again-display-existing-sites-of-a-project-when-it-is-edited-f1b6ab81c7e84d3394ce0900c2eafe16

<img width="850" alt="Bildschirmfoto 2022-03-25 um 14 27 59" src="https://user-images.githubusercontent.com/1532418/160129903-d2a7ada7-4367-4e3b-ae64-87e6cceb3a14.png">

Changes in this pull request:
- do not append `?` to URL if no query string exists