### PR TITLE
removed next-compose-plugins, fixed next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -106,9 +106,6 @@ const nextConfig =  {
   },
   basePath,
   // your config for other plugins or the general next.js here...
-  devIndicators: {
-    autoPrerender: false,
-  },
   env: {
     AUTH0_CUSTOM_DOMAIN: process.env.AUTH0_CUSTOM_DOMAIN,
     AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
@@ -197,7 +194,7 @@ const nextConfig =  {
       },
     ];
   },
-  assetPrefix: hasAssetPrefix ? `${scheme}://${process.env.ASSET_PREFIX}` : '',
+  assetPrefix: hasAssetPrefix ? `${scheme}://${process.env.ASSET_PREFIX}` : undefined,
   // Asset Prefix allows to use CDN for the generated js files
   // https://nextjs.org/docs/api-reference/next.config.js/cdn-support-with-asset-prefix
 };

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,3 @@
-const withPlugins = require('next-compose-plugins');
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
@@ -46,7 +45,7 @@ const nextauthUrl = process.env.NEXTAUTH_URL
 const hasAssetPrefix =
   process.env.ASSET_PREFIX !== '' && process.env.ASSET_PREFIX !== undefined;
 
-module.exports = withPlugins([[withBundleAnalyzer]], {
+const nextConfig =  {
   productionBrowserSourceMaps: true,
   i18n,
   serverRuntimeConfig: {
@@ -201,4 +200,9 @@ module.exports = withPlugins([[withBundleAnalyzer]], {
   assetPrefix: hasAssetPrefix ? `${scheme}://${process.env.ASSET_PREFIX}` : '',
   // Asset Prefix allows to use CDN for the generated js files
   // https://nextjs.org/docs/api-reference/next.config.js/cdn-support-with-asset-prefix
-});
+};
+
+module.exports = () => {
+  const plugins = [withBundleAnalyzer];
+  return plugins.reduce((config, plugin) => plugin(config), nextConfig);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "mapbox-gl": "^1.13.0",
         "mapbox-gl-compare": "^0.4.0",
         "next": "^12.2.2",
-        "next-compose-plugins": "^2.2.1",
         "next-i18next": "^12.1.0",
         "next-useragent": "^2.7.0",
         "papaparse": "^5.3.1",
@@ -24845,11 +24844,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/next-compose-plugins": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/next-compose-plugins/-/next-compose-plugins-2.2.1.tgz",
-      "integrity": "sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg=="
     },
     "node_modules/next-i18next": {
       "version": "12.1.0",
@@ -52061,11 +52055,6 @@
           "integrity": "sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA=="
         }
       }
-    },
-    "next-compose-plugins": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/next-compose-plugins/-/next-compose-plugins-2.2.1.tgz",
-      "integrity": "sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg=="
     },
     "next-i18next": {
       "version": "12.1.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "mapbox-gl": "^1.13.0",
     "mapbox-gl-compare": "^0.4.0",
     "next": "^12.2.2",
-    "next-compose-plugins": "^2.2.1",
     "next-i18next": "^12.1.0",
     "next-useragent": "^2.7.0",
     "papaparse": "^5.3.1",


### PR DESCRIPTION
Fixes some warning running `npm run dev`.

Changes in this pull request:
- removed next-compose-plugins from next.config.js, doing it manually