### PR TITLE
do not set single plant location twice

### DIFF
--- a/pages/[p].tsx
+++ b/pages/[p].tsx
@@ -44,6 +44,7 @@ export default function Donate({
     project,
     setSelectedSite,
     setProject,
+    selectedPl,
     setSelectedPl,
     plantLocations,
     setShowSingleProject,
@@ -146,7 +147,7 @@ export default function Donate({
         setSelectedSite(siteIndex);
       }
     }
-  }, [setSelectedSite, geoJson, project]);
+  }, [router.query.site, geoJson, project]);
 
   React.useEffect(() => {
     //for selecting one of the plant location. if user use link  to directly visit to plantLocation from home page
@@ -156,13 +157,15 @@ export default function Donate({
           return router.query.ploc === singlePlantLocation?.hid;
         });
 
-      if (singlePlantLocation === undefined) {
+      if (!singlePlantLocation) {
         router.push(`/${project.slug}`);
       } else {
-        setSelectedPl(singlePlantLocation);
+        if (!selectedPl) {
+          setSelectedPl(singlePlantLocation);
+        }
       }
     }
-  }, [router, router.query.ploc, plantLocations, setSelectedPl, project]);
+  }, [router.query.ploc, plantLocations, project]);
 
   return (
     <>


### PR DESCRIPTION
Fixes https://planetfoundation.slack.com/archives/C02RPPHEQ9Y/p1694604907762709

Changes in this pull request:
- avoid setting a single plant location twice leading to a loop showing something like https://planet-norbert.netlify.app/plant-for-ghana?ploc=OHXMHQ

Does not solve the 404 error on Netlify for e.g. https://planet-norbert.netlify.app/_next/data/ZpF4F60Yc2pSvy_S89UuA/en/plant-for-ghana.json?ploc=OHXMHQ&p=plant-for-ghana
