### PR TITLE
update number of donated trees in stats

### DIFF
--- a/src/tenants/planet/LeaderBoard/components/Stats.tsx
+++ b/src/tenants/planet/LeaderBoard/components/Stats.tsx
@@ -25,7 +25,7 @@ export default function Stats({ tenantScore }: Props): ReactElement {
       <div className={styles.container}>
         <div className={styles.statCard}>
           <h2 className={styles.statNumber}>
-            {localizedAbbreviatedNumber(locale, Number(63356788), 2)}
+            {localizedAbbreviatedNumber(locale, Number(79586370), 2)}
           </h2>
           <h3 className={styles.statText}>{tPlanet('treesDonated')}</h3>
           <button


### PR DESCRIPTION
Fixes https://planetfoundation.slack.com/archives/C015AEAU75Z/p1713974028645419

Changes in this pull request:
- update number of donated trees in stats for https://www1.plant-for-the-planet.org/all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the displayed number in the leaderboard stat card to reflect the correct value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->