### PR TITLE
fix: remove /100 for amounts in payment history

### DIFF
--- a/src/features/user/Account/components/AccountRecord.tsx
+++ b/src/features/user/Account/components/AccountRecord.tsx
@@ -128,7 +128,7 @@ export function RecordHeader({
           {getFormatedCurrency(
             i18n.language,
             record.currency,
-            record.netAmount / 100
+            record.netAmount
           )}
         </p>
         <p className={`${styles.recordStatus} ${styles[record.status]}`}>
@@ -179,7 +179,7 @@ export function DetailsComponent({ record }: DetailProps): ReactElement {
             {getFormatedCurrency(
               i18n.language,
               record.currency,
-              record.details.paidAmount / 100
+              record.details.paidAmount
             )}
           </p>
         </div>
@@ -191,7 +191,7 @@ export function DetailsComponent({ record }: DetailProps): ReactElement {
             {getFormatedCurrency(
               i18n.language,
               record.currency,
-              record.details.totalAmount / 100
+              record.details.totalAmount
             )}
           </p>
         </div>
@@ -233,7 +233,7 @@ export function DetailsComponent({ record }: DetailProps): ReactElement {
             {getFormatedCurrency(
               i18n.language,
               record.currency,
-              record.details.refundAmount / 100
+              record.details.refundAmount
             )}
           </p>
         </div>
@@ -245,7 +245,7 @@ export function DetailsComponent({ record }: DetailProps): ReactElement {
             {getFormatedCurrency(
               i18n.language,
               record.currency,
-              record.details.unitCost / 100
+              record.details.unitCost
             )}
           </p>
         </div>
@@ -271,7 +271,7 @@ export function DetailsComponent({ record }: DetailProps): ReactElement {
             {getFormatedCurrency(
               i18n.language,
               record.currency,
-              record.details.fees.disputeFee / 100
+              record.details.fees.disputeFee
             )}
           </p>
         </div>
@@ -283,7 +283,7 @@ export function DetailsComponent({ record }: DetailProps): ReactElement {
             {getFormatedCurrency(
               i18n.language,
               record.currency,
-              record.details.fees.planetFee / 100
+              record.details.fees.planetFee
             )}
           </p>
         </div>
@@ -295,7 +295,7 @@ export function DetailsComponent({ record }: DetailProps): ReactElement {
             {getFormatedCurrency(
               i18n.language,
               record.currency,
-              record.details.fees.transactionFee / 100
+              record.details.fees.transactionFee
             )}
           </p>
         </div>
@@ -307,7 +307,7 @@ export function DetailsComponent({ record }: DetailProps): ReactElement {
             {getFormatedCurrency(
               i18n.language,
               record.currency,
-              record.details.fees.transferFee / 100
+              record.details.fees.transferFee
             )}
           </p>
         </div>


### PR DESCRIPTION
Changes in this pull request:
- Removes division/100 for amounts shown in payment history (AccountRecord)