### PR TITLE
Hotfix/minor release fixes for 2061

### DIFF
--- a/src/features/user/TreeMapper/Analytics/components/Map/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Map/index.tsx
@@ -292,20 +292,15 @@ export const MapContainer = () => {
     setLoading(false);
   };
 
-  useEffect(() => {
-    if (project && species) {
-      if (queryType === QueryType.DATE) {
-        if (!isDateBetween(search, fromDate, toDate)) {
-          setErrors([{ message: t('searchDateError') }]);
-          return;
-        }
-      }
-    }
-  }, [project, species, queryType, fromDate, toDate]);
-
   useDebouncedEffect(
     () => {
       if (project && species) {
+        if (queryType === QueryType.DATE) {
+          if (!isDateBetween(search, fromDate, toDate)) {
+            setErrors([{ message: t('searchDateError') }]);
+            return;
+          }
+        }
         fetchProjectLocations();
       }
     },

--- a/src/features/user/TreeMapper/Analytics/components/ProjectFilter/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/ProjectFilter/index.tsx
@@ -75,7 +75,9 @@ const ProjectFilter = () => {
               label={t('from')}
               value={localFromDate}
               onChange={(e) => setLocalFromDate(e)}
-              onAccept={setFromDate}
+              onAccept={(value) => {
+                if (value) setFromDate(value);
+              }}
               renderInput={(props) => (
                 <MaterialTextField variant="outlined" {...props} />
               )}
@@ -102,7 +104,9 @@ const ProjectFilter = () => {
               label={t('to')}
               value={localToDate}
               onChange={(e) => setLocalToDate(e)}
-              onAccept={setToDate}
+              onAccept={(value) => {
+                if (value) setToDate(value);
+              }}
               renderInput={(props) => (
                 <MaterialTextField variant="outlined" {...props} />
               )}


### PR DESCRIPTION
Changes for Data Explorer

1. Resolves TS warnings for datepicker `onAccept` 
2. Prevents calling `fetchProjectLocations` if there is a `searchDateError` - i.e. search date is outside the current date range for the data explorer