### PR TITLE
Updates caching key naming logic to use api endpoint

### DIFF
--- a/src/utils/multiTenancy/helpers.ts
+++ b/src/utils/multiTenancy/helpers.ts
@@ -51,9 +51,11 @@ export async function constructPathsForTenantSlug() {
  */
 export const getTenantConfig = async (slug: string): Promise<Tenant> => {
   try {
-    const caching_key = `${
-      process.env.VERCEL_ENV ? process.env.VERCEL_ENV : 'preview'
-    }_TENANT_CONFIG_${slug}`;
+    // If the API_ENDPOINT is https://app-staging.planet.com, the cachingKeyPrefix will be 'staging'
+    const cachingKeyPrefix =
+      process.env.API_ENDPOINT?.replace('https://', '').split('.')[0] ||
+      'env_missing';
+    const caching_key = `${cachingKeyPrefix}_TENANT_CONFIG_${slug}`;
 
     const tenant = await redisClient.get<Tenant>(caching_key);
 


### PR DESCRIPTION
Problem: The redis caching key used for tenant config used the vercel env i.e. 'production' or 'preview' or 'development', but we noticed keys beginning with `preview` but containing values corresponding to production data. While the cause was not clear, one way this could occur is by using a production `API_ENDPOINT` in .env.local. 

Solution: To address this problem, we decided to link the key name to the api endpoint used, to avoid a clash of data. This PR updates the caching key naming logic to use the `API_ENDPOINT`
