### PR TITLE
Potential fix: login issue on TTC

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -30,7 +30,8 @@ function Login(): ReactElement {
             router.push(redirectLink);
           }
         } else {
-          router.push('/t/[id]', `/t/${user.slug}`, { shallow: true });
+          // router.push('/t/[id]', `/t/${user.slug}`, { shallow: true });
+          router.push('/profile');
         }
       }
     }


### PR DESCRIPTION
On logging in, the user is redirected to `/profile` directly rather than through an intermediate step of `/t/[slug]`. 

This applies if there is no redirect link available.

