### PR TITLE
AccountRecord - adds fallback unit type, allows title display upto 2 lines

### DIFF
--- a/src/features/user/Account/AccountHistory.module.scss
+++ b/src/features/user/Account/AccountHistory.module.scss
@@ -198,6 +198,16 @@
     background-color: #ffccc7;
   }
 }
+
+.recordTitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2; /* number of lines to show */
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
 .noCursor {
   cursor: default;
 }

--- a/src/features/user/Account/components/AccountRecord.tsx
+++ b/src/features/user/Account/components/AccountRecord.tsx
@@ -54,11 +54,10 @@ export function RecordHeader({
         title = t(`me:${record.type}`);
         break;
     }
-    const displayedTitle =
-      title.length > 42 ? `${title.substring(0, 42)}...` : title;
+
     return (
-      <p title={title} className={styles.top}>
-        {displayedTitle}
+      <p title={title} className={`${styles.top} ${styles.recordTitle}`}>
+        {title}
       </p>
     );
   };

--- a/src/features/user/Account/components/AccountRecord.tsx
+++ b/src/features/user/Account/components/AccountRecord.tsx
@@ -30,13 +30,16 @@ export function RecordHeader({
   const getRecordTitle = (): ReactElement => {
     let title: string;
     const BULLET_SEPARATOR = '\u2022';
+    let displayedUnit: string;
     switch (record.purpose) {
       case 'trees':
       case 'conservation':
+        displayedUnit =
+          record.unitType || record.purpose === 'trees' ? 'tree' : 'm2';
         // Sample title 1 => 5 Tree Gift . Yucatan,
         // Sample title 2 => 2 m² Donation . Sumatra
         title = `${getFormattedNumber(i18n.language, record.quantity)} ${t(
-          `common:${record.unitType}`,
+          `common:${displayedUnit}`,
           { count: 1 }
         )} ${
           record.details.giftRecipient ? t('me:gift') : t('me:donation')

--- a/src/features/user/Account/components/AccountRecord.tsx
+++ b/src/features/user/Account/components/AccountRecord.tsx
@@ -35,7 +35,7 @@ export function RecordHeader({
       case 'trees':
       case 'conservation':
         displayedUnit =
-          record.unitType || record.purpose === 'trees' ? 'tree' : 'm2';
+          record.unitType || (record.purpose === 'trees' ? 'tree' : 'm2');
         // Sample title 1 => 5 Tree Gift . Yucatan,
         // Sample title 2 => 2 m² Donation . Sumatra
         title = `${getFormattedNumber(i18n.language, record.quantity)} ${t(


### PR DESCRIPTION
AccountRecord:

1. Adds fallback logic to handle `unitType: undefined` for donations to tree/conservation projects
2. Updates record title styles to display un-truncated record title upto 2 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced account history visuals with improved text overflow handling and display limits.
- **Refactor**
	- Updated logic for displaying units in account records, improving localization support.
- **Bug Fixes**
	- Adjusted class names for improved styling in the `AccountRecord` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->