### PR TITLE
Replace moment with date-fns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "luma.gl": "^7.3.2",
         "mapbox-gl": "^1.13.0",
         "mapbox-gl-compare": "^0.4.0",
-        "moment": "^2.29.4",
         "next": "^12.2.2",
         "next-compose-plugins": "^2.2.1",
         "next-i18next": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "luma.gl": "^7.3.2",
     "mapbox-gl": "^1.13.0",
     "mapbox-gl-compare": "^0.4.0",
-    "moment": "^2.29.4",
     "next": "^12.2.2",
     "next-compose-plugins": "^2.2.1",
     "next-i18next": "^12.1.0",

--- a/src/utils/LayerManagerUtils.js
+++ b/src/utils/LayerManagerUtils.js
@@ -1,4 +1,6 @@
-import moment from 'moment';
+import getYear from 'date-fns/getYear';
+import getMonth from 'date-fns/getMonth';
+import getDayOfYear from 'date-fns/getDayOfYear';
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
@@ -65,19 +67,19 @@ export const getParams = (config = [], params = {}) => {
   return {
     ...newParams,
     ...(!!start && {
-      startYear: moment(start).year(),
-      startMonth: moment(start).month(),
-      startDay: moment(start).dayOfYear(),
+      startYear: getYear(start),
+      startMonth: getMonth(start),
+      startDay: getDayOfYear(start),
     }),
     ...(!!endDate && {
-      endYear: moment(end).year(),
-      endMonth: moment(end).month(),
-      endDay: moment(end).dayOfYear(),
+      endYear: getYear(end),
+      endMonth: getMonth(end),
+      endDay: getDayOfYear(end),
     }),
     ...(!!trimEndDate && {
-      trimEndYear: moment(trim).year(),
-      trimEndMonth: moment(trim).month(),
-      trimEndDay: moment(trim).dayOfYear(),
+      trimEndYear: getYear(trim),
+      trimEndMonth: getMonth(trim),
+      trimEndDay: getDayOfYear(trim),
     }),
     ...getDayRange(newParams),
   };

--- a/src/utils/LayerManagerUtils.js
+++ b/src/utils/LayerManagerUtils.js
@@ -1,6 +1,7 @@
 import getYear from 'date-fns/getYear';
 import getMonth from 'date-fns/getMonth';
 import getDayOfYear from 'date-fns/getDayOfYear';
+import parseISO from 'date-fns/parseISO';
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
@@ -58,7 +59,11 @@ export const getParams = (config = [], params = {}) => {
     ...params,
   };
 
-  const { startDate, endDate, trimEndDate, maxAbsoluteDate } = newParams;
+  let { startDate, endDate, trimEndDate, maxAbsoluteDate } = newParams;
+  if (typeof startDate == "string") startDate = parseISO(startDate)
+  if (typeof endDate == "string") endDate = parseISO(endDate)
+  if (typeof trimEndDate == "string") trimEndDate = parseISO(trimEndDate)
+  if (typeof maxAbsoluteDate == "string") maxAbsoluteDate = parseISO(maxAbsoluteDate)
 
   const start = startDate;
   const end = endDate > maxAbsoluteDate ? maxAbsoluteDate : endDate;


### PR DESCRIPTION
Changes in this pull request:
- removing moment library to increase performance by saving JavaScript code using two date libraries, compare https://bundlephobia.com/package/moment@2.29.4

I tested with the following code to make sure the result are the same for both modules:
```javascript
import getYear from 'date-fns/getYear';
import getMonth from 'date-fns/getMonth';
import getDayOfYear from 'date-fns/getDayOfYear';
import moment from 'moment';

console.log("Test moment library")
console.log(moment(new Date(2022,11,11)).year());
console.log(moment(new Date(2022,11,11)).month());
console.log(moment(new Date(2022,11,11)).dayOfYear());
console.log("Test date-fns library")
console.log(getYear(new Date(2022,11,11)));
console.log(getMonth(new Date(2022,11,11)));
console.log(getDayOfYear(new Date(2022,11,11)));
```