### PR TITLE
Remove hookform devtools

### DIFF
--- a/src/features/user/BulkCodes/components/AddRecipient.tsx
+++ b/src/features/user/BulkCodes/components/AddRecipient.tsx
@@ -2,7 +2,7 @@ import { TableRow, TableCell, IconButton } from '@mui/material';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'next-i18next';
-import { DevTool } from '@hookform/devtools';
+// import { DevTool } from '@hookform/devtools';
 import { SetState } from '../../../common/types/common';
 import themeProperties from '../../../../theme/themeProperties';
 import { Recipient } from '../BulkCodesTypes';
@@ -80,7 +80,7 @@ const AddRecipient = ({
         </TableCell>
         <RecipientFormFields control={control} errors={errors} />
       </TableRow>
-      <DevTool control={control} />
+      {/* <DevTool control={control} /> */}
     </>
   );
 };

--- a/src/features/user/BulkCodes/components/UpdateRecipient.tsx
+++ b/src/features/user/BulkCodes/components/UpdateRecipient.tsx
@@ -1,6 +1,6 @@
 import { TableRow, TableCell, IconButton } from '@mui/material';
 import { useForm } from 'react-hook-form';
-import { DevTool } from '@hookform/devtools';
+// import { DevTool } from '@hookform/devtools';
 import themeProperties from '../../../../theme/themeProperties';
 import { Recipient } from '../BulkCodesTypes';
 import AcceptIcon from '../../../../../public/assets/images/icons/AcceptIcon';
@@ -71,7 +71,7 @@ const UpdateRecipient = ({
         </TableCell>
         <RecipientFormFields control={control} errors={errors} />
       </TableRow>
-      <DevTool control={control} />
+      {/* <DevTool control={control} /> */}
     </>
   );
 };

--- a/src/features/user/TreeMapper/Import/components/PlantingLocation.tsx
+++ b/src/features/user/TreeMapper/Import/components/PlantingLocation.tsx
@@ -38,7 +38,7 @@ import {
 } from 'geojson';
 import { Species } from '../../../../common/types/plantLocation';
 import { PlantLocation, PlantingLocationFormData } from '../../Treemapper';
-import { DevTool } from '@hookform/devtools';
+// import { DevTool } from '@hookform/devtools';
 import { SetState } from '../../../../common/types/common';
 
 const dialogSx: SxProps = {
@@ -535,7 +535,7 @@ export default function PlantingLocation({
           )}
         </Button>
       </div>
-      <DevTool control={control} />
+      {/* <DevTool control={control} /> */}
     </>
   );
 }


### PR DESCRIPTION
Comments out hookform devtools as they caused a module not found error, and are only needed during development.