### PR TITLE
Resolves translation issues on leaderboard

### DIFF
--- a/public/static/locales/de/common.json
+++ b/public/static/locales/de/common.json
@@ -1,6 +1,6 @@
 {
-  "tree": "Baum",
-  "tree_plural": "Bäume",
+  "tree_one": "Baum",
+  "tree_other": "Bäume",
   "by": "Von {{tpoName}}",
   "to_project_by_tpo": "An {{projectName}} von {{tpoName}}",
   "for": "für",

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -1,6 +1,6 @@
 {
-  "tree": "Tree",
-  "tree_plural": "Trees",
+  "tree_one": "Tree",
+  "tree_other": "Trees",
   "by": "By {{tpoName}}",
   "to_project_by_tpo": "To {{projectName}} by {{tpoName}}",
   "for": "for",

--- a/public/static/locales/es/common.json
+++ b/public/static/locales/es/common.json
@@ -1,6 +1,6 @@
 {
-  "tree": "Árbol",
-  "tree_plural": "Árboles",
+  "tree_one": "Árbol",
+  "tree_other": "Árboles",
   "by": "Por {{tpoName}}",
   "to_project_by_tpo": "Para {{projectName}} por {{tpoName}}",
   "for": "para",

--- a/public/static/locales/fr/common.json
+++ b/public/static/locales/fr/common.json
@@ -1,6 +1,6 @@
 {
-  "tree": "Arbre",
-  "tree_plural": "Arbres",
+  "tree_one": "Arbre",
+  "tree_other": "Arbres",
   "by": "Par {{tpoName}}",
   "to_project_by_tpo": "Au {{projectName}} par {{tpoName}}",
   "for": "pour",

--- a/public/static/locales/it/common.json
+++ b/public/static/locales/it/common.json
@@ -1,6 +1,6 @@
 {
-  "tree": "Albero",
-  "tree_plural": "Alberi",
+  "tree_one": "Albero",
+  "tree_other": "Alberi",
   "by": "Di {{tpoName}}",
   "to_project_by_tpo": "A {{projectName}} di {{tpoName}}",
   "for": "per",

--- a/public/static/locales/pt-BR/common.json
+++ b/public/static/locales/pt-BR/common.json
@@ -1,6 +1,6 @@
 {
-  "tree": "Árvore",
-  "tree_plural": "Árvores",
+  "tree_one": "Árvore",
+  "tree_other": "Árvores",
   "by": "Por {{tpoName}}",
   "to_project_by_tpo": "Para {{projectName}} por {{tpoName}}",
   "for": "para",

--- a/src/features/projects/components/ProjectSnippet.tsx
+++ b/src/features/projects/components/ProjectSnippet.tsx
@@ -109,7 +109,7 @@ export default function ProjectSnippet({
                     Number(project.countPlanted),
                     1
                   )}{' '}
-                  {t('common:tree_plural', {
+                  {t('common:tree', {
                     count: Number(project.countPlanted),
                   })}{' '}
                   •{' '}

--- a/src/features/user/BulkCodes/components/BulkGiftTotal.tsx
+++ b/src/features/user/BulkCodes/components/BulkGiftTotal.tsx
@@ -22,11 +22,7 @@ const BulkGiftTotal = ({
 
   const getUnit = (_unit: string, _units?: number) => {
     if (_unit === 'tree') {
-      if (_units) {
-        if (_units === 1) {
-          return t('common:tree');
-        } else return t('common:tree_plural');
-      } else return _unit;
+      return t('common:tree', { count: _units });
     } else if (_unit === 'm2') {
       return 'm2';
     } else return 'ha';

--- a/src/tenants/salesforce/Home/components/LeaderBoardSection.tsx
+++ b/src/tenants/salesforce/Home/components/LeaderBoardSection.tsx
@@ -15,7 +15,7 @@ export default function LeaderBoardSection(leaderboard: Props) {
   return ready ? (
     <div className={styles.leaderBoardSection}>
       <div className={styles.leaderBoard}>
-        <h2>{t('leaderboard:Tree Donation Tracker')}</h2>
+        <h2>Tree Donation Tracker</h2>
         <div className={styles.leaderBoardTable}>
           <div className={styles.leaderBoardTableHeader}>
             <button


### PR DESCRIPTION
1. Fixes translation issue with heading on salesforce leaderboard
2. Fixes pluralization issue for "trees" with all leaderboards
3. Updates code that pluralizes"trees" elsewhere in the app

#### Salesforce leaderboard

_Before_

![Screenshot 2023-03-09 at 4 23 09 PM](https://user-images.githubusercontent.com/44917347/224003411-88ba69dc-8ae4-4127-849f-f8deb51b79f3.png)

_After_

![Screenshot 2023-03-09 at 4 25 00 PM](https://user-images.githubusercontent.com/44917347/224003435-e38b670a-accd-4c93-a86f-98b3db300212.png)
