### PR TITLE
Localized date for resource in top project description

### DIFF
--- a/src/features/projects/components/projectDetails/TopProjectReports.tsx
+++ b/src/features/projects/components/projectDetails/TopProjectReports.tsx
@@ -4,6 +4,7 @@ import VerifiedIcon from '@mui/icons-material/Verified';
 import { getPDFFile } from '../../../../utils/getImageURL';
 import parse from 'date-fns/parse';
 import format from 'date-fns/format';
+import { localeMapForDate } from '../../../../utils/language/getLanguageName';
 import { Trans } from 'react-i18next';
 import { useTranslation } from 'next-i18next';
 import { Review } from '@planet-sdk/common/build/types/project/common';
@@ -15,7 +16,9 @@ interface Props {
 export default function TopProjectReports({ projectReviews }: Props) {
   const { t, ready } = useTranslation(['common']);
   const displayDate = (date: string) => {
-    return format(parse(date, 'MM-yyyy', new Date()), 'LLLL yyyy');
+    return format(parse(date, 'MM-yyyy', new Date()), 'LLLL yyyy', {
+      locale: localeMapForDate[localStorage.getItem('language') || 'en'],
+    });
   };
   return ready ? (
     <>

--- a/src/utils/language/getLanguageName.ts
+++ b/src/utils/language/getLanguageName.ts
@@ -1,6 +1,7 @@
 import supportedLanguages from './supportedLanguages.json';
 import enLocale from 'date-fns/locale/en-US';
 import deLocale from 'date-fns/locale/de';
+import csLocale from 'date-fns/locale/cs';
 import esLocale from 'date-fns/locale/es';
 import frLocale from 'date-fns/locale/fr';
 import itLocale from 'date-fns/locale/it';
@@ -30,6 +31,7 @@ type LocaleMap = {
   [key: string]: Locale['locale'];
   en: Locale['locale'];
   de: Locale['locale'];
+  cs: Locale['locale'];
   es: Locale['locale'];
   fr: Locale['locale'];
   it: Locale['locale'];
@@ -39,6 +41,7 @@ type LocaleMap = {
 export const localeMapForDate: LocaleMap = {
   en: enLocale,
   de: deLocale,
+  cs: csLocale,
   es: esLocale,
   fr: frLocale,
   it: itLocale,


### PR DESCRIPTION
Fixes https://planetfoundation.slack.com/archives/C02393H3GDC/p1699441851695139

Changes in this pull request:
- use i18n formatting of date in resource
- added Czech to supported languages (for date formatting)

(This resource does not seem to be translated yet successfully in some languages.)