### PR TITLE
fix: fixes map marker positioning

### DIFF
--- a/src/features/projects/components/maps/Markers.tsx
+++ b/src/features/projects/components/maps/Markers.tsx
@@ -42,7 +42,6 @@ export default function Markers({
           longitude={projectMarker.geometry.coordinates[0]}
           offsetLeft={5}
           offsetTop={-16}
-          style={{ left: '28px' }}
         >
           <div
             className={`${styles.marker} ${


### PR DESCRIPTION
- Inline style={{ left: '28px' }} was applied to marker, and was not functional earlier
- `style` prop support was added in `react-map-gl 5.3.19`
- As a result, map markers had moved 28px to the right
- This PR corrects that by removing the inline style