### PR TITLE
Add locale query param and remove language cookie

### DIFF
--- a/i18n/index.js
+++ b/i18n/index.js
@@ -14,16 +14,14 @@ export default new NextI18Next({
   debug: false,
   otherLanguages: config.languages, // list all languages here
   detection: {
-    // check if language is cached in cookies, if not check local storage,
-    // last retrieve from browser language
-    order: ['cookie', 'localStorage', 'navigator'],
+    // check if language is cached in local storage, otherwise retrieve from browser language
+    order: ['localStorage', 'navigator'],
 
-    // next-i18next by default searches for the 'next-i18next' cookie on server requests
-    lookupCookie: 'language',
+    // next-i18next by default searches for the 'next-i18next' cookie, local storage key on server requests
     lookupLocalStorage: 'language',
 
-    // cache the language in cookies and local storage
-    caches: ['cookie', 'localStorage'],
+    // cache the language local storage
+    caches: ['localStorage'],
   },
   react: {
     // trigger a rerender when language is changed

--- a/src/features/common/Layout/QueryParamsContext.tsx
+++ b/src/features/common/Layout/QueryParamsContext.tsx
@@ -29,29 +29,25 @@ const QueryParamsProvider: FC = ({ children }) => {
   const { query } = router;
 
   useEffect(() => {
-    setEmbed(router.query.embed);
+    if (query.embed) setEmbed(query.embed);
   }, [query.embed]);
 
   useEffect(() => {
-    setSingleProject(query.singleProject);
+    if (query.singleProject) setSingleProject(query.singleProject);
   }, [query.singleProject]);
 
   useEffect(() => {
-    setCallbackUrl(query.callback);
+    if (query.callback) setCallbackUrl(query.callback);
   }, [query.callback]);
 
   useEffect(() => {
-    if (query.locale) {
-      setLanguage(query.locale);
-    } else {
-      setLanguage(localStorage.getItem('language'));
-    }
+    if (query.locale) setLanguage(query.locale);
   }, [query.locale]);
 
   useEffect(() => {
-    if (i18n && i18n.isInitialized) {
+    if (i18n && i18n.isInitialized && language) {
       i18n.changeLanguage(language as string);
-      localStorage.setItem('language', language as string);
+      /* localStorage.setItem('language', language as string); */ //not needed as i18n handles setting the local storage
     }
   }, [language, i18n.isInitialized]);
 

--- a/src/features/common/Layout/QueryParamsContext.tsx
+++ b/src/features/common/Layout/QueryParamsContext.tsx
@@ -1,29 +1,59 @@
 import React, { createContext, FC, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import i18next from '../../../../i18n';
 
-type QueryParamType = string | undefined | string[];
+const { useTranslation } = i18next;
+
+type QueryParamType = string | undefined | string[] | null;
 export interface ParamsContextType {
   embed: QueryParamType;
   singleProject: QueryParamType;
   callbackUrl: QueryParamType;
+  language: QueryParamType;
 }
 export const ParamsContext = createContext<ParamsContextType>({
   embed: undefined,
   singleProject: undefined,
   callbackUrl: undefined,
+  language: undefined,
 });
 
 const QueryParamsProvider: FC = ({ children }) => {
+  const { i18n } = useTranslation();
+
   const [embed, setEmbed] = useState<QueryParamType>(undefined);
   const [singleProject, setSingleProject] = useState<QueryParamType>(undefined);
   const [callbackUrl, setCallbackUrl] = useState<QueryParamType>(undefined);
+  const [language, setLanguage] = useState<QueryParamType>(undefined);
   const router = useRouter();
+  const { query } = router;
 
   useEffect(() => {
     setEmbed(router.query.embed);
-    setSingleProject(router.query.singleproject);
-    setCallbackUrl(router.query.callback);
-  }, [router]);
+  }, [query.embed]);
+
+  useEffect(() => {
+    setSingleProject(query.singleProject);
+  }, [query.singleProject]);
+
+  useEffect(() => {
+    setCallbackUrl(query.callback);
+  }, [query.callback]);
+
+  useEffect(() => {
+    if (query.locale) {
+      setLanguage(query.locale);
+    } else {
+      setLanguage(localStorage.getItem('language'));
+    }
+  }, [query.locale]);
+
+  useEffect(() => {
+    if (i18n && i18n.isInitialized) {
+      i18n.changeLanguage(language as string);
+      localStorage.setItem('language', language as string);
+    }
+  }, [language, i18n.isInitialized]);
 
   return (
     <ParamsContext.Provider
@@ -31,6 +61,7 @@ const QueryParamsProvider: FC = ({ children }) => {
         embed,
         singleProject,
         callbackUrl,
+        language,
       }}
     >
       {children}


### PR DESCRIPTION
1. Removes language cookie from webapp
2. Adds locale query param to QueryParamContext and sets app language based on locale (if passed in url)

This was created by branching off from #1540. 