### PR TITLE
Fix: Polygon Zoom Issues

### DIFF
--- a/src/features/projects/components/PlantLocation/ImageSlider.tsx
+++ b/src/features/projects/components/PlantLocation/ImageSlider.tsx
@@ -29,12 +29,6 @@ export default function ImageSlider({
     return ImageSource;
   };
 
-  React.useEffect(() => {
-    if (images.length > 0) {
-      setupSlider()
-    }
-  }, [images]);
-
   const setupSlider = () => {
     const projectImages: Story[] = []
     images.forEach((sliderImage) => {
@@ -58,6 +52,14 @@ export default function ImageSlider({
     });
     setSlider(projectImages)
   }
+
+
+  React.useEffect(() => {
+    if (images.length > 0) {
+      setupSlider()
+    }
+  }, [images]);
+
 
   if (slider.length === 0) {
     return null

--- a/src/features/projects/components/PlantLocation/ImageSlider.tsx
+++ b/src/features/projects/components/PlantLocation/ImageSlider.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react';
+import React, { useState } from 'react';
 import Stories from 'react-insta-stories';
 import getImageUrl from '../../../../utils/getImageURL';
 import styles from './../../styles/PlantLocation.module.scss';
+import { Story } from 'react-insta-stories/dist/interfaces';
 
 export type SliderImage = {
   image?: string;
@@ -21,8 +22,7 @@ export default function ImageSlider({
   imageSize,
   type,
 }: Props) {
-  const [slider, setSlider] = React.useState<ReactElement>();
-  const projectImages: { content: () => ReactElement }[] = [];
+  const [slider, setSlider] = useState<Story[]>([]);
 
   const loadImageSource = (imageName: string): string => {
     const ImageSource = getImageUrl(type, imageSize, imageName);
@@ -30,6 +30,13 @@ export default function ImageSlider({
   };
 
   React.useEffect(() => {
+    if (images.length > 0) {
+      setupSlider()
+    }
+  }, [images]);
+
+  const setupSlider = () => {
+    const projectImages: Story[] = []
     images.forEach((sliderImage) => {
       if (sliderImage.image) {
         const imageURL = loadImageSource(sliderImage.image);
@@ -49,18 +56,19 @@ export default function ImageSlider({
         });
       }
     });
-  }, [images]);
+    setSlider(projectImages)
+  }
 
-  React.useEffect(() => {
-    setSlider(
-      <Stories
-        stories={projectImages}
-        defaultInterval={7000}
-        width="100%"
-        height={height}
-        loop={true}
-      />
-    );
-  }, []);
-  return <>{slider}</>;
+  if (slider.length === 0) {
+    return null
+  }
+
+
+  return <Stories
+    stories={slider}
+    defaultInterval={7000}
+    width="100%"
+    height={height}
+    loop={true}
+  />;
 }

--- a/src/features/projects/components/PlantLocation/ImageSlider.tsx
+++ b/src/features/projects/components/PlantLocation/ImageSlider.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Stories from 'react-insta-stories';
 import getImageUrl from '../../../../utils/getImageURL';
 import styles from './../../styles/PlantLocation.module.scss';
@@ -30,7 +30,7 @@ export default function ImageSlider({
   };
 
   const setupSlider = () => {
-    const projectImages: Story[] = []
+    const projectImages: Story[] = [];
     images.forEach((sliderImage) => {
       if (sliderImage.image) {
         const imageURL = loadImageSource(sliderImage.image);
@@ -50,27 +50,26 @@ export default function ImageSlider({
         });
       }
     });
-    setSlider(projectImages)
-  }
+    setSlider(projectImages);
+  };
 
-
-  React.useEffect(() => {
+  useEffect(() => {
     if (images.length > 0) {
-      setupSlider()
+      setupSlider();
     }
   }, [images]);
 
-
   if (slider.length === 0) {
-    return null
+    return null;
   }
 
-
-  return <Stories
-    stories={slider}
-    defaultInterval={7000}
-    width="100%"
-    height={height}
-    loop={true}
-  />;
+  return (
+    <Stories
+      stories={slider}
+      defaultInterval={7000}
+      width="100%"
+      height={height}
+      loop={true}
+    />
+  );
 }

--- a/src/features/projects/components/ProjectSnippet.tsx
+++ b/src/features/projects/components/ProjectSnippet.tsx
@@ -55,7 +55,7 @@ export default function ProjectSnippet({
     ? getImageUrl('project', 'medium', project.image)
     : '';
 
-  const { selectedPl, hoveredPl } = useProjectProps();
+  const { selectedPl, hoveredPl, setSelectedSite } = useProjectProps();
   const { tenantConfig } = useTenant();
 
   let progressPercentage = 0;
@@ -110,6 +110,7 @@ export default function ProjectSnippet({
       ) : null}
       <div
         onClick={() => {
+          setSelectedSite(0);
           router.push(
             `/${locale}/${project.slug}/${
               embed === 'true'

--- a/src/features/projects/components/ProjectsMap.tsx
+++ b/src/features/projects/components/ProjectsMap.tsx
@@ -114,17 +114,24 @@ export default function ProjectsMap(): ReactElement {
   const onMapHover = (e: MapEvent) => {
     if (plantLocations && e && e.features && e.features[0]) {
       const activeElement = e.features[0];
+      if (selectedPl && selectedPl.id === activeElement.properties.id) {
+        setHoveredPl(null)
+        setShowDetails({ coordinates: e.lngLat, show: true });
+        return
+      }
       const activePlantLocation = plantLocations.find(
         (obj) => obj.id === activeElement.properties.id
       );
       if (activePlantLocation) {
         setHoveredPl(activePlantLocation);
+        setSamplePlantLocation(null)
         setShowDetails({ coordinates: e.lngLat, show: true });
+        return
       }
-      return;
+    } else {
+      setShowDetails({ ...showDetails, show: false });
+      setHoveredPl(null);
     }
-    setShowDetails({ ...showDetails, show: false });
-    setHoveredPl(null);
   };
 
   React.useEffect(() => {
@@ -164,7 +171,7 @@ export default function ProjectsMap(): ReactElement {
         onClick={onMapClick}
         onHover={onMapHover}
         onLoad={handleOnLoad}
-        interactiveLayerIds={['polygon-layer', 'point-layer']}
+        interactiveLayerIds={project !== null ? ['polygon-layer', 'point-layer'] : undefined}
       >
         {zoomLevel === 1 && searchedProject && showProjects && (
           <Home {...homeProps} />

--- a/src/features/projects/components/maps/Project.tsx
+++ b/src/features/projects/components/maps/Project.tsx
@@ -111,7 +111,7 @@ export default function Project({
       return
     }
 
-    if (project && project.sites  && router.query.ploc && !selectedPl) {
+    if (project && project.sites && !selectedPl) {
       zoomToProjectSite(
         {
           type: 'FeatureCollection',
@@ -141,7 +141,6 @@ export default function Project({
     project,
     siteExists,
     plantLocations,
-    router.query.ploc,
     selectedPl,
     plantPolygonCoordinates,
   ]);

--- a/src/features/projects/components/maps/Project.tsx
+++ b/src/features/projects/components/maps/Project.tsx
@@ -100,7 +100,10 @@ export default function Project({
 
   React.useEffect(() => {
     if (selectedPl) {
-      const locationCoordinates = selectedPl.type === 'multi' ? selectedPl.geometry.coordinates[0] : selectedPl.geometry.coordinates
+      const locationCoordinates =
+        selectedPl.type === 'multi'
+          ? selectedPl.geometry.coordinates[0]
+          : selectedPl.geometry.coordinates;
       zoomToPlantLocation(
         locationCoordinates,
         viewport,
@@ -108,10 +111,10 @@ export default function Project({
         setViewPort,
         1200
       );
-      return
+      return;
     }
 
-    if (project && project.sites && !selectedPl) {
+    if (project && project.sites && siteExists && !selectedPl) {
       zoomToProjectSite(
         {
           type: 'FeatureCollection',

--- a/src/features/projects/components/maps/Project.tsx
+++ b/src/features/projects/components/maps/Project.tsx
@@ -38,6 +38,7 @@ export default function Project({
     siteExists,
     rasterData,
     setRasterData,
+    hoveredPl,
     isMobile,
     setSiteViewPort,
   } = useProjectProps();
@@ -98,8 +99,19 @@ export default function Project({
   }, [selectedPl]);
 
   React.useEffect(() => {
-    if (project.sites && siteExists && !router.query.ploc) {
-      loadRasterData();
+    if (selectedPl) {
+      const locationCoordinates = selectedPl.type === 'multi' ? selectedPl.geometry.coordinates[0] : selectedPl.geometry.coordinates
+      zoomToPlantLocation(
+        locationCoordinates,
+        viewport,
+        isMobile,
+        setViewPort,
+        1200
+      );
+      return
+    }
+
+    if (project && project.sites  && router.query.ploc && !selectedPl) {
       zoomToProjectSite(
         {
           type: 'FeatureCollection',
@@ -111,17 +123,11 @@ export default function Project({
         setSiteViewPort,
         4000
       );
-    } else if (plantLocations && router.query.ploc && selectedPl) {
-      if (selectedPl?.type === 'multi' && plantPolygonCoordinates) {
-        zoomToPlantLocation(
-          plantPolygonCoordinates,
-          viewport,
-          isMobile,
-          setViewPort,
-          1200
-        );
-      }
-    } else {
+      loadRasterData();
+      return;
+    }
+
+    if (!selectedPl || !hoveredPl) {
       zoomToLocation(
         viewport,
         setViewPort,

--- a/src/features/projects/components/maps/Sites.tsx
+++ b/src/features/projects/components/maps/Sites.tsx
@@ -13,19 +13,23 @@ export default function Sites(): ReactElement {
     selectedMode,
     rasterData,
     satellite,
+    selectedPl,
+    hoveredPl,
     setSiteViewPort,
     plantLocationsLoaded,
   } = useProjectProps();
 
   React.useEffect(() => {
-    zoomToProjectSite(
-      geoJson,
-      selectedSite,
-      viewport,
-      setViewPort,
-      setSiteViewPort,
-      4000
-    );
+    if (!hoveredPl && !selectedPl) {
+      zoomToProjectSite(
+        geoJson,
+        selectedSite,
+        viewport,
+        setViewPort,
+        setSiteViewPort,
+        4000
+      );
+    }
   }, [selectedSite, selectedMode]);
 
   return (

--- a/src/features/projects/components/projectDetails/ImageSlider.tsx
+++ b/src/features/projects/components/projectDetails/ImageSlider.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react';
+import React, { useState } from 'react';
 import Stories from 'react-insta-stories';
 import getImageUrl from '../../../../utils/getImageURL';
 import styles from './../../styles/ProjectDetails.module.scss';
+import { Story } from 'react-insta-stories/dist/interfaces';
 
 export type SliderImage = {
   image?: string;
@@ -21,8 +22,7 @@ export default function ImageSlider({
   imageSize,
   type,
 }: Props) {
-  const [slider, setSlider] = React.useState<ReactElement>(<div></div>);
-  const projectImages: { content: () => ReactElement }[] = [];
+  const [slider, setSlider] = useState<Story[]>([]);
 
   const loadImageSource = (imageName: string): string => {
     const ImageSource = getImageUrl(type, imageSize, imageName);
@@ -30,6 +30,14 @@ export default function ImageSlider({
   };
 
   React.useEffect(() => {
+    if (images.length > 0) {
+      setupSlider()
+    }
+  }, [images]);
+
+
+  const setupSlider = () => {
+    const projectImages: Story[] = []
     images.forEach((sliderImage) => {
       if (sliderImage.image) {
         const imageURL = loadImageSource(sliderImage.image);
@@ -41,8 +49,8 @@ export default function ImageSlider({
                 type === 'coordinate'
                   ? { background: `url(${imageURL})` }
                   : {
-                      background: `linear-gradient(to top, rgba(0,0,0,1), rgba(0,0,0,0.2), rgba(0,0,0,0), rgba(0,0,0,0)),url(${imageURL})`,
-                    }
+                    background: `linear-gradient(to top, rgba(0,0,0,1), rgba(0,0,0,0.2), rgba(0,0,0,0), rgba(0,0,0,0)),url(${imageURL})`,
+                  }
               }
             >
               <p className={styles.projectImageSliderContentText}>
@@ -53,23 +61,19 @@ export default function ImageSlider({
         });
       }
     });
-  }, [images]);
+    setSlider(projectImages)
+  }
 
-  React.useEffect(() => {
-    if (projectImages.length > 0) {
-      setSlider(
-        <Stories
-          stories={projectImages}
-          defaultInterval={7000}
-          width="100%"
-          height={height}
-          loop={true}
-        />
-      );
-    } else {
-      setSlider(<div></div>);
-    }
-  }, [images]);
+  if (slider.length === 0) {
+    return null
+  }
 
-  return <>{slider}</>;
+
+  return <Stories
+    stories={slider}
+    defaultInterval={300}
+    width="100%"
+    height={height}
+    loop={true}
+  />;
 }

--- a/src/features/projects/components/projectDetails/ImageSlider.tsx
+++ b/src/features/projects/components/projectDetails/ImageSlider.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Stories from 'react-insta-stories';
 import getImageUrl from '../../../../utils/getImageURL';
 import styles from './../../styles/ProjectDetails.module.scss';
@@ -29,9 +29,8 @@ export default function ImageSlider({
     return ImageSource;
   };
 
-
   const setupSlider = () => {
-    const projectImages: Story[] = []
+    const projectImages: Story[] = [];
     images.forEach((sliderImage) => {
       if (sliderImage.image) {
         const imageURL = loadImageSource(sliderImage.image);
@@ -43,8 +42,8 @@ export default function ImageSlider({
                 type === 'coordinate'
                   ? { background: `url(${imageURL})` }
                   : {
-                    background: `linear-gradient(to top, rgba(0,0,0,1), rgba(0,0,0,0.2), rgba(0,0,0,0), rgba(0,0,0,0)),url(${imageURL})`,
-                  }
+                      background: `linear-gradient(to top, rgba(0,0,0,1), rgba(0,0,0,0.2), rgba(0,0,0,0), rgba(0,0,0,0)),url(${imageURL})`,
+                    }
               }
             >
               <p className={styles.projectImageSliderContentText}>
@@ -55,27 +54,26 @@ export default function ImageSlider({
         });
       }
     });
-    setSlider(projectImages)
-  }
+    setSlider(projectImages);
+  };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (images.length > 0) {
-      setupSlider()
+      setupSlider();
     }
   }, [images]);
 
-
-
   if (slider.length === 0) {
-    return null
+    return null;
   }
 
-
-  return <Stories
-    stories={slider}
-    defaultInterval={300}
-    width="100%"
-    height={height}
-    loop={true}
-  />;
+  return (
+    <Stories
+      stories={slider}
+      defaultInterval={7000}
+      width="100%"
+      height={height}
+      loop={true}
+    />
+  );
 }

--- a/src/features/projects/components/projectDetails/ImageSlider.tsx
+++ b/src/features/projects/components/projectDetails/ImageSlider.tsx
@@ -29,12 +29,6 @@ export default function ImageSlider({
     return ImageSource;
   };
 
-  React.useEffect(() => {
-    if (images.length > 0) {
-      setupSlider()
-    }
-  }, [images]);
-
 
   const setupSlider = () => {
     const projectImages: Story[] = []
@@ -63,6 +57,14 @@ export default function ImageSlider({
     });
     setSlider(projectImages)
   }
+
+  React.useEffect(() => {
+    if (images.length > 0) {
+      setupSlider()
+    }
+  }, [images]);
+
+
 
   if (slider.length === 0) {
     return null


### PR DESCRIPTION
This PR addresses all zoom and hover-related issues with polygons. The following issues have been fixed:

1. When the user hovered over any polygons, the data did not update.
2. When a user select any polygon, the zoom was not working as expected. It either got stuck or was delayed.
3. When a user selected any site, it did not respond.

4. The PR also has a fix for ImageSlider crash
steps to reproduce:
    1. select a plantlocation
    2. select sample Trees
    3. Hover over any other polygon that don't have sample trees(app crash)
    or
    3. Select other polygon that don't have sample trees(app crash)

5. Fixes crash while visiting a project with less sites after visiting a project with more sites and selecting one of the last sites - this was due to the selected site index not being reset, resulting in an index out of bound error when visiting the new project. Also takes care of projects with no sites while fixing this.