### PR TITLE
fix after login redeem process issue

### DIFF
--- a/pages/claim/[type]/[code].tsx
+++ b/pages/claim/[type]/[code].tsx
@@ -106,7 +106,7 @@ function ClaimDonation(): ReactElement {
     }
   }, [user, contextLoaded, ready, router.query.type, router.query.code]);
 
-  return ready ? (
+  return ready && user ? (
     <LandingSection>
       <>
         {redeemedCodeData ? (

--- a/pages/claim/[type]/[code].tsx
+++ b/pages/claim/[type]/[code].tsx
@@ -79,24 +79,13 @@ function ClaimDonation(): ReactElement {
       setCode(router.query.code);
     }
   }, [router.query.code]);
+
   // // Check if the user is logged in or not.
   React.useEffect(() => {
-    // If the user is logged in -
-    // Validate the code automatically
-    // Once validated ask user to claim their donation
-    // Once claimed user can share the donation
-    // From here user can go back to home by clicking X
-    if (contextLoaded && user) {
-      // validate code
-      if (ready && router.query.type && router.query.code) {
-        redeemingCode(router.query.code);
-      }
-    }
-
     // If the user is not logged in - send the user to log in page, store the claim redirect link in the localstorage.
     // When the user logs in, redirect user to the claim link from the localstorage and clear the localstorage.
     // For this  fetch the link from the storage, clears the storage and then redirects the user using the link
-    else if (contextLoaded && !user) {
+    if (contextLoaded && !user) {
       // store the claim link in localstorage
       if (typeof window !== 'undefined') {
         localStorage.setItem('redirectLink', window.location.href);
@@ -106,7 +95,16 @@ function ClaimDonation(): ReactElement {
         });
       }
     }
-  }, [contextLoaded, user, code]);
+  }, [contextLoaded, user]);
+
+  React.useEffect(() => {
+    //redeem code using route
+    if (user && contextLoaded) {
+      if (ready && router.query.type && router.query.code) {
+        redeemingCode(router.query.code);
+      }
+    }
+  }, [user, contextLoaded, ready, router.query.type, router.query.code]);
 
   return ready ? (
     <LandingSection>

--- a/pages/profile/redeem/[code].tsx
+++ b/pages/profile/redeem/[code].tsx
@@ -95,7 +95,7 @@ const ReedemCode: FC = () => {
     }
   }
 
-  return ready ? (
+  return ready && user ? (
     router.query.inputCode === 'true' ? (
       // to input  redeem code
       <LandingSection>

--- a/src/features/user/Profile/styles/RedeemModal.module.scss
+++ b/src/features/user/Profile/styles/RedeemModal.module.scss
@@ -94,6 +94,7 @@
 
 .crossWidth {
   width: 17px;
+  cursor: pointer;
 }
 
 


### PR DESCRIPTION
fix: -->1.when user tries to claim code using route `/claim/gift/:code` without login. it redirect user to login page then when  login process gets complete then  user reaches to redeem modal using the same route `(i.e /claim/gift/:code)` but  redeem modal does not show any result of that code`(i.e invalid code, already redeemed, successfully redeemed)` .

2-->cross button of modal (change to cursor)