### PR TITLE
Resolves routing issue on About Us click (mobile devices)

### DIFF
--- a/src/features/common/Layout/Navbar/index.tsx
+++ b/src/features/common/Layout/Navbar/index.tsx
@@ -210,7 +210,11 @@ export default function NavbarComponent() {
                 }
                 key={link}
               >
-                <Link href={isMobile && hasSubMenu ? '' : SingleLink.onclick}>
+                <Link
+                  href={
+                    isMobile && hasSubMenu ? router.asPath : SingleLink.onclick
+                  }
+                >
                   <div className={`linkContainer`}>
                     <GetNavBarIcon
                       mainKey={link}


### PR DESCRIPTION
On mobile devices, we intended to pass a blank href to the Link component for menu items with submenus - so that the menu can be opened without navigating away. 

NextJS seems to be replacing a blank href with `router.pathname` in the `Link` component, which does not work well when we have dynamic segments e.g. [slug] or [p]. The issue was masked in the old site as the dynamic segments did not exist for the home page / leaderboard.

To avoid this issue, we are now explicitly providing `href = router.asPath` i.e. the relative link displayed on the current page. An alternative was providing `href="#"`, but this would result in scrolling to the top of the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the navigation bar links to correctly use the current path for mobile devices with submenus, enhancing navigation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->