### PR TITLE
Release Cleanup - May IV

### DIFF
--- a/src/features/projects/components/ProjectSnippet.tsx
+++ b/src/features/projects/components/ProjectSnippet.tsx
@@ -16,8 +16,8 @@ import TopProjectBadge from './TopProjectBadge';
 
 interface Props {
   project: any;
-  editMode: Boolean;
-  displayPopup: Boolean;
+  editMode: boolean;
+  displayPopup: boolean;
 }
 
 export default function ProjectSnippet({


### PR DESCRIPTION
Resolves TS warnings caused by a mismatch between `Boolean` and `boolean`