### PR TITLE
Handles client side error for projects not supported by the webapp

### DIFF
--- a/pages/[p].tsx
+++ b/pages/[p].tsx
@@ -16,6 +16,8 @@ import {
   APIError,
   TreeProjectExtended,
   ConservationProjectExtended,
+  ProjectExtended,
+  ClientError,
 } from '@planet-sdk/common';
 import { SetState } from '../src/features/common/types/common';
 import { PlantLocation } from '../src/features/common/types/plantLocation';
@@ -71,18 +73,29 @@ export default function Donate({
         setCurrencyCode(currency);
         try {
           const { p } = router.query;
-          const project = await getRequest<
-            TreeProjectExtended | ConservationProjectExtended
-          >(encodeURI(`/app/projects/${p}`), {
-            _scope: 'extended',
-            currency: currency,
-            locale: i18n.language,
-          });
-          setProject(project);
-          setShowSingleProject(true);
-          setZoomLevel(2);
+          const project = await getRequest<ProjectExtended>(
+            encodeURI(`/app/projects/${p}`),
+            {
+              _scope: 'extended',
+              currency: currency || '',
+              locale: i18n.language,
+            }
+          );
+          if (
+            project.purpose === 'conservation' ||
+            project.purpose === 'trees'
+          ) {
+            setProject(project);
+            setShowSingleProject(true);
+            setZoomLevel(2);
+          } else {
+            throw new ClientError(404, {
+              error_type: 'project_not_available',
+              error_code: 'project_not_available',
+            });
+          }
         } catch (err) {
-          setErrors(handleError(err as APIError));
+          setErrors(handleError(err as APIError | ClientError));
           redirect('/');
         }
       }

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -123,6 +123,7 @@
   "active_account_exists": "Active PlanetCash account already exists",
   "duplicate_account": "Account already exists",
   "token_expired": "Token Expired. Please login again",
+  "project_not_available": "Project details are currently unavailable",
   "topProject": "Top Project",
   "viewReport": "View Report",
   "reviewInfo": " The project was inspected in a multiday field review in <2>month</2> and fullfills our <5>standards.</5>",


### PR DESCRIPTION
If a project not of type `trees` or `conservation` is attempted to be accessed using the webapp, the user is redirected to the home page (map) and shown an error to indicate that the project is unavailable

Fixes https://github.com/Plant-for-the-Planet-org/planet-webapp/issues/1813
