### PR TITLE
Adds enable_intro query param to enable intro video for embedded site

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -202,43 +202,43 @@ const PlanetWeb = ({ Component, pageProps }: any) => {
   } else {
     return (
       <ErrorHandlingProvider>
-        <div>
-          <div
-            style={
-              showVideo &&
-              (config.tenantName === 'planet' || config.tenantName === 'ttc')
-                ? {}
-                : { display: 'none' }
-            }
-          >
-            {config.tenantName === 'planet' || config.tenantName === 'ttc' ? (
-              <VideoContainer setshowVideo={setshowVideo} />
-            ) : (
-              <></>
-            )}
-          </div>
-
-          <div
-            style={
-              showVideo &&
-              (config.tenantName === 'planet' || config.tenantName === 'ttc')
-                ? { display: 'none' }
-                : {}
-            }
-          >
-            <Auth0Provider
-              domain={process.env.AUTH0_CUSTOM_DOMAIN}
-              clientId={process.env.AUTH0_CLIENT_ID}
-              redirectUri={process.env.NEXTAUTH_URL}
-              audience={'urn:plant-for-the-planet'}
-              cacheLocation={'localstorage'}
-              onRedirectCallback={onRedirectCallback}
-              useRefreshTokens={true}
+        <QueryParamsProvider>
+          <div>
+            <div
+              style={
+                showVideo &&
+                (config.tenantName === 'planet' || config.tenantName === 'ttc')
+                  ? {}
+                  : { display: 'none' }
+              }
             >
-              <ThemeProvider>
-                <MuiThemeProvider theme={materialTheme}>
-                  <CssBaseline />
-                  <QueryParamsProvider>
+              {config.tenantName === 'planet' || config.tenantName === 'ttc' ? (
+                <VideoContainer setshowVideo={setshowVideo} />
+              ) : (
+                <></>
+              )}
+            </div>
+
+            <div
+              style={
+                showVideo &&
+                (config.tenantName === 'planet' || config.tenantName === 'ttc')
+                  ? { display: 'none' }
+                  : {}
+              }
+            >
+              <Auth0Provider
+                domain={process.env.AUTH0_CUSTOM_DOMAIN}
+                clientId={process.env.AUTH0_CLIENT_ID}
+                redirectUri={process.env.NEXTAUTH_URL}
+                audience={'urn:plant-for-the-planet'}
+                cacheLocation={'localstorage'}
+                onRedirectCallback={onRedirectCallback}
+                useRefreshTokens={true}
+              >
+                <ThemeProvider>
+                  <MuiThemeProvider theme={materialTheme}>
+                    <CssBaseline />
                     <UserPropsProvider>
                       <PlanetCashProvider>
                         <PayoutsProvider>
@@ -275,12 +275,12 @@ const PlanetWeb = ({ Component, pageProps }: any) => {
                         </PayoutsProvider>
                       </PlanetCashProvider>
                     </UserPropsProvider>
-                  </QueryParamsProvider>
-                </MuiThemeProvider>
-              </ThemeProvider>
-            </Auth0Provider>
+                  </MuiThemeProvider>
+                </ThemeProvider>
+              </Auth0Provider>
+            </div>
           </div>
-        </div>
+        </QueryParamsProvider>
       </ErrorHandlingProvider>
     );
   }

--- a/src/features/common/LandingVideo/PlayButton.tsx
+++ b/src/features/common/LandingVideo/PlayButton.tsx
@@ -10,16 +10,22 @@ interface Props {
   setshowVideo: Function;
 }
 
-export default function PlayButton({ setshowVideo }: Props): ReactElement {
+export default function PlayButton({
+  setshowVideo,
+}: Props): ReactElement | null {
   const { isImpersonationModeOn } = useUserProps();
-  const { embed } = React.useContext(ParamsContext);
+  const { embed, enableIntro, isContextLoaded } =
+    React.useContext(ParamsContext);
   const { t } = useTranslation(['common']);
   const { pathname } = useRouter();
 
   const playButtonClasses = `${
     embed === 'true' ? styles.embed_playButton : styles.playButton
   } ${pathname === '/[p]' ? styles['playButton--reduce-right-offset'] : ''}`;
-  return (
+
+  const canShowPlayButton = !(embed === 'true' && enableIntro !== 'true');
+
+  return isContextLoaded && canShowPlayButton ? (
     <div
       title={t('howDoesThisWork')}
       onClick={() => setshowVideo(true)}
@@ -28,5 +34,5 @@ export default function PlayButton({ setshowVideo }: Props): ReactElement {
     >
       <PlayIcon />
     </div>
-  );
+  ) : null;
 }

--- a/src/features/common/LandingVideo/index.tsx
+++ b/src/features/common/LandingVideo/index.tsx
@@ -1,17 +1,25 @@
-import React, { ReactElement } from 'react';
+import React, {
+  ReactElement,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import styles from './styles.module.scss';
 import { useTranslation } from 'next-i18next';
 import ReactPlayer from 'react-player/lazy';
 import { useUserAgent } from 'next-useragent';
+import { ParamsContext } from '../Layout/QueryParamsContext';
 
 interface Props {
   setshowVideo: Function;
 }
 
 function VideoContainer({ setshowVideo }: Props): ReactElement {
-  const { t, ready, i18n } = useTranslation(['common']);
-  const [videoURL, setvideoURL] = React.useState<null | string>(null);
-  const videoRef = React.useRef<ReactPlayer | null>(null);
+  const { t, ready } = useTranslation(['common']);
+  const [videoURL, setvideoURL] = useState<null | string>(null);
+  const { isContextLoaded, embed, enableIntro } = useContext(ParamsContext);
+  const videoRef = useRef<ReactPlayer | null>(null);
   const handleVideoClose = () => {
     setshowVideo(false);
     if (videoRef?.current) {
@@ -22,7 +30,7 @@ function VideoContainer({ setshowVideo }: Props): ReactElement {
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (typeof navigator !== 'undefined') {
       const ua = navigator.userAgent;
       const agent = useUserAgent(ua);
@@ -32,7 +40,13 @@ function VideoContainer({ setshowVideo }: Props): ReactElement {
     }
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
+    if (isContextLoaded && embed === 'true' && enableIntro !== 'true') {
+      handleVideoClose();
+    }
+  }, [isContextLoaded, embed, enableIntro]);
+
+  useEffect(() => {
     const screenWidth = window.innerWidth;
 
     if (screenWidth < 768) {
@@ -72,7 +86,7 @@ function VideoContainer({ setshowVideo }: Props): ReactElement {
     }
   }, []);
 
-  React.useEffect((): void => {
+  useEffect((): void => {
     // See if video can play through and disable the video
     if (videoURL) {
       if (!ReactPlayer.canPlay(videoURL)) {
@@ -81,7 +95,7 @@ function VideoContainer({ setshowVideo }: Props): ReactElement {
     }
   }, [videoURL]);
 
-  return ready ? (
+  return ready && isContextLoaded ? (
     <div className={styles.landingVideoSection}>
       <div className={styles.landingVideoWrapper}>
         {videoURL &&

--- a/src/features/common/Layout/QueryParamsContext.tsx
+++ b/src/features/common/Layout/QueryParamsContext.tsx
@@ -13,6 +13,8 @@ export interface ParamsContextType {
   language: QueryParamType;
   showProjectDetails: QueryParamType;
   showProjectList: QueryParamType;
+  enableIntro: QueryParamType;
+  isContextLoaded: boolean;
 }
 export const ParamsContext = createContext<ParamsContextType>({
   embed: undefined,
@@ -21,11 +23,13 @@ export const ParamsContext = createContext<ParamsContextType>({
   language: undefined,
   showProjectDetails: undefined,
   showProjectList: undefined,
+  enableIntro: undefined,
+  isContextLoaded: false,
 });
 
 const QueryParamsProvider: FC = ({ children }) => {
   const { i18n } = useTranslation();
-
+  const [isContextLoaded, setIsContextLoaded] = useState(false);
   const [embed, setEmbed] = useState<QueryParamType>(undefined);
   const [showBackIcon, setShowBackIcon] = useState<QueryParamType>(undefined);
   const [callbackUrl, setCallbackUrl] = useState<QueryParamType>(undefined);
@@ -39,20 +43,24 @@ const QueryParamsProvider: FC = ({ children }) => {
     useState<QueryParamType>(undefined);
   const [showProjectList, setShowProjectList] =
     useState<QueryParamType>(undefined);
+  const [enableIntro, setEnableIntro] = useState<QueryParamType>(undefined);
   const router = useRouter();
-  const { query } = router;
 
   useEffect(() => {
-    if (query.embed) setEmbed(query.embed);
-  }, [query.embed]);
-
-  useEffect(() => {
-    if (query.back_icon) setShowBackIcon(query.back_icon);
-  }, [query.back_icon]);
-
-  useEffect(() => {
-    if (query.callback) setCallbackUrl(query.callback);
-  }, [query.callback]);
+    if (router.isReady) {
+      const { query } = router;
+      if (query.embed) setEmbed(query.embed);
+      if (query.back_icon) setShowBackIcon(query.back_icon);
+      if (query.callback) setCallbackUrl(query.callback);
+      if (query.project_details === 'true' || query.project_details === 'false')
+        setShowProjectDetails(query.project_details);
+      if (query.project_list === 'true' || query.project_list === 'false')
+        setShowProjectList(query.project_list);
+      if (query.enable_intro === 'true' || query.enable_intro === 'false')
+        setEnableIntro(query.enable_intro);
+      setIsContextLoaded(true);
+    }
+  }, [router]);
 
   useEffect(() => {
     if (localStorage.getItem('language') === null) {
@@ -78,16 +86,6 @@ const QueryParamsProvider: FC = ({ children }) => {
   }, [tenantSupportedLocale]);
 
   useEffect(() => {
-    if (query.project_details === 'true' || query.project_details === 'false')
-      setShowProjectDetails(query.project_details);
-  }, [query.project_details]);
-
-  useEffect(() => {
-    if (query.project_list === 'true' || query.project_list === 'false')
-      setShowProjectList(query.project_list);
-  }, [query.project_list]);
-
-  useEffect(() => {
     if (i18n && i18n.isInitialized && language) {
       i18n.changeLanguage(language as string);
       /* localStorage.setItem('language', language as string); */ //not needed as i18n handles setting the local storage
@@ -103,6 +101,8 @@ const QueryParamsProvider: FC = ({ children }) => {
         language,
         showProjectDetails,
         showProjectList,
+        enableIntro,
+        isContextLoaded,
       }}
     >
       {children}


### PR DESCRIPTION
- updates QueryParamsContext
1. initializes query param related state at one go
2. adds `enableIntro` 
3. adds `isContextLoaded`  to detect context initialization

- if embed=true and enable_intro=false is passed in url
1. does not show video
2. hides play button

Testing scenarios
- [ ] No `embed` param / `embed=true` is not passed >> video shown on first load, play button visible on map and clickable
- [ ] `embed=true` is passed, `enable_intro=true` is not passed (empty or any other value) >> video and play button not shown
- [ ] `embed=true` and `enable_intro=true` is passed >> video shown on first load, play button visible on map and clickable