### PR TITLE
fix: removes text transform from MuiButton text

### DIFF
--- a/src/features/common/InputTypes/MuiButton.tsx
+++ b/src/features/common/InputTypes/MuiButton.tsx
@@ -4,7 +4,7 @@ import themeProperties from '../../../theme/themeProperties';
 // replace styles here with theme when consolidating the Mui Themes. Use theme palette etc.
 const MuiButton = styled(Button)({
   '&.MuiButton-root': {
-    textTransform: 'capitalize',
+    textTransform: 'none',
     borderRadius: 28,
     fontWeight: 600,
   },


### PR DESCRIPTION
- shows text from translation file as is
- so that German text is not incorrectly capitalized

![Screenshot 2022-09-21 at 11 38 33 AM](https://user-images.githubusercontent.com/44917347/191427152-89f3cb5e-6d9d-40ea-8e59-816d58613d72.png)
![Screenshot 2022-09-21 at 11 38 05 AM](https://user-images.githubusercontent.com/44917347/191427158-5814aa3e-1f12-469b-a8a5-cf71195f3b51.png)
