### PR TITLE
Minor Changes for Bulk Codes and Payment History

### DIFF
--- a/src/features/user/Account/components/AccountRecord.tsx
+++ b/src/features/user/Account/components/AccountRecord.tsx
@@ -413,7 +413,7 @@ export default function AccountRecord({
 
   const showCertificate = useMemo(() => {
     if (
-      (shouldEnableCertificate(record.purpose, record.unitType) &&
+      (shouldEnableCertificate(record.purpose) &&
         (record?.details?.donorCertificate ||
           record?.details?.giftCertificate)) ||
       record?.details?.taxDeductibleReceipt

--- a/src/features/user/Account/components/Certificates.tsx
+++ b/src/features/user/Account/components/Certificates.tsx
@@ -11,15 +11,8 @@ interface CertificatesProps {
   unitType: UnitTypes;
 }
 
-export const shouldEnableCertificate = (
-  purpose: ProjectPurpose,
-  unitType: UnitTypes
-) => {
-  if (
-    purpose === 'conservation' ||
-    purpose === 'bouquet' ||
-    (purpose === 'trees' && unitType === 'm2')
-  ) {
+export const shouldEnableCertificate = (purpose: ProjectPurpose) => {
+  if (purpose === 'bouquet') {
     return false;
   } else {
     return true;

--- a/src/features/user/BulkCodes/index.tsx
+++ b/src/features/user/BulkCodes/index.tsx
@@ -98,6 +98,7 @@ export default function BulkCodes({
               .filter((project) => {
                 return (
                   project.properties.allowDonations &&
+                  project.properties.unitType === 'tree' &&
                   (planetCashAccount.currency !== 'CHF' ||
                     (planetCashAccount.currency === 'CHF' &&
                       allowedCHFProjects.includes(project.properties.slug)))


### PR DESCRIPTION
Changes:
1. Removes projects with `unitType = m2` from permitted projects to generate bulk codes
2. Enables donor certificate download for projects with `purpose = conservation` and projects with `purpose = tree, unitType = m2`