### PR TITLE
use some existing label for projects on profile page

### DIFF
--- a/public/static/locales/de/donate.json
+++ b/public/static/locales/de/donate.json
@@ -5,7 +5,7 @@
   "yourTreesPlantedByOnLocation_plural": "Deine {{treeCount}} Bäume werden von {{projectName}} in {{location}} gepflanzt.",
   "myTreesPlantedByOnLocation": "Mein {{treeCount}} Baum wird in {{location}} gepflanzt.",
   "myTreesPlantedByOnLocation_plural": "Meine {{treeCount}} Bäume werden in {{location}} gepflanzt.",
-  "PROJECTS": "PROJEKTE",
+  "projects": "Projekte",
   "topProjects": "Top Projekte",
   "allCountProjects": "Alle {{projectCount}} Projekte",
   "searchProjects": "Projekte suchen",

--- a/public/static/locales/en/donate.json
+++ b/public/static/locales/en/donate.json
@@ -5,7 +5,7 @@
   "yourTreesPlantedByOnLocation_plural": "Your {{treeCount}} trees will be planted by {{projectName}} in {{location}}.",
   "myTreesPlantedByOnLocation": "My {{treeCount}} tree is being planted in {{location}}.",
   "myTreesPlantedByOnLocation_plural": "My {{treeCount}} trees are being planted in {{location}}.",
-  "PROJECTS": "PROJECTS",
+  "projects": "Projects",
   "topProjects": "Top Projects",
   "allCountProjects": "All {{projectCount}} Projects",
   "searchProjects": "Search Projects",

--- a/public/static/locales/es/donate.json
+++ b/public/static/locales/es/donate.json
@@ -5,7 +5,7 @@
   "yourTreesPlantedByOnLocation_plural": "Sus árboles {{treeCount}} serán plantados por {{projectName}} en {{location}}.",
   "myTreesPlantedByOnLocation": "Mi árbol {{treeCount}} está siendo plantado en {{location}}.",
   "myTreesPlantedByOnLocation_plural": "Mis árboles {{treeCount}} están siendo plantados en {{location}}.",
-  "PROJECTS": "PROYECTOS",
+  "projects": "Proyectos",
   "topProjects": "Proyectos principales",
   "allCountProjects": "Todos {{projectCount}} los Proyectos",
   "searchProjects": "Buscar Proyectos",

--- a/public/static/locales/fr/donate.json
+++ b/public/static/locales/fr/donate.json
@@ -5,7 +5,7 @@
   "yourTreesPlantedByOnLocation_plural": "Vos {{treeCount}} arbres seront plantés par {{projectName}} à {{location}}.",
   "myTreesPlantedByOnLocation": "Mes {{treeCount}} arbres sont plantés à {{location}}.",
   "myTreesPlantedByOnLocation_plural": "Mes {{treeCount}} arbres sont plantés à {{location}}.",
-  "PROJECTS": "PROJETS",
+  "projects": "Projets",
   "topProjects": "Principaux projets",
   "allCountProjects": "Tous {{projectCount}} Projets",
   "searchProjects": "Recherche de projets",

--- a/public/static/locales/it/donate.json
+++ b/public/static/locales/it/donate.json
@@ -5,7 +5,7 @@
   "yourTreesPlantedByOnLocation_plural": "I vostri alberi {{treeCount}} saranno piantati da {{projectName}} in {{location}}.",
   "myTreesPlantedByOnLocation": "I miei {{treeCount}} alberi sono stati piantati in {{location}}.",
   "myTreesPlantedByOnLocation_plural": "I miei {{treeCount}} alberi sono stati piantati in {{location}}.",
-  "PROJECTS": "PROGETTI",
+  "projects": "Progetti",
   "topProjects": "Progetti Top",
   "allCountProjects": "Tutti {{projectCount}} Progetti",
   "searchProjects": "Ricerca progetti",

--- a/public/static/locales/pt-BR/donate.json
+++ b/public/static/locales/pt-BR/donate.json
@@ -5,7 +5,7 @@
   "yourTreesPlantedByOnLocation_plural": "As suas {{treeCount}} árvores serão plantadas por {{projectName}} em {{location}}.",
   "myTreesPlantedByOnLocation": "A minha {{treeCount}} árvore está sendo plantada em {{location}}.",
   "myTreesPlantedByOnLocation_plural": "Minhas {{treeCount}} árvores estão sendo plantadas em {{location}}.",
-  "PROJECTS": "PROJETOS",
+  "projects": "Projetos",
   "topProjects": "Principais projetos",
   "allCountProjects": "Todos {{projectCount}} Projetos",
   "searchProjects": "Pesquisar Projetos",

--- a/src/features/user/Profile/ProjectsContainer.tsx
+++ b/src/features/user/Profile/ProjectsContainer.tsx
@@ -54,7 +54,7 @@ export default function ProjectsContainer({ profile }: any) {
           </div>
         ) : (
           <div className={styles.listProjects}>
-            <h6 className={styles.projectsTitleText}>{t('donate:PROJECTS')}</h6>
+            <h6 className={styles.projectsTitleText}>{t('donate:projects')}</h6>
 
             {projects.map((project) => {
               return (

--- a/src/features/user/Profile/ProjectsContainer.tsx
+++ b/src/features/user/Profile/ProjectsContainer.tsx
@@ -54,7 +54,7 @@ export default function ProjectsContainer({ profile }: any) {
           </div>
         ) : (
           <div className={styles.listProjects}>
-            <h6 className={styles.projectsTitleText}>{t('donate:Projects')}</h6>
+            <h6 className={styles.projectsTitleText}>{t('donate:PROJECTS')}</h6>
 
             {projects.map((project) => {
               return (


### PR DESCRIPTION
Fixes  a bug

Changes in this pull request:
- renamed and used existing unused label for `Projects` on profile page to allow a proper translation
