### PR TITLE
Resolve multiple api calls in data explorer

### DIFF
--- a/src/features/user/TreeMapper/Analytics/components/Export/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Export/index.tsx
@@ -240,7 +240,7 @@ export const Export = () => {
             }
           >
             <MuiDatePicker
-              label={t('from')}
+              label={t('to')}
               value={localToDate}
               onChange={setLocalToDate}
               renderInput={(props) => (

--- a/src/features/user/TreeMapper/Analytics/components/Map/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Map/index.tsx
@@ -49,6 +49,7 @@ import {
 import { ErrorHandlingContext } from '../../../../../common/Layout/ErrorHandlingContext';
 import PlantLocationDetails from './components/PlantLocationDetails';
 import MyForestMapCredit from '../../../../Profile/components/MyForestMap/microComponents/MyForestMapCredit';
+import { useDebouncedEffect } from '../../../../../../utils/useDebouncedEffect';
 
 const EMPTY_STYLE = {
   version: 8,
@@ -299,10 +300,18 @@ export const MapContainer = () => {
           return;
         }
       }
-      const getResponse = setTimeout(fetchProjectLocations, 500);
-      return () => clearTimeout(getResponse);
     }
   }, [project, species, queryType, fromDate, toDate]);
+
+  useDebouncedEffect(
+    () => {
+      if (project && species) {
+        fetchProjectLocations();
+      }
+    },
+    500,
+    [project, species, queryType, fromDate, toDate]
+  );
 
   // Set the map style to the default style
   // Currently this only shows Intervention

--- a/src/features/user/TreeMapper/Analytics/components/Map/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Map/index.tsx
@@ -299,7 +299,8 @@ export const MapContainer = () => {
           return;
         }
       }
-      fetchProjectLocations();
+      const getResponse = setTimeout(fetchProjectLocations, 2000);
+      return () => clearTimeout(getResponse);
     }
   }, [project, species, queryType, fromDate, toDate]);
 

--- a/src/features/user/TreeMapper/Analytics/components/Map/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Map/index.tsx
@@ -299,7 +299,7 @@ export const MapContainer = () => {
           return;
         }
       }
-      const getResponse = setTimeout(fetchProjectLocations, 2000);
+      const getResponse = setTimeout(fetchProjectLocations, 500);
       return () => clearTimeout(getResponse);
     }
   }, [project, species, queryType, fromDate, toDate]);

--- a/src/features/user/TreeMapper/Analytics/components/ProjectFilter/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/ProjectFilter/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Project,
   useAnalytics,
@@ -49,6 +49,9 @@ const ProjectFilter = () => {
     setProject(proj);
   };
 
+  const [localToDate, setLocalToDate] = useState<Date | null>(toDate);
+  const [localFromDate, setLocalFromDate] = useState<Date | null>(fromDate);
+
   return (
     <Grid alignItems="top" container spacing={2}>
       <Grid item xs={12} md={6}>
@@ -70,8 +73,9 @@ const ProjectFilter = () => {
           >
             <MuiDatePicker
               label={t('from')}
-              value={fromDate}
-              onChange={setFromDate}
+              value={localFromDate}
+              onChange={(e) => setLocalFromDate(e)}
+              onAccept={setFromDate}
               renderInput={(props) => (
                 <MaterialTextField variant="outlined" {...props} />
               )}
@@ -96,8 +100,9 @@ const ProjectFilter = () => {
           >
             <MuiDatePicker
               label={t('to')}
-              value={toDate}
-              onChange={setToDate}
+              value={localToDate}
+              onChange={(e) => setLocalToDate(e)}
+              onAccept={setToDate}
               renderInput={(props) => (
                 <MaterialTextField variant="outlined" {...props} />
               )}

--- a/src/utils/useDebouncedEffect.ts
+++ b/src/utils/useDebouncedEffect.ts
@@ -10,7 +10,8 @@ import { useCallback, useEffect } from 'react';
 export const useDebouncedEffect = (
   effect: () => void,
   delay: number,
-  deps: string[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  deps: any[]
 ) => {
   const callback = useCallback(effect, deps);
 


### PR DESCRIPTION
**Description**

There are multiple api calls being made at below places:
1. When adding a HID or selecting a date in the HID/Date filter, the application is making excessive API calls. Specifically, every time the user presses the backspace key in the input field, a new API call is triggered, leading to unnecessary server requests and potentially impacting performance.
2. In the Data Explorer section, selecting dates in the From or To fields triggers an API call each time a date is chosen from the calendar.

 

**Expected behavior**

For first point, debouncing should be implemented to reduce the number of calls per second

In the second point, API calls should be made only after the user has finalized their date selection, rather than for each individual date chosen from the calendar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the project location fetching mechanism in the Map component with a delayed execution to enhance performance.
	- Enhanced date selection controls in the Project Filter component for better user input management.

- **Refactor**
	- Implemented local state management for date handling in the Project Filter component, allowing for more precise control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->