### PR TITLE
Add link to platform documentation

### DIFF
--- a/src/features/common/Layout/UserLayout/UserLayout.tsx
+++ b/src/features/common/Layout/UserLayout/UserLayout.tsx
@@ -287,6 +287,15 @@ function UserLayout(props: any): ReactElement {
 
         <div>
           <LanguageSwitcher />
+          <div className={styles.navlink}>
+            <a
+              className={styles.navlinkTitle}
+              target={'_blank'}
+              href="https://plantfortheplanet.notion.site/Public-Documentation-Plant-for-the-Planet-Platform-04af8ed821b44d358130142778d79e01"
+            >
+              Platform Documentation (EN){' '}
+            </a>
+          </div>
           <div
             className={styles.navlink}
             //logout user

--- a/src/features/common/Layout/UserLayout/UserLayout.tsx
+++ b/src/features/common/Layout/UserLayout/UserLayout.tsx
@@ -291,7 +291,7 @@ function UserLayout(props: any): ReactElement {
             <a
               className={styles.navlinkTitle}
               target={'_blank'}
-              href="https://plantfortheplanet.notion.site/Public-Documentation-Plant-for-the-Planet-Platform-04af8ed821b44d358130142778d79e01"
+              href="https://plantfortheplanet.notion.site/Public-Documentation-Plant-for-the-Planet-Platform-04af8ed821b44d358130142778d79e01" rel="noreferrer"
             >
               Platform Documentation (EN){' '}
             </a>


### PR DESCRIPTION
Fixes #


Changes in this pull request:
- Add link to notion documentation when user is logged in to enable them to lookup solutions for potential problems themselves.
-
-

@