### PR TITLE
Add Bank Country to ManagePayouts

### DIFF
--- a/public/static/locales/en/managePayouts.json
+++ b/public/static/locales/en/managePayouts.json
@@ -22,6 +22,7 @@
     "payoutMinAmount": "Minimum Payout Amount",
     "bankName": "Bank Name",
     "bankAddress": "Bank Address",
+    "bankCountry": "Bank Country",
     "holderName": "Name of Account Holder",
     "holderAddress": "Address of Account Holder",
     "remarks": "Additional Details",

--- a/src/features/common/types/payouts.d.ts
+++ b/src/features/common/types/payouts.d.ts
@@ -3,6 +3,7 @@ export interface BankAccount {
   currency: string | null;
   payoutMinAmount: number | null;
   bankName: string;
+  bankCountry: string;
   bankAddress: string;
   routingNumber: string;
   bic: string;

--- a/src/features/user/ManagePayouts/components/BankAccountDetails.tsx
+++ b/src/features/user/ManagePayouts/components/BankAccountDetails.tsx
@@ -48,7 +48,7 @@ interface BankAccountDetailsProps {
 const BankAccountDetails = ({
   account,
 }: BankAccountDetailsProps): ReactElement => {
-  const { t, i18n } = useTranslation('managePayouts');
+  const { t, i18n } = useTranslation(['managePayouts', 'country']);
 
   const renderAccountTitle = () => {
     const { currency } = account;
@@ -92,6 +92,12 @@ const BankAccountDetails = ({
           <div className="detailInfo">{account.bankName}</div>
         </Grid>
         <Grid item component={SingleDetail} xs={12} md={6}>
+          <h3 className="detailTitle">{t('labels.bankCountry')}</h3>
+          <div className="detailInfo">
+            {t(`country:${account.bankCountry.toLowerCase()}`)}
+          </div>
+        </Grid>
+        <Grid item component={SingleDetail} xs={12}>
           <h3 className="detailTitle">{t('labels.bankAddress')}</h3>
           <div className="detailInfo">{account.bankAddress}</div>
         </Grid>

--- a/src/features/user/ManagePayouts/components/BankDetailsForm.tsx
+++ b/src/features/user/ManagePayouts/components/BankDetailsForm.tsx
@@ -7,11 +7,14 @@ import { PayoutCurrency } from '../../../../utils/constants/payoutConstants';
 import { useTranslation } from 'next-i18next';
 import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDisplayGroup';
 import { BankAccount } from '../../../common/types/payouts';
+import AutoCompleteCountry from '../../../common/InputTypes/AutoCompleteCountry';
+import { getStoredConfig } from '../../../../utils/storeConfig';
 
 export type FormData = {
   currency: string;
   payoutMinAmount?: string;
   bankName: string;
+  bankCountry: string;
   bankAddress: string;
   holderName: string;
   holderAddress: string;
@@ -34,6 +37,7 @@ const extractFormValues = (account?: BankAccount): FormData => {
     currency: account?.currency || PayoutCurrency.DEFAULT,
     payoutMinAmount: account?.payoutMinAmount?.toString() || '',
     bankName: account?.bankName || '',
+    bankCountry: account?.bankCountry || '',
     bankAddress: account?.bankAddress || '',
     holderName: account?.holderName || '',
     holderAddress: account?.holderAddress || '',
@@ -168,6 +172,25 @@ const BankDetailsForm = ({
                 helperText={
                   errors.bankName !== undefined && errors.bankName.message
                 }
+              />
+            )}
+          />
+          <Controller
+            name="bankCountry"
+            control={control}
+            render={({ field: { onChange, value, name } }) => (
+              <AutoCompleteCountry
+                label={t('labels.bankCountry')}
+                name={name}
+                defaultValue={
+                  value ||
+                  (getStoredConfig('loc').countryCode === 'T1' ||
+                  getStoredConfig('loc').countryCode === 'XX' ||
+                  getStoredConfig('loc').countryCode === ''
+                    ? ''
+                    : getStoredConfig('loc').countryCode)
+                }
+                onChange={onChange}
               />
             )}
           />


### PR DESCRIPTION
1. Displays `bankCountry` in account details (Overview)
2. Adds `bankCountry` to forms to add/edit bank account