### PR TITLE
Fix widgets layout

### DIFF
--- a/pages/profile/widgets.tsx
+++ b/pages/profile/widgets.tsx
@@ -40,7 +40,7 @@ function ProfilePage(): ReactElement {
         <title>{t('widgets')}</title>
       </Head>
       {user?.isPrivate === false ? (
-        <div className="profilePage" style={{ padding: '0px', marginTop: 130 }}>
+        <div className={styles.widgetsContainer}>
           <iframe
             src={`${process.env.WIDGET_URL}?user=${user?.id}&tenantkey=${TENANT_ID}`}
             className={styles.widgetIFrame}

--- a/pages/profile/widgets.tsx
+++ b/pages/profile/widgets.tsx
@@ -40,7 +40,7 @@ function ProfilePage(): ReactElement {
         <title>{t('widgets')}</title>
       </Head>
       {user?.isPrivate === false ? (
-        <div className="profilePage" style={{ padding: '0px' }}>
+        <div className="profilePage" style={{ padding: '0px', marginTop: 130 }}>
           <iframe
             src={`${process.env.WIDGET_URL}?user=${user?.id}&tenantkey=${TENANT_ID}`}
             className={styles.widgetIFrame}

--- a/src/features/common/Layout/UserLayout/UserLayout.module.scss
+++ b/src/features/common/Layout/UserLayout/UserLayout.module.scss
@@ -40,6 +40,15 @@
 .profilePageWrapper {
   width: 100%;
   min-height: 100vh;
+  .widgetsContainer {
+    padding: 0px; 
+    margin-top: 130px;
+  }
+    @include xsPhoneView {    
+      & .widgetsContainer {
+          padding-top: 80px !important;
+        }
+    }
 }
 
 .profileImpersonation {

--- a/src/features/common/Layout/UserLayout/UserLayout.module.scss
+++ b/src/features/common/Layout/UserLayout/UserLayout.module.scss
@@ -47,6 +47,7 @@
     @include xsPhoneView {    
       & .widgetsContainer {
           padding-top: 80px !important;
+          margin-top: 80px;
         }
     }
 }


### PR DESCRIPTION
Current look: 
<img width="834" alt="image" src="https://github.com/Plant-for-the-Planet-org/planet-webapp/assets/72646230/1fc156f2-6f5d-460d-998b-4ed3f06f5142">

This PR adds margin to the top of widgets container.