### PR TITLE
Redirects user to desired path after login

### DIFF
--- a/src/features/common/Layout/UserLayout/UserLayout.tsx
+++ b/src/features/common/Layout/UserLayout/UserLayout.tsx
@@ -451,15 +451,9 @@ const UserLayout: FC = ({ children }) => {
 
   useEffect(() => {
     if (contextLoaded) {
-      //checks whether user is login
-      if (router.asPath) {
-        if (router.query.slug) {
-          // router.push(`${router.pathname.replace('/_sites/[slug]', '')}`);
-        } else {
-          localStorage.setItem('redirectLink', router.asPath);
-        }
-      }
+      //Redirects the user to the desired page after login
       if (!user) {
+        if (router.asPath) localStorage.setItem('redirectLink', router.asPath);
         router.push('/login');
       }
     }


### PR DESCRIPTION
Fixes non working functionality to redirect user to desired authenticated path after login.

For example, if user was trying to access `/profile/register-trees`, and was not logged in, they will now be redirected to `/profile/register-trees` after logging in successfully.

The current implementation resulted in the user visiting `/profile` after every login, without considering their intended path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced post-login redirection process, now directing users to specific pages based on predefined conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->