### PR TITLE
Configures Donate buttons on public profile for direct gifts (supporting the profile)

### DIFF
--- a/src/features/user/MFV2/MyContributions/index.tsx
+++ b/src/features/user/MFV2/MyContributions/index.tsx
@@ -36,6 +36,9 @@ const MyContributions = ({ profilePageType, userProfile }: ProfileV2Props) => {
               contributionDetails={item}
               project={projectListResult[key]}
               profilePageType={profilePageType}
+              {...(profilePageType === 'public'
+                ? { supportedTreecounter: userProfile.slug }
+                : {})}
             />
           );
         }


### PR DESCRIPTION
Donate buttons on the public profile page are now configured to add a `s = :slug` in the donation link, in order for donations to support the relevant public profile.