### PR TITLE
increase gap between footer and show Project details/list toggle

### DIFF
--- a/src/features/projects/styles/Projects.scss
+++ b/src/features/projects/styles/Projects.scss
@@ -348,6 +348,9 @@
   .embedContainer {
     margin-top: 40vh;
   }
+  .MuiButton-root.toggleButton {
+    bottom: 62px;
+  }
 }
 :export {
   primaryColor: $primaryColor;


### PR DESCRIPTION
for width<486px increase gap between footer and show Project details/list toggle.

To test: add parameter /?embed=true and set to mobile view