### PR TITLE
Displays correct unit in per unit cost on ProjectSnippet

### DIFF
--- a/src/features/projects/components/ProjectSnippet.tsx
+++ b/src/features/projects/components/ProjectSnippet.tsx
@@ -235,9 +235,8 @@ export default function ProjectSnippet({
             <div className={'perUnitCost'}>
               {getFormatedCurrency(locale, project.currency, project.unitCost)}{' '}
               <span>
-                {project.purpose === 'conservation'
-                  ? tDonate('perM2')
-                  : tDonate('perTree')}
+                {project.unitType === 'tree' && tDonate('perTree')}
+                {project.unitType === 'm2' && tDonate('perM2')}
               </span>
             </div>
           )}


### PR DESCRIPTION
The unit displayed was always "trees" regardless of the project `unitType`, this has now been corrected.