### PR TITLE
hotfix:overlapping buttons of sample trees form

### DIFF
--- a/src/features/user/TreeMapper/Import/Import.module.scss
+++ b/src/features/user/TreeMapper/Import/Import.module.scss
@@ -87,6 +87,9 @@
   input {
     width: 100%;
   }
+  button {
+    width:100%;
+  }
 }
 
 .formFieldLarge {

--- a/src/features/user/TreeMapper/Import/components/SampleTrees.tsx
+++ b/src/features/user/TreeMapper/Import/components/SampleTrees.tsx
@@ -255,11 +255,7 @@ export default function SampleTrees({
       </div>
       <div className={`${styles.formField}`}>
         <div className={styles.formFieldHalf}>
-          <button
-            onClick={handleSubmit(onSubmit)}
-            className="primaryButton"
-            style={{ width: '188px' }}
-          >
+          <button onClick={handleSubmit(onSubmit)} className="primaryButton">
             {isUploadingData ? (
               <div className={styles.spinner}></div>
             ) : (
@@ -268,11 +264,7 @@ export default function SampleTrees({
           </button>
         </div>
         <div className={`${styles.formFieldHalf} `}>
-          <button
-            onClick={() => handleNext()}
-            className="secondaryButton"
-            style={{ width: '188px' }}
-          >
+          <button onClick={() => handleNext()} className="secondaryButton">
             {isUploadingData ? (
               <div className={styles.spinner}></div>
             ) : (

--- a/src/features/user/TreeMapper/Import/components/SampleTrees.tsx
+++ b/src/features/user/TreeMapper/Import/components/SampleTrees.tsx
@@ -255,7 +255,11 @@ export default function SampleTrees({
       </div>
       <div className={`${styles.formField}`}>
         <div className={styles.formFieldHalf}>
-          <button onClick={handleSubmit(onSubmit)} className="primaryButton">
+          <button
+            onClick={handleSubmit(onSubmit)}
+            className="primaryButton"
+            style={{ width: '188px' }}
+          >
             {isUploadingData ? (
               <div className={styles.spinner}></div>
             ) : (
@@ -263,8 +267,12 @@ export default function SampleTrees({
             )}
           </button>
         </div>
-        <div className={styles.formFieldHalf}>
-          <button onClick={() => handleNext()} className="secondaryButton">
+        <div className={`${styles.formFieldHalf} `}>
+          <button
+            onClick={() => handleNext()}
+            className="secondaryButton"
+            style={{ width: '188px' }}
+          >
             {isUploadingData ? (
               <div className={styles.spinner}></div>
             ) : (

--- a/src/features/user/TreeMapper/Import/components/SampleTrees.tsx
+++ b/src/features/user/TreeMapper/Import/components/SampleTrees.tsx
@@ -253,7 +253,7 @@ export default function SampleTrees({
           ? t('treemapper:addSampleTree')
           : t('treemapper:addAnotherSampleTree')}
       </div>
-      <div className={`${styles.formField}`}>
+      <div className={styles.formField}>
         <div className={styles.formFieldHalf}>
           <button onClick={handleSubmit(onSubmit)} className="primaryButton">
             {isUploadingData ? (
@@ -263,7 +263,7 @@ export default function SampleTrees({
             )}
           </button>
         </div>
-        <div className={`${styles.formFieldHalf} `}>
+        <div className={styles.formFieldHalf}>
           <button onClick={() => handleNext()} className="secondaryButton">
             {isUploadingData ? (
               <div className={styles.spinner}></div>


### PR DESCRIPTION
visit to the following route ->` profile/treemapper/import`
then visit to 2nd form (sample trees form) and checkout the` continue` and `skip` button  