### PR TITLE
style: move language modals buttons to center

### DIFF
--- a/src/features/common/Layout/Footer/SelectLanguageAndCountry.module.scss
+++ b/src/features/common/Layout/Footer/SelectLanguageAndCountry.module.scss
@@ -62,7 +62,7 @@
   border-top: 1px solid $dividerColor;
   padding: 6px 0px;
   display: flex;
-  justify-content: flex-end;
+  justify-content: center;
 }
 
 // styles the button text to bold and green


### PR DESCRIPTION
Fixes #

Check this list and then dismiss it:
- **Localization**
  - Have you added translation resources?
  - Have you localized numbers, dates and other stuff?
- **Validation and error management**
  - Is the user input validated?
  - Is the API response valided and are error responses properly handled?
  - Are errors caught if necessary?
- **Coding style**
  - Have you used a specific type for declaring the properties and parameters instead of `any`?
  - Have you defined interfaces for new components?
  - Have you added a source file not using TypeScript?
  - Have you checked if your newly introduced modules or functions are not already existing?
  - Is your `React.useEffect` using the right dependencies?
  - Check your code if it matches the existing code formatting.

Changes in this pull request:
-
-
-

@