### PR TITLE
Update blue carbon project link for salesforce

### DIFF
--- a/src/tenants/salesforce/Home/components/SeaOfTrees.tsx
+++ b/src/tenants/salesforce/Home/components/SeaOfTrees.tsx
@@ -83,7 +83,7 @@ export default function SeaOfTrees() {
                 increase resilience, enhance food security, and help secure
                 livelihoods.
               </p>
-              <a href="https://trees.salesforce.com/ridge-to-reef">
+              <a href="https://trees.salesforce.com/restoring-guatemala">
                 <button onClick={handleOpen}>
                   Donate to Blue Carbon Projects
                 </button>


### PR DESCRIPTION
Note: this has already been updated for the temporary salesforce branch (feature/salesforce-earthforce-campaign). This PR is to make sure that this change is made to the main branch (for when the temporary branch is abandoned in the future).