### PR TITLE
Fixes queries for contributions API to avoid null gift plantdate 

### DIFF
--- a/src/server/procedures/myForestV2/contributions.ts
+++ b/src/server/procedures/myForestV2/contributions.ts
@@ -102,7 +102,7 @@ async function fetchGifts(profileIds: number[]) {
 				g.metadata->>'$.project.id' as projectGuid, 
 				g.metadata->>'$.project.name' as projectName, 
 				g.metadata->>'$.project.country' as country, 
-				g.payment_date as plantDate
+				COALESCE(g.payment_date, g.redemption_date) as plantDate
 			FROM 
 				gift g
 			WHERE 


### PR DESCRIPTION
Update query logic while fetching gift plant date to consider `redemption_date` if `payment_date = null`