### PR TITLE
Disable chromatic workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,9 +7,7 @@ name: 'Chromatic'
 on:
   push:
     branches:
-      - develop
-      - main
-      - feature/fix-storybook-module-not-found
+      - feature/update-storybook-to-v7
 # List of jobs
 jobs:
   chromatic-deployment:


### PR DESCRIPTION
Chromatic workflow is disabled on `develop` and `main` as storybook does not seem to play nicely with next 13 currently

See more here: https://github.com/storybookjs/storybook/issues/22987 

PR to fix this issue once possible: https://github.com/Plant-for-the-Planet-org/planet-webapp/pull/1804