### PR TITLE
fix:restrict access to page for unauthorize user

### DIFF
--- a/pages/profile/payouts/add-bank-details.tsx
+++ b/pages/profile/payouts/add-bank-details.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import UserLayout from '../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import ManagePayouts, {
@@ -6,15 +6,22 @@ import ManagePayouts, {
 } from '../../../src/features/user/ManagePayouts';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { UserPropsContext } from '../../../src/features/common/Layout/UserPropsContext';
+import AccessDeniedLoader from '../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 
 export default function AddBankDetailsPage(): ReactElement {
   const { t, ready } = useTranslation('me');
+  const { user } = useContext(UserPropsContext);
   return (
     <UserLayout>
       <Head>
         <title>{ready ? t('managePayouts.titleAddBankDetails') : ''}</title>
       </Head>
-      <ManagePayouts step={ManagePayoutTabs.ADD_BANK_DETAILS} />
+      {user.type === 'tpo' ? (
+        <ManagePayouts step={ManagePayoutTabs.ADD_BANK_DETAILS} />
+      ) : (
+        <AccessDeniedLoader />
+      )}
     </UserLayout>
   );
 }

--- a/pages/profile/payouts/index.tsx
+++ b/pages/profile/payouts/index.tsx
@@ -7,13 +7,13 @@ import ManagePayouts, {
 } from '../../../src/features/user/ManagePayouts';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-import { ParamsContext } from '../../../src/features/common/Layout/QueryParamsContext';
+import { UserPropsContext } from '../../../src/features/common/Layout/UserPropsContext';
 import AccessDeniedLoader from '../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 
 export default function OverviewPage(): ReactElement {
   const { t, ready } = useTranslation('me');
   const [progress, setProgress] = useState(0);
-  const { user } = useContext(ParamsContext);
+  const { user } = useContext(UserPropsContext);
 
   return (
     <>

--- a/pages/profile/payouts/index.tsx
+++ b/pages/profile/payouts/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useContext, useState } from 'react';
 import TopProgressBar from '../../../src/features/common/ContentLoaders/TopProgressBar';
 import UserLayout from '../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
@@ -7,10 +7,13 @@ import ManagePayouts, {
 } from '../../../src/features/user/ManagePayouts';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { ParamsContext } from '../../../src/features/common/Layout/QueryParamsContext';
+import AccessDeniedLoader from '../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 
 export default function OverviewPage(): ReactElement {
   const { t, ready } = useTranslation('me');
   const [progress, setProgress] = useState(0);
+  const { user } = useContext(ParamsContext);
 
   return (
     <>
@@ -23,10 +26,14 @@ export default function OverviewPage(): ReactElement {
         <Head>
           <title>{ready ? t('managePayouts.titleOverview') : ''}</title>
         </Head>
-        <ManagePayouts
-          step={ManagePayoutTabs.OVERVIEW}
-          setProgress={setProgress}
-        />
+        {user?.type === 'tpo' ? (
+          <ManagePayouts
+            step={ManagePayoutTabs.OVERVIEW}
+            setProgress={setProgress}
+          />
+        ) : (
+          <AccessDeniedLoader />
+        )}
       </UserLayout>
     </>
   );

--- a/pages/profile/payouts/schedule.tsx
+++ b/pages/profile/payouts/schedule.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import UserLayout from '../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import ManagePayouts, {
@@ -6,15 +6,21 @@ import ManagePayouts, {
 } from '../../../src/features/user/ManagePayouts';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-
+import { UserPropsContext } from '../../../src/features/common/Layout/UserPropsContext';
+import AccessDeniedLoader from '../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 export default function PayoutSchedulePage(): ReactElement {
   const { t, ready } = useTranslation('me');
+  const { user } = useContext(UserPropsContext);
   return (
     <UserLayout>
       <Head>
         <title>{ready ? t('managePayouts.titlePayoutSchedule') : ''}</title>
       </Head>
-      <ManagePayouts step={ManagePayoutTabs.PAYOUT_SCHEDULE} />
+      {user?.type === 'tpo' ? (
+        <ManagePayouts step={ManagePayoutTabs.PAYOUT_SCHEDULE} />
+      ) : (
+        <AccessDeniedLoader />
+      )}
     </UserLayout>
   );
 }

--- a/pages/profile/projects/index.tsx
+++ b/pages/profile/projects/index.tsx
@@ -1,20 +1,22 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import ProjectsContainer from '../../../src/features/user/ManageProjects/ProjectsContainer';
 import UserLayout from '../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-
+import { UserPropsContext } from '../../../src/features/common/Layout/UserPropsContext';
+import AccessDeniedLoader from '../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 interface Props {}
 export default function Register({}: Props): ReactElement {
   const { t } = useTranslation('me');
+  const { user } = useContext(UserPropsContext);
 
   return (
     <UserLayout>
       <Head>
         <title>{t('projects')}</title>
       </Head>
-      <ProjectsContainer />
+      {user.type === 'tpo' ? <ProjectsContainer /> : <AccessDeniedLoader />}
     </UserLayout>
   );
 }

--- a/pages/profile/projects/new-project.tsx
+++ b/pages/profile/projects/new-project.tsx
@@ -115,8 +115,11 @@ export default function AddProjectType(): ReactElement {
                     )
                     :
                     null} */}
-
-        <ManageProjects token={token} />
+        {user.type === 'tpo' ? (
+          <ManageProjects token={token} />
+        ) : (
+          <AccessDeniedLoader />
+        )}
       </UserLayout>
     </div>
   );

--- a/pages/profile/treemapper/import.tsx
+++ b/pages/profile/treemapper/import.tsx
@@ -1,20 +1,22 @@
 import Head from 'next/head';
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import UserLayout from '../../../src/features/common/Layout/UserLayout/UserLayout';
 import { useTranslation } from 'next-i18next';
 import ImportData from '../../../src/features/user/TreeMapper/Import';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-
+import { UserPropsContext } from '../../../src/features/common/Layout/UserPropsContext';
+import AccessDeniedLoader from '../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 interface Props {}
 
 export default function Import({}: Props): ReactElement {
   const { t } = useTranslation('treemapper');
+  const { user } = useContext(UserPropsContext);
   return (
     <UserLayout>
       <Head>
         <title>{t('treemapper:importData')}</title>
       </Head>
-      <ImportData />
+      {user.type === 'tpo' ? <ImportData /> : <AccessDeniedLoader />}
     </UserLayout>
   );
 }

--- a/pages/profile/treemapper/my-species.tsx
+++ b/pages/profile/treemapper/my-species.tsx
@@ -1,20 +1,23 @@
 import Head from 'next/head';
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import UserLayout from '../../../src/features/common/Layout/UserLayout/UserLayout';
 import MySpecies from '../../../src/features/user/TreeMapper/MySpecies';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import { useTranslation } from 'next-i18next';
+import { UserPropsContext } from '../../../src/features/common/Layout/UserPropsContext';
+import AccessDeniedLoader from '../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 
 interface Props {}
 
 export default function MySpeciesPage({}: Props): ReactElement {
   const { t } = useTranslation('me');
+  const { user } = useContext(UserPropsContext);
   return (
     <UserLayout>
       <Head>
         <title>{t('mySpecies')}</title>
       </Head>
-      <MySpecies />
+      {user.type === 'tpo' ? <MySpecies /> : <AccessDeniedLoader />}
     </UserLayout>
   );
 }


### PR DESCRIPTION
Fixes # some features are only available to tpo (i.e `profile/treemapper/import`) , restricted that pages to normal user
