### PR TITLE
fixed wrong not existing link to privacy

### DIFF
--- a/src/features/common/Layout/CookiePolicy/index.tsx
+++ b/src/features/common/Layout/CookiePolicy/index.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'next-i18next';
 
 export default function CookiePolicy() {
   const [showCookieNotice, setShowCookieNotice] = useState(false);
-  const { t, ready } = useTranslation(['leaderboard']);
+  const { i18n, t, ready } = useTranslation(['leaderboard']);
   const { user, contextLoaded } = useUserProps();
 
   useEffect(() => {
@@ -51,7 +51,7 @@ export default function CookiePolicy() {
       </button>
       <div className={styles.cookieContent}>
         {t('common:privacyPolicyNotice')}{' '}
-        <a href="https://www.plant-for-the-planet.org/en/footermenu/privacy-policy">
+        <a href={`https://pp.eco/legal/${i18n.language}/privacy`}>
           {t('common:privacyPolicy')}
         </a>
       </div>


### PR DESCRIPTION
Fixes bug

Changes in this pull request:
- fixed wrong not existing link to privacy in cookie notice dialog

<img width="557" alt="Bildschirmfoto 2024-01-10 um 13 59 10" src="https://github.com/Plant-for-the-Planet-org/planet-webapp/assets/1532418/53aa9302-10a8-4a8e-b9ad-58bd2aae0839">

@