### PR TITLE
Fix certificate toggle visibility condition

### DIFF
--- a/src/features/user/ManageProjects/components/ProjectCertificates.tsx
+++ b/src/features/user/ManageProjects/components/ProjectCertificates.tsx
@@ -185,7 +185,7 @@ function ProjectCertificates({
   };
 
   React.useEffect(() => {
-    if (uploadedFiles && uploadedFiles.length > 0) {
+    if (uploadedFiles && uploadedFiles.length == 0) {
       setShowToggle(true);
       setShowForm(true);
       setisCertified(false);


### PR DESCRIPTION
The condition for showing certificate toggle in `DetailedAnalysis` while editing/creating new project was changed from `uploadedFiles && !uploadedFiles.length > 0` to `uploadedFiles && uploadedFiles.length > 0` due to which the toggle was no longer visible for projects with no certificates. This PR deals with fixing that condition. 