### PR TITLE
Add message for self_gift error in redeem code

### DIFF
--- a/pages/sites/[slug]/claim/[type]/[code].tsx
+++ b/pages/sites/[slug]/claim/[type]/[code].tsx
@@ -106,6 +106,12 @@ function ClaimDonation({ pageProps }: Props): ReactElement {
               });
               break;
 
+            case 'self_gift':
+              _serializedErrors.push({
+                message: t('redeem:selfGiftMessage'),
+              });
+              break;
+
             default:
               _serializedErrors.push(error);
               break;

--- a/pages/sites/[slug]/profile/redeem/[code].tsx
+++ b/pages/sites/[slug]/profile/redeem/[code].tsx
@@ -104,6 +104,12 @@ const ReedemCode = ({ pageProps: { tenantConfig } }: Props) => {
               });
               break;
 
+            case 'self_gift':
+              _serializedErrors.push({
+                message: t('redeem:selfGiftMessage'),
+              });
+              break;
+
             default:
               _serializedErrors.push(error);
               break;

--- a/public/static/locales/en/redeem.json
+++ b/public/static/locales/en/redeem.json
@@ -9,6 +9,7 @@
   "invalidType": "Invalid type, please check the link again",
   "redeeming": "Redeeming:",
   "invalidCode": "This code is invalid.",
+  "selfGiftMessage": "You cannot redeem a gift/code issued by yourself",
   "alreadyRedeemed": "The code has already been redeemed",
   "redeemCode": "Redeem Code",
   "redeemingCode": "Redeeming Code...",

--- a/src/features/user/Profile/components/ProfileBox/microComponents/RedeemModal.tsx
+++ b/src/features/user/Profile/components/ProfileBox/microComponents/RedeemModal.tsx
@@ -80,6 +80,12 @@ export default function RedeemModal({
               });
               break;
 
+            case 'self_gift':
+              _serializedErrors.push({
+                message: t('redeem:selfGiftMessage'),
+              });
+              break;
+
             default:
               _serializedErrors.push(error);
               break;


### PR DESCRIPTION
An error is thrown when someone tries to redeem a gift/code where giver/issuer and redeemer are identical. This PR adds a message for such cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Added specific error handling for self-gift scenarios across various features to improve user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->