### PR TITLE
Map Crash fixes - Reference (DO NOT MERGE)

### DIFF
--- a/src/features/projects/components/PlantLocation/ImageSlider.tsx
+++ b/src/features/projects/components/PlantLocation/ImageSlider.tsx
@@ -66,7 +66,7 @@ export default function ImageSlider({
 
   return <Stories
     stories={slider}
-    defaultInterval={300}
+    defaultInterval={7000}
     width="100%"
     height={height}
     loop={true}

--- a/src/features/projects/components/PlantLocation/ImageSlider.tsx
+++ b/src/features/projects/components/PlantLocation/ImageSlider.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react';
+import React, { useState } from 'react';
 import Stories from 'react-insta-stories';
 import getImageUrl from '../../../../utils/getImageURL';
 import styles from './../../styles/PlantLocation.module.scss';
+import { Story } from 'react-insta-stories/dist/interfaces';
 
 export type SliderImage = {
   image?: string;
@@ -21,8 +22,7 @@ export default function ImageSlider({
   imageSize,
   type,
 }: Props) {
-  const [slider, setSlider] = React.useState<ReactElement>();
-  const projectImages: { content: () => ReactElement }[] = [];
+  const [slider, setSlider] = useState<Story[]>([]);
 
   const loadImageSource = (imageName: string): string => {
     const ImageSource = getImageUrl(type, imageSize, imageName);
@@ -30,6 +30,13 @@ export default function ImageSlider({
   };
 
   React.useEffect(() => {
+    if (images.length > 0) {
+      setupSlider()
+    }
+  }, [images]);
+
+  const setupSlider = () => {
+    const projectImages: Story[] = []
     images.forEach((sliderImage) => {
       if (sliderImage.image) {
         const imageURL = loadImageSource(sliderImage.image);
@@ -49,18 +56,19 @@ export default function ImageSlider({
         });
       }
     });
-  }, [images]);
+    setSlider(projectImages)
+  }
 
-  React.useEffect(() => {
-    setSlider(
-      <Stories
-        stories={projectImages}
-        defaultInterval={7000}
-        width="100%"
-        height={height}
-        loop={true}
-      />
-    );
-  }, []);
-  return <>{slider}</>;
+  if (slider.length === 0) {
+    return null
+  }
+
+
+  return <Stories
+    stories={slider}
+    defaultInterval={300}
+    width="100%"
+    height={height}
+    loop={true}
+  />;
 }

--- a/src/features/projects/components/PlantLocation/ImageSlider.tsx
+++ b/src/features/projects/components/PlantLocation/ImageSlider.tsx
@@ -29,12 +29,6 @@ export default function ImageSlider({
     return ImageSource;
   };
 
-  React.useEffect(() => {
-    if (images.length > 0) {
-      setupSlider()
-    }
-  }, [images]);
-
   const setupSlider = () => {
     const projectImages: Story[] = []
     images.forEach((sliderImage) => {
@@ -58,6 +52,14 @@ export default function ImageSlider({
     });
     setSlider(projectImages)
   }
+
+
+  React.useEffect(() => {
+    if (images.length > 0) {
+      setupSlider()
+    }
+  }, [images]);
+
 
   if (slider.length === 0) {
     return null

--- a/src/features/projects/components/ProjectSnippet.tsx
+++ b/src/features/projects/components/ProjectSnippet.tsx
@@ -55,8 +55,8 @@ export default function ProjectSnippet({
     ? getImageUrl('project', 'medium', project.image)
     : '';
 
-  const { selectedPl, hoveredPl } = useProjectProps();
-  const { tenantConfig } = useTenant();
+    const { selectedPl, hoveredPl, setSelectedSite } = useProjectProps();
+    const { tenantConfig } = useTenant();
 
   let progressPercentage = 0;
 
@@ -110,6 +110,7 @@ export default function ProjectSnippet({
       ) : null}
       <div
         onClick={() => {
+          setSelectedSite(0)
           router.push(
             `/${locale}/${project.slug}/${
               embed === 'true'

--- a/src/features/projects/components/ProjectsMap.tsx
+++ b/src/features/projects/components/ProjectsMap.tsx
@@ -114,17 +114,24 @@ export default function ProjectsMap(): ReactElement {
   const onMapHover = (e: MapEvent) => {
     if (plantLocations && e && e.features && e.features[0]) {
       const activeElement = e.features[0];
+      if (selectedPl && selectedPl.id === activeElement.properties.id) {
+        setHoveredPl(null)
+        setShowDetails({ coordinates: e.lngLat, show: true });
+        return
+      }
       const activePlantLocation = plantLocations.find(
         (obj) => obj.id === activeElement.properties.id
       );
       if (activePlantLocation) {
         setHoveredPl(activePlantLocation);
+        setSamplePlantLocation(null)
         setShowDetails({ coordinates: e.lngLat, show: true });
+        return
       }
-      return;
+    } else {
+      setShowDetails({ ...showDetails, show: false });
+      setHoveredPl(null);
     }
-    setShowDetails({ ...showDetails, show: false });
-    setHoveredPl(null);
   };
 
   React.useEffect(() => {
@@ -164,7 +171,7 @@ export default function ProjectsMap(): ReactElement {
         onClick={onMapClick}
         onHover={onMapHover}
         onLoad={handleOnLoad}
-        interactiveLayerIds={['polygon-layer', 'point-layer']}
+        interactiveLayerIds={project !== null ? ['polygon-layer', 'point-layer'] : undefined}
       >
         {zoomLevel === 1 && searchedProject && showProjects && (
           <Home {...homeProps} />

--- a/src/features/projects/components/maps/Project.tsx
+++ b/src/features/projects/components/maps/Project.tsx
@@ -111,7 +111,7 @@ export default function Project({
       return
     }
 
-    if (project && project.sites  && router.query.ploc && !selectedPl) {
+    if (project && project.sites && !selectedPl) {
       zoomToProjectSite(
         {
           type: 'FeatureCollection',
@@ -141,7 +141,6 @@ export default function Project({
     project,
     siteExists,
     plantLocations,
-    router.query.ploc,
     selectedPl,
     plantPolygonCoordinates,
   ]);

--- a/src/features/projects/components/maps/Project.tsx
+++ b/src/features/projects/components/maps/Project.tsx
@@ -38,6 +38,7 @@ export default function Project({
     siteExists,
     rasterData,
     setRasterData,
+    hoveredPl,
     isMobile,
     setSiteViewPort,
   } = useProjectProps();
@@ -98,8 +99,19 @@ export default function Project({
   }, [selectedPl]);
 
   React.useEffect(() => {
-    if (project.sites && siteExists && !router.query.ploc) {
-      loadRasterData();
+    if (selectedPl) {
+      const locationCoordinates = selectedPl.type === 'multi' ? selectedPl.geometry.coordinates[0] : selectedPl.geometry.coordinates
+      zoomToPlantLocation(
+        locationCoordinates,
+        viewport,
+        isMobile,
+        setViewPort,
+        1200
+      );
+      return
+    }
+
+    if (project && project.sites  && router.query.ploc && !selectedPl) {
       zoomToProjectSite(
         {
           type: 'FeatureCollection',
@@ -111,17 +123,11 @@ export default function Project({
         setSiteViewPort,
         4000
       );
-    } else if (plantLocations && router.query.ploc && selectedPl) {
-      if (selectedPl?.type === 'multi' && plantPolygonCoordinates) {
-        zoomToPlantLocation(
-          plantPolygonCoordinates,
-          viewport,
-          isMobile,
-          setViewPort,
-          1200
-        );
-      }
-    } else {
+      loadRasterData();
+      return;
+    }
+
+    if (!selectedPl || !hoveredPl) {
       zoomToLocation(
         viewport,
         setViewPort,

--- a/src/features/projects/components/maps/Sites.tsx
+++ b/src/features/projects/components/maps/Sites.tsx
@@ -13,19 +13,23 @@ export default function Sites(): ReactElement {
     selectedMode,
     rasterData,
     satellite,
+    selectedPl,
+    hoveredPl,
     setSiteViewPort,
     plantLocationsLoaded,
   } = useProjectProps();
 
   React.useEffect(() => {
-    zoomToProjectSite(
-      geoJson,
-      selectedSite,
-      viewport,
-      setViewPort,
-      setSiteViewPort,
-      4000
-    );
+    if (!hoveredPl && !selectedPl) {
+      zoomToProjectSite(
+        geoJson,
+        selectedSite,
+        viewport,
+        setViewPort,
+        setSiteViewPort,
+        4000
+      );
+    }
   }, [selectedSite, selectedMode]);
 
   return (

--- a/src/features/projects/components/projectDetails/ImageSlider.tsx
+++ b/src/features/projects/components/projectDetails/ImageSlider.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react';
+import React, { useState } from 'react';
 import Stories from 'react-insta-stories';
 import getImageUrl from '../../../../utils/getImageURL';
 import styles from './../../styles/ProjectDetails.module.scss';
+import { Story } from 'react-insta-stories/dist/interfaces';
 
 export type SliderImage = {
   image?: string;
@@ -21,8 +22,7 @@ export default function ImageSlider({
   imageSize,
   type,
 }: Props) {
-  const [slider, setSlider] = React.useState<ReactElement>(<div></div>);
-  const projectImages: { content: () => ReactElement }[] = [];
+  const [slider, setSlider] = useState<Story[]>([]);
 
   const loadImageSource = (imageName: string): string => {
     const ImageSource = getImageUrl(type, imageSize, imageName);
@@ -30,6 +30,14 @@ export default function ImageSlider({
   };
 
   React.useEffect(() => {
+    if (images.length > 0) {
+      setupSlider()
+    }
+  }, [images]);
+
+
+  const setupSlider = () => {
+    const projectImages: Story[] = []
     images.forEach((sliderImage) => {
       if (sliderImage.image) {
         const imageURL = loadImageSource(sliderImage.image);
@@ -41,8 +49,8 @@ export default function ImageSlider({
                 type === 'coordinate'
                   ? { background: `url(${imageURL})` }
                   : {
-                      background: `linear-gradient(to top, rgba(0,0,0,1), rgba(0,0,0,0.2), rgba(0,0,0,0), rgba(0,0,0,0)),url(${imageURL})`,
-                    }
+                    background: `linear-gradient(to top, rgba(0,0,0,1), rgba(0,0,0,0.2), rgba(0,0,0,0), rgba(0,0,0,0)),url(${imageURL})`,
+                  }
               }
             >
               <p className={styles.projectImageSliderContentText}>
@@ -53,23 +61,19 @@ export default function ImageSlider({
         });
       }
     });
-  }, [images]);
+    setSlider(projectImages)
+  }
 
-  React.useEffect(() => {
-    if (projectImages.length > 0) {
-      setSlider(
-        <Stories
-          stories={projectImages}
-          defaultInterval={7000}
-          width="100%"
-          height={height}
-          loop={true}
-        />
-      );
-    } else {
-      setSlider(<div></div>);
-    }
-  }, [images]);
+  if (slider.length === 0) {
+    return null
+  }
 
-  return <>{slider}</>;
+
+  return <Stories
+    stories={slider}
+    defaultInterval={300}
+    width="100%"
+    height={height}
+    loop={true}
+  />;
 }

--- a/src/features/projects/components/projectDetails/ImageSlider.tsx
+++ b/src/features/projects/components/projectDetails/ImageSlider.tsx
@@ -29,12 +29,6 @@ export default function ImageSlider({
     return ImageSource;
   };
 
-  React.useEffect(() => {
-    if (images.length > 0) {
-      setupSlider()
-    }
-  }, [images]);
-
 
   const setupSlider = () => {
     const projectImages: Story[] = []
@@ -63,6 +57,14 @@ export default function ImageSlider({
     });
     setSlider(projectImages)
   }
+
+  React.useEffect(() => {
+    if (images.length > 0) {
+      setupSlider()
+    }
+  }, [images]);
+
+
 
   if (slider.length === 0) {
     return null

--- a/src/features/projects/components/projectDetails/ImageSlider.tsx
+++ b/src/features/projects/components/projectDetails/ImageSlider.tsx
@@ -71,7 +71,7 @@ export default function ImageSlider({
 
   return <Stories
     stories={slider}
-    defaultInterval={300}
+    defaultInterval={7000}
     width="100%"
     height={height}
     loop={true}


### PR DESCRIPTION
This PR addresses map crash issues. Below are the issues and steps to reproduce them on the production app:

1.When a user selects a project with fewer sites than the previously selected site, the map crashes because the current state index exceeds the number of sites in the new project.

Steps I followed to reproduce the issue:
1.Open Browser incognito(Mac OS. Chrome)
2.Clicked on "Yucatan" project.
3.Selected site with higher index. eg- "Inifap site B"
4.Go back from Project details UI.
5. Selected a project with less number of site.(Eg. Saving The Amazon(Columbia)"
6. Although the map zoom in everything on the details parts is gone.(You see a White Screen before zoom-in) 

2.Image slider issue: If a user selects a polygon with images and then hovers over a polygon without images, the app crashes. According to the fix for the issue I found on their Github, content should be set to null if there are no images, not an empty array. The code has been updated accordingly.
Issue Link- https://github.com/mohitk05/react-insta-stories/issues/213#issuecomment-1359356779
Plant location which don't have sampleTrees: en/yucatan?ploc=04DR23 (dev env)

3.When someone selects sites from the dropdown, the app sometimes doesn't respond. There was a redundant query parameter condition in zoomToSite() that is already handled in "Sites.tsx", so I removed the unnecessary condition.
This issue is not very common.  I removed the query condition as there was already a effect that handles siteChange condition.

Note:
Fixes 1 and 2 are now present in #2085, remaining changes can be left here as a reference but should not be merged in. The map logic is complicated - it may be more effective to redo the logic, and update the libraries.