### PR TITLE
remove extra space for width < 481px

### DIFF
--- a/src/features/common/Layout/UserLayout/UserLayout.module.scss
+++ b/src/features/common/Layout/UserLayout/UserLayout.module.scss
@@ -12,6 +12,7 @@
   }
   @include xsPhoneView {
     padding-left: 0;
+    margin-left: 0;
     & .hamburgerIcon {
       display: block;
       position: fixed;

--- a/src/theme/global.scss
+++ b/src/theme/global.scss
@@ -345,7 +345,6 @@ button {
   }
   .profilePage {
     padding-top: 80px !important;
-    margin-left: -35px;
   }
 }
 


### PR DESCRIPTION
Fixes #

Check this list and then dismiss it:
- **Localization**
  - Have you added translation resources?
  - Have you localized numbers, dates and other stuff?
- **Validation and error management**
  - Is the user input validated?
  - Is the API response valided and are error responses properly handled?
  - Are errors caught if necessary?
- **Coding style**
  - Have you used a specific type for declaring the properties and parameters instead of `any`?
  - Have you defined interfaces for new components?
  - Have you added a source file not using TypeScript?
  - Have you checked if your newly introduced modules or functions are not already existing?
  - Is your `React.useEffect` using the right dependencies?
  - Check your code if it matches the existing code formatting.

Changes in this pull request:
-
-
-

@