### PR TITLE
Updates for Planet Cash

### DIFF
--- a/pages/profile/planetcash/index.tsx
+++ b/pages/profile/planetcash/index.tsx
@@ -24,11 +24,7 @@ export default function PlanetCashPage(): ReactElement {
         <Head>
           <title>{ready ? t('planetcash.titleAccount') : ''}</title>
         </Head>
-        <PlanetCash
-          step={PlanetCashTabs.ACCOUNTS}
-          setProgress={setProgress}
-          shouldReload={true}
-        />
+        <PlanetCash step={PlanetCashTabs.ACCOUNTS} setProgress={setProgress} />
       </UserLayout>
     </>
   );

--- a/pages/profile/planetcash/new.tsx
+++ b/pages/profile/planetcash/new.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import TopProgressBar from '../../../src/features/common/ContentLoaders/TopProgressBar';
 import UserLayout from '../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
@@ -12,6 +12,13 @@ const { useTranslation } = i18next;
 export default function PlanetCashCreatePage(): ReactElement {
   const { t, ready } = useTranslation('me');
   const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    // Cleanup function to reset state and address Warning: Can't perform a React state update on an unmounted component.
+    return () => {
+      setProgress(0);
+    };
+  }, []);
 
   return (
     <>

--- a/pages/profile/planetcash/transactions.tsx
+++ b/pages/profile/planetcash/transactions.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useState, useEffect } from 'react';
 import TopProgressBar from '../../../src/features/common/ContentLoaders/TopProgressBar';
 import UserLayout from '../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
@@ -12,6 +12,13 @@ const { useTranslation } = i18next;
 export default function PlanetCashTransactionsPage(): ReactElement {
   const { t, ready } = useTranslation('me');
   const [progress, setProgress] = useState(0);
+
+  // Cleanup function to reset state and address Warning: Can't perform a React state update on an unmounted component.
+  useEffect(() => {
+    return () => {
+      setProgress(0);
+    };
+  }, []);
 
   return (
     <>

--- a/public/static/locales/en/planetcash.json
+++ b/public/static/locales/en/planetcash.json
@@ -14,7 +14,7 @@
   "labelCreditLimit": "Credit Limit",
   "deactivateAccountButton": "Deactivate",
   "activateAccountButton": "Activate",
-  "accountInactiveHelpText": "This account is inactive and cannot be used to make contributions. To activate this account, please deactivate your active account first.",
+  "accountInactiveHelpText": "This account is inactive and cannot be used to make contributions. To activate this account, please contact support@plant-for-the-planet.org.",
   "noAccountsText": "You don't seem to have created a PlanetCash account yet.",
   "createPlanetCashButton": "Create Planet Cash Account",
   "accountQuotaReachedText": "You cannot create more accounts as you have exhausted your account quota.",

--- a/public/static/locales/en/planetcash.json
+++ b/public/static/locales/en/planetcash.json
@@ -11,7 +11,7 @@
   "addBalanceButton": "Add Balance",
   "labelAccountHolder": "Account Holder",
   "labelBalance": "Balance",
-  "labelCreditLimit": "Credit Limit",
+  "labelCreditLimit": "Limit",
   "deactivateAccountButton": "Deactivate",
   "activateAccountButton": "Activate",
   "accountInactiveHelpText": "This account is inactive and cannot be used to make contributions. To activate this account, please contact support@plant-for-the-planet.org.",

--- a/src/features/common/Layout/CenteredContainer/index.tsx
+++ b/src/features/common/Layout/CenteredContainer/index.tsx
@@ -1,12 +1,18 @@
 import { styled } from '@mui/material';
 
-const CenteredContainer = styled('div')(() => ({
+const CenteredContainer = styled('div')(({ theme }) => ({
+  backgroundColor: theme.palette.background.default,
+  padding: 24,
+  borderRadius: 9,
+  boxShadow: theme.shadows[1],
   display: 'flex',
   flexDirection: 'column',
-  height: 160,
   width: '100%',
   alignItems: 'center',
   justifyContent: 'center',
+  '&.CenteredContainer--small': {
+    height: 160,
+  },
 }));
 
 export default CenteredContainer;

--- a/src/features/common/Layout/TabbedView/TabSteps.tsx
+++ b/src/features/common/Layout/TabbedView/TabSteps.tsx
@@ -1,4 +1,9 @@
-import React, { ReactElement, SyntheticEvent } from 'react';
+import React, {
+  ReactElement,
+  SyntheticEvent,
+  useEffect,
+  useState,
+} from 'react';
 import { useRouter } from 'next/router';
 import { Tab, Tabs } from '@mui/material';
 import { styled } from '@mui/material/styles';
@@ -33,6 +38,7 @@ export default function TabSteps({
   tabItems = [],
 }: TabStepsProps): ReactElement | null {
   const router = useRouter();
+  const [isStepFound, setIsStepFound] = useState(false);
 
   const handleTabChange = (event: SyntheticEvent) => {
     if (event.currentTarget instanceof HTMLButtonElement) {
@@ -40,6 +46,12 @@ export default function TabSteps({
       router.push(targetLink);
     }
   };
+
+  useEffect(() => {
+    // sets value for Tabs component only if the specified step is within the list of tabs
+    if (tabItems)
+      setIsStepFound(tabItems.some((tabItem) => tabItem.step === step));
+  }, [step, tabItems]);
 
   const renderTabs = () => {
     return tabItems.map((tabItem, index) => {
@@ -59,8 +71,8 @@ export default function TabSteps({
     <StyledTabs
       orientation="vertical"
       variant="scrollable"
-      aria-label="form-steps"
-      value={step}
+      aria-label="form-step"
+      value={isStepFound ? step : false}
       TabIndicatorProps={{ children: <span /> }}
       onChange={handleTabChange}
     >

--- a/src/features/common/Layout/TabbedView/TabSteps.tsx
+++ b/src/features/common/Layout/TabbedView/TabSteps.tsx
@@ -5,7 +5,7 @@ import { styled } from '@mui/material/styles';
 import { TabItem } from './TabbedViewTypes';
 
 interface TabStepsProps {
-  step: number;
+  step: number | string;
   tabItems: TabItem[];
 }
 
@@ -49,6 +49,7 @@ export default function TabSteps({
           label={tabItem.label}
           data-link={tabItem.link}
           disabled={tabItem.disabled}
+          value={tabItem.step}
         />
       );
     });

--- a/src/features/common/Layout/TabbedView/TabbedViewTypes.d.ts
+++ b/src/features/common/Layout/TabbedView/TabbedViewTypes.d.ts
@@ -2,6 +2,5 @@ export interface TabItem {
   label: string;
   link: string;
   disabled?: boolean;
-  hasList?: boolean;
   step: number | string;
 }

--- a/src/features/common/Layout/TabbedView/TabbedViewTypes.d.ts
+++ b/src/features/common/Layout/TabbedView/TabbedViewTypes.d.ts
@@ -3,4 +3,5 @@ export interface TabItem {
   link: string;
   disabled?: boolean;
   hasList?: boolean;
+  step: number | string;
 }

--- a/src/features/common/Layout/TabbedView/index.tsx
+++ b/src/features/common/Layout/TabbedView/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import { ReactElement, useEffect, useState } from 'react';
 import { Grid, styled } from '@mui/material';
 import TabSteps from './TabSteps';
 import { TabItem } from './TabbedViewTypes';
@@ -26,17 +26,22 @@ const TabContainer = styled('div')(({ theme }) => ({
 
 interface TabbedViewProps {
   children: React.ReactNode;
-  step: number;
+  step: number | string;
   tabItems: TabItem[];
-  isShowingList?: boolean;
 }
 
 export default function TabbedView({
   children,
   step,
   tabItems,
-  isShowingList,
 }: TabbedViewProps): ReactElement {
+  const [isShowingList, setIsShowingList] = useState(false);
+
+  useEffect(() => {
+    const currentTab = tabItems.find((tabItem) => step === tabItem.step);
+    setIsShowingList(currentTab?.hasList || false);
+  }, [step, tabItems]);
+
   return (
     <Grid container className="TabbedView">
       <Grid

--- a/src/features/common/Layout/TabbedView/index.tsx
+++ b/src/features/common/Layout/TabbedView/index.tsx
@@ -1,23 +1,17 @@
-import { ReactElement, useEffect, useState } from 'react';
+import { ReactElement } from 'react';
 import { Grid, styled } from '@mui/material';
 import TabSteps from './TabSteps';
 import { TabItem } from './TabbedViewTypes';
 
-const TabContainer = styled('div')(({ theme }) => ({
-  backgroundColor: theme.palette.background.default,
-  padding: 24,
+const TabContainer = styled('div')(() => ({
+  backgroundColor: 'inherit',
   borderRadius: 9,
-  boxShadow: theme.shadows[1],
-  alignItems: 'flex-end',
-  '&.tabContainer--list': {
-    backgroundColor: 'inherit',
-    boxShadow: 'none',
-    padding: 0,
-    display: 'flex',
+  boxShadow: 'none',
+  alignItems: 'center',
+  display: 'flex',
+  '&.TabContainer': {
     flexDirection: 'column',
     gap: 16,
-    fontSize: '0.875rem',
-    alignItems: 'center',
     '& .loadingButton': {
       minWidth: 150,
     },
@@ -35,13 +29,6 @@ export default function TabbedView({
   step,
   tabItems,
 }: TabbedViewProps): ReactElement {
-  const [isShowingList, setIsShowingList] = useState(false);
-
-  useEffect(() => {
-    const currentTab = tabItems.find((tabItem) => step === tabItem.step);
-    setIsShowingList(currentTab?.hasList || false);
-  }, [step, tabItems]);
-
   return (
     <Grid container className="TabbedView">
       <Grid
@@ -55,9 +42,7 @@ export default function TabbedView({
         xs={12}
         md={9}
         component={TabContainer}
-        className={
-          isShowingList ? 'tabContainer--list' : 'tabContainer--singular'
-        }
+        className={'TabContainer'}
       >
         {children}
       </Grid>

--- a/src/features/user/Account/AccountHistory.module.scss
+++ b/src/features/user/Account/AccountHistory.module.scss
@@ -622,6 +622,7 @@
 
 .record {
   cursor: pointer;
+  font-size: 0.875rem;
   width: 100%;
   display: flex;
   flex-direction: column;

--- a/src/features/user/PlanetCash/components/AccountDetails.tsx
+++ b/src/features/user/PlanetCash/components/AccountDetails.tsx
@@ -1,11 +1,9 @@
 import { ReactElement, useContext } from 'react';
 import { styled, Grid, Button, Divider } from '@mui/material';
 import i18next from '../../../../../i18n';
-import { postAuthenticatedRequest } from '../../../../utils/apiRequests/api';
 import getFormatedCurrency from '../../../../utils/countryCurrency/getFormattedCurrency';
 import { getDonationUrl } from '../../../../utils/getDonationUrl';
 import { UserPropsContext } from '../../../common/Layout/UserPropsContext';
-import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
 
 const { useTranslation } = i18next;
 
@@ -60,62 +58,14 @@ const SingleDetail = styled('div')(({ theme }) => ({
 }));
 
 interface AccountDetailsProps {
-  isPlanetCashActive: boolean;
   account: PlanetCash.Account;
-  updateAccount: (account: PlanetCash.Account) => void;
 }
 
-const AccountDetails = ({
-  isPlanetCashActive,
-  account,
-  updateAccount,
-}: AccountDetailsProps): ReactElement => {
+const AccountDetails = ({ account }: AccountDetailsProps): ReactElement => {
   const { t, i18n } = useTranslation('planetcash');
   const { token } = useContext(UserPropsContext);
-  const { handleError } = useContext(ErrorHandlingContext);
 
   const addBalanceLink = getDonationUrl('planetcash', token);
-
-  const handleDeactivate = async () => {
-    const res = await postAuthenticatedRequest(
-      `/app/planetCash/${account.id}/deactivate`,
-      {},
-      token,
-      handleError
-    );
-    if (res && !res['error_code']) {
-      updateAccount(res);
-    }
-  };
-
-  const handleActivate = async () => {
-    const res = await postAuthenticatedRequest(
-      `/app/planetCash/${account.id}/activate`,
-      {},
-      token,
-      handleError
-    );
-    if (res) {
-      if (!res['error_code']) {
-        updateAccount(res);
-      } else {
-        switch (res['error_code']) {
-          case 'active_account_exists':
-            handleError({
-              code: 400,
-              message: t(`accountError.${res['error_code']}`),
-            });
-            break;
-          default:
-            handleError({
-              code: 400,
-              message: t(`accountError.default`),
-            });
-            break;
-        }
-      }
-    }
-  };
 
   return (
     <Grid
@@ -187,19 +137,11 @@ const AccountDetails = ({
             </div>
           </Grid>
         )}
-        <Grid item xs={12}>
-          {account.isActive ? (
-            <Button onClick={handleDeactivate} color="warning">
-              {t('deactivateAccountButton')}
-            </Button>
-          ) : isPlanetCashActive ? (
+        {!account.isActive && (
+          <Grid item xs={12}>
             <p className="helpText">{t('accountInactiveHelpText')}</p>
-          ) : (
-            <Button onClick={handleActivate}>
-              {t('activateAccountButton')}
-            </Button>
-          )}
-        </Grid>
+          </Grid>
+        )}
       </Grid>
     </Grid>
   );

--- a/src/features/user/PlanetCash/components/AccountDetails.tsx
+++ b/src/features/user/PlanetCash/components/AccountDetails.tsx
@@ -14,6 +14,7 @@ const AccountDetailsGrid = styled('article')(({ theme }) => ({
   borderRadius: 9,
   width: '100%',
   boxShadow: theme.shadows[1],
+  fontSize: '0.875rem',
   '&.accountDetails--inactive': {
     opacity: '80%',
     backgroundColor: theme.palette.grey[200],

--- a/src/features/user/PlanetCash/components/CreateAccountForm.tsx
+++ b/src/features/user/PlanetCash/components/CreateAccountForm.tsx
@@ -7,6 +7,7 @@ import i18next from '../../../../../i18n';
 import { postAuthenticatedRequest } from '../../../../utils/apiRequests/api';
 import { UserPropsContext } from '../../../common/Layout/UserPropsContext';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
+import { usePlanetCash } from '../../../common/Layout/PlanetCashContext';
 import { CountryType } from '../../../common/types/country';
 import { useRouter } from 'next/router';
 
@@ -21,6 +22,7 @@ const CreateAccountForm = ({
   isPlanetCashActive,
 }: Props): ReactElement | null => {
   const { t, ready } = useTranslation(['planetcash', 'country']);
+  const { setAccounts } = usePlanetCash();
   const [country, setCountry] = useState<string | undefined>(undefined);
   const [isProcessing, setIsProcessing] = useState(false);
   const [isAccountCreated, setIsAccountCreated] = useState(false);
@@ -39,12 +41,13 @@ const CreateAccountForm = ({
       handleError
     );
     if (res?.id) {
-      // show success message
+      // show success message and update accounts in context
       setIsAccountCreated(true);
+      setAccounts([res]);
       // go to accounts tab
       setTimeout(() => {
         router.push('/profile/planetcash');
-      }, 3000);
+      }, 1000);
     } else {
       setIsProcessing(false);
       if (res && res['error_type'] === 'planet_cash_account_error') {

--- a/src/features/user/PlanetCash/components/NoPlanetCashAccount.tsx
+++ b/src/features/user/PlanetCash/components/NoPlanetCashAccount.tsx
@@ -1,3 +1,5 @@
+// Currently Unused
+
 import { ReactElement } from 'react';
 import { Button, styled } from '@mui/material';
 import i18next from '../../../../../i18n';

--- a/src/features/user/PlanetCash/components/NoTransactionsFound.tsx
+++ b/src/features/user/PlanetCash/components/NoTransactionsFound.tsx
@@ -4,7 +4,7 @@ import TransactionsNotFound from '../../../../../public/assets/images/icons/Tran
 
 const NoTransactionsFound = (): ReactElement => {
   return (
-    <CenteredContainer>
+    <CenteredContainer className="CenteredContainer--small">
       <TransactionsNotFound />
     </CenteredContainer>
   );

--- a/src/features/user/PlanetCash/index.tsx
+++ b/src/features/user/PlanetCash/index.tsx
@@ -63,6 +63,8 @@ export default function PlanetCash({
         setProgress(100);
         setTimeout(() => setProgress(0), 1000);
       }
+    } else {
+      redirectIfNeeded(accounts);
     }
   }, [accounts]);
 

--- a/src/features/user/PlanetCash/index.tsx
+++ b/src/features/user/PlanetCash/index.tsx
@@ -132,13 +132,11 @@ export default function PlanetCash({
           {
             label: t('tabAccounts'),
             link: '/profile/planetcash',
-            hasList: true,
             step: PlanetCashTabs.ACCOUNTS,
           },
           {
             label: t('tabTransactions'),
             link: '/profile/planetcash/transactions',
-            hasList: true,
             step: PlanetCashTabs.TRANSACTIONS,
           },
         ]);

--- a/src/features/user/PlanetCash/screens/Accounts.tsx
+++ b/src/features/user/PlanetCash/screens/Accounts.tsx
@@ -1,7 +1,6 @@
 import { ReactElement } from 'react';
 import AccountListLoader from '../../../../../public/assets/images/icons/AccountListLoader';
 import AccountDetails from '../components/AccountDetails';
-import NoPlanetCashAccount from '../components/NoPlanetCashAccount';
 import { usePlanetCash } from '../../../common/Layout/PlanetCashContext';
 
 interface AccountsProps {
@@ -14,7 +13,6 @@ const Accounts = ({ isDataLoading }: AccountsProps): ReactElement | null => {
   return isDataLoading ? (
     <>
       <AccountListLoader />
-      <AccountListLoader />
     </>
   ) : accounts && accounts.length > 0 ? (
     <>
@@ -22,9 +20,7 @@ const Accounts = ({ isDataLoading }: AccountsProps): ReactElement | null => {
         return <AccountDetails account={account} key={index} />;
       })}
     </>
-  ) : (
-    accounts && <NoPlanetCashAccount />
-  );
+  ) : null;
 };
 
 export default Accounts;

--- a/src/features/user/PlanetCash/screens/Accounts.tsx
+++ b/src/features/user/PlanetCash/screens/Accounts.tsx
@@ -9,19 +9,7 @@ interface AccountsProps {
 }
 
 const Accounts = ({ isDataLoading }: AccountsProps): ReactElement | null => {
-  const { accounts, isPlanetCashActive, setAccounts, setIsPlanetCashActive } =
-    usePlanetCash();
-  const updateAccount = (accountToUpdate: PlanetCash.Account): void => {
-    const updatedAccounts = accounts?.map((account) =>
-      account.id === accountToUpdate.id ? accountToUpdate : account
-    );
-    if (updatedAccounts) {
-      setAccounts(updatedAccounts);
-      setIsPlanetCashActive(
-        updatedAccounts.some((account) => account.isActive)
-      );
-    }
-  };
+  const { accounts } = usePlanetCash();
 
   return isDataLoading ? (
     <>
@@ -31,14 +19,7 @@ const Accounts = ({ isDataLoading }: AccountsProps): ReactElement | null => {
   ) : accounts && accounts.length > 0 ? (
     <>
       {accounts?.map((account, index) => {
-        return (
-          <AccountDetails
-            account={account}
-            key={index}
-            updateAccount={updateAccount}
-            isPlanetCashActive={isPlanetCashActive}
-          />
-        );
+        return <AccountDetails account={account} key={index} />;
       })}
     </>
   ) : (

--- a/src/features/user/PlanetCash/screens/CreateAccount.tsx
+++ b/src/features/user/PlanetCash/screens/CreateAccount.tsx
@@ -4,6 +4,7 @@ import CenteredContainer from '../../../common/Layout/CenteredContainer';
 import { usePlanetCash } from '../../../common/Layout/PlanetCashContext';
 import { CountryType } from '../../../common/types/country';
 import i18next from '../../../../../i18n';
+import AccountListLoader from '../../../../../public/assets/images/icons/AccountListLoader';
 
 const { useTranslation } = i18next;
 
@@ -20,22 +21,30 @@ const CreateAccount = (): ReactElement | null => {
   const { accounts, isPlanetCashActive } = usePlanetCash();
   const { t, ready } = useTranslation('planetcash');
 
+  // Prevents creating a duplicate planetcash account for a country.
+  // This condition cannot currently happen, as the frontend prevents users from creating multiple planet cash accounts
   useEffect(() => {
     if (accounts) {
-      const accountCountryCodes = accounts.map((account) => account.country);
-      const newAllowedCountries = initialAllowedCountries.filter(
-        (country) => !accountCountryCodes.includes(country.code)
-      );
-      setAllowedCountries(newAllowedCountries);
+      if (accounts.length > 0) {
+        const accountCountryCodes = accounts.map((account) => account.country);
+        const newAllowedCountries = initialAllowedCountries.filter(
+          (country) => !accountCountryCodes.includes(country.code)
+        );
+        setAllowedCountries(newAllowedCountries);
+      } else {
+        setAllowedCountries(initialAllowedCountries);
+      }
     }
   }, [accounts]);
 
-  if (accounts && allowedCountries) {
+  if (accounts && allowedCountries && accounts.length === 0) {
     return allowedCountries.length > 0 ? (
-      <CreateAccountForm
-        allowedCountries={allowedCountries}
-        isPlanetCashActive={isPlanetCashActive}
-      />
+      <CenteredContainer>
+        <CreateAccountForm
+          allowedCountries={allowedCountries}
+          isPlanetCashActive={isPlanetCashActive}
+        />
+      </CenteredContainer>
     ) : (
       <CenteredContainer>
         {ready && t('accountQuotaReachedText')}
@@ -43,7 +52,7 @@ const CreateAccount = (): ReactElement | null => {
     );
   }
 
-  return null;
+  return <AccountListLoader />;
 };
 
 export default CreateAccount;

--- a/src/features/user/PlanetCash/screens/Transactions.tsx
+++ b/src/features/user/PlanetCash/screens/Transactions.tsx
@@ -92,6 +92,15 @@ const Transactions = ({
       fetchTransactions();
   }, [contextLoaded, token, accounts]);
 
+  useEffect(() => {
+    // Cleanup function to reset state and address Warning: Can't perform a React state update on an unmounted component.
+    return () => {
+      setSelectedRecord(null);
+      setIsDataLoading(false);
+      setIsModalOpen(false);
+    };
+  }, []);
+
   return !transactionHistory && isDataLoading ? (
     <>
       <TransactionListLoader />


### PR DESCRIPTION
Changes
1. Remove planet cash account activation / deactivation functionality
2. Prevent account creation from front end if a planet cash account already exists.
    a. If an account exists, the Create Account tab is not shown. Only Accounts and Transaction tabs are visible. Any attempt to visit the Create Account route ([/profile/planetcash/new](#)) is redirected to the Accounts route ([/profile/planetcash](#)).
    b. If an account does not exist, only the Create Account tab is shown. Any attempt to visit the Accounts ([/profile/planetcash](#))/Transaction ([/profile/planetcash/transactions](#)) routes is redirected to the Create Account route ([/profile/planetcash/new](#)). 