### PR TITLE
Fixes instances of incorrect shallow routing to different pages

### DIFF
--- a/pages/sites/[slug]/s/[id].tsx
+++ b/pages/sites/[slug]/s/[id].tsx
@@ -54,9 +54,7 @@ export default function DirectGift({
           })
         );
       }
-      router.push('/', undefined, {
-        shallow: true,
-      });
+      router.push('/');
     } catch (err) {
       setErrors(handleError(err as APIError));
       redirect('/');

--- a/src/features/common/Layout/UserPropsContext.tsx
+++ b/src/features/common/Layout/UserPropsContext.tsx
@@ -92,7 +92,7 @@ export const UserPropsProvider: FC = ({ children }) => {
         // if 303 -> user doesn not exist in db
         setUser(null);
         if (typeof window !== 'undefined') {
-          router.push('/complete-signup', undefined, { shallow: true });
+          router.push('/complete-signup');
         }
       } else if (res.status === 401) {
         // in case of 401 - invalid token: signIn()

--- a/src/features/projects/components/maps/Markers.tsx
+++ b/src/features/projects/components/maps/Markers.tsx
@@ -70,11 +70,7 @@ export default function Markers({
                             : '?embed=true'
                         }`
                       : ''
-                  }`,
-                  undefined,
-                  {
-                    shallow: true,
-                  }
+                  }`
                 );
               }}
               onKeyDown={() => {
@@ -87,11 +83,7 @@ export default function Markers({
                             : '?embed=true'
                         }`
                       : ''
-                  }`,
-                  undefined,
-                  {
-                    shallow: true,
-                  }
+                  }`
                 );
               }}
               role="button"
@@ -148,11 +140,7 @@ export default function Markers({
                             : '?embed=true'
                         }`
                       : ''
-                  }`,
-                  undefined,
-                  {
-                    shallow: true,
-                  }
+                  }`
                 );
               }
             }}
@@ -166,11 +154,7 @@ export default function Markers({
                           : '?embed=true'
                       }`
                     : ''
-                }`,
-                undefined,
-                {
-                  shallow: true,
-                }
+                }`
               );
             }}
             role="button"

--- a/src/features/user/RegisterTrees/RegisterTrees/SingleContribution.tsx
+++ b/src/features/user/RegisterTrees/RegisterTrees/SingleContribution.tsx
@@ -38,7 +38,6 @@ export default function SingleContribution({
   token,
   contribution,
   contributionGUID,
-  slug,
 }: SingleContributionProps): ReactElement {
   const router = useRouter();
   const UploadProps = {
@@ -75,7 +74,7 @@ export default function SingleContribution({
       </div>
       <Button
         id={'singleControCont'}
-        onClick={() => router.push(`/t/${slug}`, undefined, { shallow: true })}
+        onClick={() => router.push('/profile')}
         variant="contained"
         color="primary"
         style={{ maxWidth: '100px', marginTop: '24px' }}

--- a/src/features/user/RegisterTrees/RegisterTreesWidget.tsx
+++ b/src/features/user/RegisterTrees/RegisterTreesWidget.tsx
@@ -439,7 +439,7 @@ type FormData = {
 };
 
 export default function RegisterTreesWidget() {
-  const { user, token } = useUserProps();
+  const { token } = useUserProps();
   const [contributionGUID, setContributionGUID] = React.useState('');
   const [contributionDetails, setContributionDetails] =
     React.useState<ContributionProperties | null>(null);
@@ -449,7 +449,6 @@ export default function RegisterTreesWidget() {
     token,
     contribution: contributionDetails !== null ? contributionDetails : null,
     contributionGUID,
-    slug: user !== null ? user.slug : null,
   };
 
   return (


### PR DESCRIPTION
**Changes**
1. Removes shallow routing where not applicable - i.e. when navigating to another page. 
2. Resolves white screen bugs due to navigation with shallow routing at multiple places on the index page, while visiting the single project page.
3. Register Trees success takes the user to the `/profile` route instead of an intermediate `t/:slug` step`

**Rationale**: See this thread > https://github.com/vercel/next.js/issues/38595#issuecomment-1197477538
While the app could recover from incorrect shallow routing without middleware, middleware breaks that recovery mechanism.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Simplified navigation code by removing unnecessary parameters in multiple components.
- **New Features**
	- Updated navigation behavior in the tree registration feature to direct users to their profile page after a contribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->