### PR TITLE
fix: prevents crash redeeming codes without tpo

### DIFF
--- a/pages/claim/[type]/[code].tsx
+++ b/pages/claim/[type]/[code].tsx
@@ -105,7 +105,7 @@ function ClaimDonation({}: Props): ReactElement {
           setErrorMessage(res.message);
           setIsUploadingData(false);
         } else if (res.status === 'error') {
-          setErrorMessage(res.errorText);
+          setErrorMessage(res.errorText || t('me:wentWrong'));
           setIsUploadingData(false);
         } else if (res.status === 'success') {
           setCodeValidated(true);
@@ -162,8 +162,8 @@ function ClaimDonation({}: Props): ReactElement {
         if (res.code === 401) {
           setErrorMessage(res.message);
           setIsUploadingData(false);
-        } else if (res.response.status === 'error') {
-          setErrorMessage(res.errorText);
+        } else if (!res.response || res.response.status === 'error') {
+          setErrorMessage(res.errorText || t('me:wentWrong'));
           setIsUploadingData(false);
         } else if (res.response.status === 'success') {
           setCodeRedeemed(true);

--- a/pages/claim/[type]/[code].tsx
+++ b/pages/claim/[type]/[code].tsx
@@ -211,13 +211,15 @@ function ClaimDonation({}: Props): ReactElement {
                     />
                   </div>
                   <div className={styles.donationCount}>
-                    {t('redeem:myPlantedTreesByOrg', {
-                      count: getFormattedNumber(
-                        i18n.language,
-                        Number(validCodeData.treeCount)
-                      ),
-                      tpoName: validCodeData.tpos[0].tpoName,
-                    })}
+                    {validCodeData.tpos?.length > 0 &&
+                      t('redeem:myPlantedTreesByOrg', {
+                        count: Number(validCodeData.treeCount),
+                        formattedNumber: getFormattedNumber(
+                          i18n.language,
+                          Number(validCodeData.treeCount)
+                        ),
+                        tpoName: validCodeData.tpos[0]?.tpoName,
+                      })}
                     <p className={styles.donationTenant}>
                       {t('donate:plantTreesAtURL', { url: config.tenantURL })}
                     </p>
@@ -236,13 +238,15 @@ function ClaimDonation({}: Props): ReactElement {
                     />
                   </div>
                   <p className={styles.tempDonationCount}>
-                    {t('redeem:myPlantedTreesByOrg', {
-                      count: getFormattedNumber(
-                        i18n.language,
-                        Number(validCodeData.treeCount)
-                      ),
-                      tpoName: validCodeData.tpos[0].tpoName,
-                    })}
+                    {validCodeData.tpos?.length > 0 &&
+                      t('redeem:myPlantedTreesByOrg', {
+                        count: Number(validCodeData.treeCount),
+                        formattedNumber: getFormattedNumber(
+                          i18n.language,
+                          Number(validCodeData.treeCount)
+                        ),
+                        tpoName: validCodeData.tpos[0]?.tpoName,
+                      })}
                   </p>
                   <p className={styles.tempDonationTenant}>
                     {t('donate:plantTreesAtURL', { url: config.tenantURL })}
@@ -300,10 +304,12 @@ function ClaimDonation({}: Props): ReactElement {
                   </span>
                 </div>
 
-                <div className={styles.plantedBy}>
-                  <span>{t('common:plantedBy')}</span>
-                  <p>{validCodeData.tpos[0].tpoName}</p>
-                </div>
+                {validCodeData.tpos?.length > 0 && (
+                  <div className={styles.plantedBy}>
+                    <span>{t('common:plantedBy')}</span>
+                    <p>{validCodeData.tpos[0].tpoName}</p>
+                  </div>
+                )}
 
                 <div
                   onClick={() => redeemCode(code, type)}

--- a/src/features/user/Profile/components/RedeemModal.tsx
+++ b/src/features/user/Profile/components/RedeemModal.tsx
@@ -61,11 +61,11 @@ export default function RedeemModal({
     setTextCopiedSnackbarOpen(false);
   };
 
-  const Alert = styled(MuiAlert)(({theme}) => {
+  const Alert = styled(MuiAlert)(({ theme }) => {
     return {
       backgroundColor: theme.palette.primary.main,
-    }
-  })
+    };
+  });
 
   const { register, handleSubmit, errors, getValues } = useForm({
     mode: 'onBlur',
@@ -189,14 +189,15 @@ export default function RedeemModal({
                   />
                 </div>
                 <div className={styles.donationCount}>
-                  {t('redeem:myPlantedTreesByOrg', {
-                    count: Number(validCodeData.treeCount),
-                    formattedNumber: getFormattedNumber(
-                      i18n.language,
-                      Number(validCodeData.treeCount)
-                    ),
-                    tpoName: validCodeData.tpos[0].tpoName,
-                  })}
+                  {validCodeData.tpos?.length > 0 &&
+                    t('redeem:myPlantedTreesByOrg', {
+                      count: Number(validCodeData.treeCount),
+                      formattedNumber: getFormattedNumber(
+                        i18n.language,
+                        Number(validCodeData.treeCount)
+                      ),
+                      tpoName: validCodeData.tpos[0]?.tpoName,
+                    })}
                   <p className={styles.donationTenant}>
                     {t('donate:plantTreesAtURL', { url: config.tenantURL })}
                   </p>
@@ -215,14 +216,15 @@ export default function RedeemModal({
                   />
                 </div>
                 <p className={styles.tempDonationCount}>
-                  {t('redeem:myPlantedTreesByOrg', {
-                    count: Number(validCodeData.treeCount),
-                    formattedNumber: getFormattedNumber(
-                      i18n.language,
-                      Number(validCodeData.treeCount)
-                    ),
-                    tpoName: validCodeData.tpos[0].tpoName,
-                  })}
+                  {validCodeData.tpos?.length > 0 &&
+                    t('redeem:myPlantedTreesByOrg', {
+                      count: Number(validCodeData.treeCount),
+                      formattedNumber: getFormattedNumber(
+                        i18n.language,
+                        Number(validCodeData.treeCount)
+                      ),
+                      tpoName: validCodeData.tpos[0]?.tpoName,
+                    })}
                 </p>
                 <p className={styles.tempDonationTenant}>
                   {t('donate:plantTreesAtURL', { url: config.tenantURL })}
@@ -250,8 +252,8 @@ export default function RedeemModal({
             >
               <div>
                 <Alert
-                elevation={6}
-                variant="filled"
+                  elevation={6}
+                  variant="filled"
                   onClose={handleTextCopiedSnackbarClose}
                   severity="success"
                 >
@@ -276,10 +278,12 @@ export default function RedeemModal({
                   </span>
                 </div>
 
-                <div className={styles.plantedBy}>
-                  <span>{t('common:plantedBy')}</span>
-                  <p>{validCodeData.tpos[0].tpoName}</p>
-                </div>
+                {validCodeData.tpos?.length > 0 && (
+                  <div className={styles.plantedBy}>
+                    <span>{t('common:plantedBy')}</span>
+                    <p>{validCodeData.tpos[0]?.tpoName}</p>
+                  </div>
+                )}
 
                 <button
                   id={'redeemModalCont'}

--- a/src/features/user/Profile/components/RedeemModal.tsx
+++ b/src/features/user/Profile/components/RedeemModal.tsx
@@ -88,7 +88,7 @@ export default function RedeemModal({
           setErrorMessage(res.message);
           setIsUploadingData(false);
         } else if (res.status === 'error') {
-          setErrorMessage(res.errorText);
+          setErrorMessage(res.errorText || t('me:wentWrong'));
           setIsUploadingData(false);
         } else if (res.status === 'success') {
           setCode(data.code);
@@ -117,8 +117,8 @@ export default function RedeemModal({
         if (res.code === 401) {
           setErrorMessage(res.message);
           setIsUploadingData(false);
-        } else if (res.response.status === 'error') {
-          setErrorMessage(res.errorText);
+        } else if (!res.response || res.response.status === 'error') {
+          setErrorMessage(res.errorText || t('me:wentWrong'));
           setIsUploadingData(false);
         } else if (res.response.status === 'success') {
           setCodeRedeemed(true);
@@ -285,6 +285,9 @@ export default function RedeemModal({
                   </div>
                 )}
 
+                {errorMessage && (
+                  <span className={styles.formErrors}>{errorMessage}</span>
+                )}
                 <button
                   id={'redeemModalCont'}
                   onClick={handleSubmit(redeemCode)}


### PR DESCRIPTION
Fixes crash seen while redeeming codes when tpos array is empty (during code validation phase)

Also fixes crash when a 500 error is received while converting codes to trees.