### PR TITLE
Limits projects renderable in public profile

### DIFF
--- a/src/features/user/Profile/ProjectsContainer.tsx
+++ b/src/features/user/Profile/ProjectsContainer.tsx
@@ -56,20 +56,26 @@ export default function ProjectsContainer({ profile }: any) {
           <div className={styles.listProjects}>
             <h6 className={styles.projectsTitleText}>{t('donate:projects')}</h6>
 
-            {projects.map((project) => {
-              return (
-                <div
-                  className={styles.singleProject}
-                  key={project.properties.id}
-                >
-                  <ProjectSnippet
-                    project={project.properties}
-                    editMode={false}
-                    displayPopup={true}
-                  />
-                </div>
-              );
-            })}
+            {projects
+              .filter(
+                (project) =>
+                  project.properties.purpose === 'trees' ||
+                  project.properties.purpose === 'conservation'
+              )
+              .map((project) => {
+                return (
+                  <div
+                    className={styles.singleProject}
+                    key={project.properties.id}
+                  >
+                    <ProjectSnippet
+                      project={project.properties}
+                      editMode={false}
+                      displayPopup={true}
+                    />
+                  </div>
+                );
+              })}
             {/* {user ? (
               <Link href="/profile/projects/add-project">
                 <div className={styles.singleProject}>


### PR DESCRIPTION
Prevents rendering of non-tree/conservation projects, and the resultant crash due to absence of `metadata`