### PR TITLE
allow locale selection for tree certificate and code

### DIFF
--- a/public/static/locales/en/bulkCodes.json
+++ b/public/static/locales/en/bulkCodes.json
@@ -11,12 +11,20 @@
   "importMethodText": {
     "title": "Create Custom Tree Certificates",
     "subtitle": "Use this method (for a maximum of 1000 recipients in one transaction) if one of the following criteria match your use case:",
-    "details": ["I want to provide the Recipient's name or Email for each code.", "I want Plant-for-the-Planet to automatically email the recipients once it has been generated (optional).", "I want to issue codes for different tree counts."]
+    "details": [
+      "I want to provide the Recipient's name or Email for each code.",
+      "I want Plant-for-the-Planet to automatically email the recipients once it has been generated (optional).",
+      "I want to issue codes for different tree counts."
+    ]
   },
   "genericMethodText": {
     "title": "Create Generic Codes",
     "subtitle": "Use this method if the following criteria matches your use case:",
-    "details": ["All codes will have the same value.", "I want to generate a number of code for arbitrary recipients.", "Names and Emails cannot be associated with the code."]
+    "details": [
+      "All codes will have the same value.",
+      "I want to generate a number of code for arbitrary recipients.",
+      "Names and Emails cannot be associated with the code."
+    ]
   },
   "projectName": "Project Name",
   "costPerUnit": "Cost per Unit",
@@ -30,6 +38,7 @@
   "unitsPerCode": "Units per Code*",
   "totalNumberOfCodes": "Total Number of Codes*",
   "occasion": "Occasion",
+  "notificationLanguage": "Notification language",
   "total": "Total",
   "chargeConsentText": "By clicking Issue Codes, you agree that above amount will be charged to your account.",
   "invalidEmailWarningText": "Please make sure that that Recipient Email is a valid email. Using dummy or invalid emails will lead to account suspension in accordance with Platform terms and conditions.",

--- a/src/features/user/BulkCodes/forms/IssueCodesForm.tsx
+++ b/src/features/user/BulkCodes/forms/IssueCodesForm.tsx
@@ -1,4 +1,10 @@
-import React, { FormEvent, ReactElement, useContext, useState } from 'react';
+import React, {
+  FormEvent,
+  ReactElement,
+  useContext,
+  useState,
+  useEffect,
+} from 'react';
 import { useTranslation } from 'next-i18next';
 import { Button, TextField, MenuItem } from '@mui/material';
 import styles from '../../../../../src/features/user/BulkCodes/BulkCodes.module.scss';
@@ -52,9 +58,7 @@ const IssueCodesForm = (): ReactElement | null => {
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [isEditingRecipient, setIsEditingRecipient] = useState(false);
   const [isAddingRecipient, setIsAddingRecipient] = useState(false);
-  const [notificationLocale, setNotificationLocale] = useState(
-    i18n.language === 'de' ? 'de' : 'en'
-  );
+  const [notificationLocale, setNotificationLocale] = useState('');
 
   const notificationLocales = [
     {
@@ -96,7 +100,11 @@ const IssueCodesForm = (): ReactElement | null => {
     });
     return recipients;
   };
-
+  useEffect(() => {
+    if (i18n.language) {
+      setNotificationLocale(i18n.language === 'de' ? 'de' : 'en');
+    }
+  }, []);
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
     if (isAddingRecipient || isEditingRecipient) {

--- a/src/features/user/BulkCodes/forms/IssueCodesForm.tsx
+++ b/src/features/user/BulkCodes/forms/IssueCodesForm.tsx
@@ -91,7 +91,6 @@ const IssueCodesForm = (): ReactElement | null => {
         message: recipient.recipient_message,
         notifyRecipient: recipient.recipient_notify === 'yes',
         units: parseInt(recipient.units),
-        // notificationLocale: notificationLang,
       };
       recipients.push(temp);
     });

--- a/src/features/user/BulkCodes/forms/IssueCodesForm.tsx
+++ b/src/features/user/BulkCodes/forms/IssueCodesForm.tsx
@@ -1,6 +1,14 @@
 import React, { FormEvent, ReactElement, useContext, useState } from 'react';
 import { useTranslation } from 'next-i18next';
-import { Button, TextField } from '@mui/material';
+import {
+  Button,
+  TextField,
+  InputLabel,
+  MenuItem,
+  FormControl,
+  Select,
+  SelectChangeEvent,
+} from '@mui/material';
 import styles from '../../../../../src/features/user/BulkCodes/BulkCodes.module.scss';
 import { useRouter } from 'next/router';
 import ProjectSelector from '../components/ProjectSelector';
@@ -52,7 +60,11 @@ const IssueCodesForm = (): ReactElement | null => {
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [isEditingRecipient, setIsEditingRecipient] = useState(false);
   const [isAddingRecipient, setIsAddingRecipient] = useState(false);
+  const [notificationLang, setNotificationLang] = React.useState('en');
 
+  const handleLocale = (event: SelectChangeEvent) => {
+    setNotificationLang(event.target.value as string);
+  };
   const resetBulkContext = (): void => {
     setProject(null);
     setBulkMethod(null);
@@ -79,7 +91,7 @@ const IssueCodesForm = (): ReactElement | null => {
         message: recipient.recipient_message,
         notifyRecipient: recipient.recipient_notify === 'yes',
         units: parseInt(recipient.units),
-        // occasion: recipient.recipient_occasion,
+        // notificationLocale: notificationLang,
       };
       recipients.push(temp);
     });
@@ -115,6 +127,7 @@ const IssueCodesForm = (): ReactElement | null => {
           break;
         case BulkCodeMethods.IMPORT:
           donationData.gift = {
+            notificationLocale: notificationLang,
             type: 'discrete-bulk',
             occasion,
             recipients: getProcessedRecipients(),
@@ -242,6 +255,23 @@ const IssueCodesForm = (): ReactElement | null => {
                 value={occasion}
                 label={t('bulkCodes:occasion')}
               />
+              {bulkMethod === 'import' && (
+                <FormControl fullWidth>
+                  <InputLabel id="demo-simple-select-label">
+                    Notification language
+                  </InputLabel>
+                  <Select
+                    labelId="demo-simple-select-label"
+                    id="demo-simple-select"
+                    value={notificationLang}
+                    label="Notification language"
+                    onChange={handleLocale}
+                  >
+                    <MenuItem value={'en'}>English</MenuItem>
+                    <MenuItem value={'de'}>Deutsch</MenuItem>
+                  </Select>
+                </FormControl>
+              )}
               {bulkMethod === 'generic' && (
                 <GenericCodesPartial
                   codeQuantity={codeQuantity}

--- a/src/features/user/BulkCodes/forms/IssueCodesForm.tsx
+++ b/src/features/user/BulkCodes/forms/IssueCodesForm.tsx
@@ -100,11 +100,12 @@ const IssueCodesForm = (): ReactElement | null => {
     });
     return recipients;
   };
+
   useEffect(() => {
     if (i18n.language) {
       setNotificationLocale(i18n.language === 'de' ? 'de' : 'en');
     }
-  }, []);
+  }, [i18n.language]);
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
     if (isAddingRecipient || isEditingRecipient) {

--- a/src/features/user/BulkCodes/forms/IssueCodesForm.tsx
+++ b/src/features/user/BulkCodes/forms/IssueCodesForm.tsx
@@ -1,14 +1,6 @@
 import React, { FormEvent, ReactElement, useContext, useState } from 'react';
 import { useTranslation } from 'next-i18next';
-import {
-  Button,
-  TextField,
-  InputLabel,
-  MenuItem,
-  FormControl,
-  Select,
-  SelectChangeEvent,
-} from '@mui/material';
+import { Button, TextField, MenuItem } from '@mui/material';
 import styles from '../../../../../src/features/user/BulkCodes/BulkCodes.module.scss';
 import { useRouter } from 'next/router';
 import ProjectSelector from '../components/ProjectSelector';
@@ -60,16 +52,24 @@ const IssueCodesForm = (): ReactElement | null => {
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [isEditingRecipient, setIsEditingRecipient] = useState(false);
   const [isAddingRecipient, setIsAddingRecipient] = useState(false);
-  const [notificationLang, setNotificationLang] = React.useState('en');
+  const [notificationLocale, setNotificationLocale] = useState(
+    i18n.language === 'de' ? 'de' : 'en'
+  );
 
-  const handleLocale = (event: SelectChangeEvent) => {
-    setNotificationLang(event.target.value as string);
-  };
+  const notificationLocales = [
+    {
+      langCode: 'en',
+      languageName: 'English',
+    },
+    {
+      langCode: 'de',
+      languageName: 'Deutsch',
+    },
+  ];
   const resetBulkContext = (): void => {
     setProject(null);
     setBulkMethod(null);
   };
-
   const getTotalUnits = (): number => {
     if (bulkMethod === BulkCodeMethods.GENERIC) {
       return project ? Number(codeQuantity) * Number(unitsPerCode) : 0;
@@ -126,7 +126,7 @@ const IssueCodesForm = (): ReactElement | null => {
           break;
         case BulkCodeMethods.IMPORT:
           donationData.gift = {
-            notificationLocale: notificationLang,
+            notificationLocale: notificationLocale,
             type: 'discrete-bulk',
             occasion,
             recipients: getProcessedRecipients(),
@@ -231,7 +231,6 @@ const IssueCodesForm = (): ReactElement | null => {
         : undefined;
     }
   };
-
   if (ready) {
     if (!isSubmitted) {
       return (
@@ -255,21 +254,21 @@ const IssueCodesForm = (): ReactElement | null => {
                 label={t('bulkCodes:occasion')}
               />
               {bulkMethod === 'import' && (
-                <FormControl fullWidth>
-                  <InputLabel id="demo-simple-select-label">
-                    Notification language
-                  </InputLabel>
-                  <Select
-                    labelId="demo-simple-select-label"
-                    id="demo-simple-select"
-                    value={notificationLang}
-                    label="Notification language"
-                    onChange={handleLocale}
-                  >
-                    <MenuItem value={'en'}>English</MenuItem>
-                    <MenuItem value={'de'}>Deutsch</MenuItem>
-                  </Select>
-                </FormControl>
+                <TextField
+                  label={t('bulkCodes:notificationLanguage')}
+                  variant="outlined"
+                  select
+                  value={notificationLocale}
+                  onChange={(event) =>
+                    setNotificationLocale(event.target.value as string)
+                  }
+                >
+                  {notificationLocales.map((locale) => (
+                    <MenuItem key={locale.langCode} value={locale.langCode}>
+                      {locale.languageName}
+                    </MenuItem>
+                  ))}
+                </TextField>
               )}
               {bulkMethod === 'generic' && (
                 <GenericCodesPartial


### PR DESCRIPTION
feature
-Provided a dropdown menu to select the locale for issuing the tree certificate and code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Enhanced user control by adding the ability to select notification language during bulk code issuance.
    - Improved user experience with updated UI for selecting notification language based on the bulk method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->