### PR TITLE
Handle no leaderboard layout on public profile

### DIFF
--- a/src/features/user/MFV2/MyContributions/MyContributions.module.scss
+++ b/src/features/user/MFV2/MyContributions/MyContributions.module.scss
@@ -7,8 +7,8 @@
 
 .myContributionsList {
   margin: 16px 12px 16px;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr;
   gap: 16px;
 
   @include smTabletView {
@@ -24,6 +24,10 @@
       width: 0;
       height: 0;
     }
+  }
+
+  @include lgLaptopView {
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 450px), 1fr));
   }
 }
 
@@ -308,10 +312,14 @@
 .registrationItemCard {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   background-color: #ffffff;
   border: 3px solid rgba(#007a49, 0.1);
   border-radius: 12px;
   overflow: hidden;
+  width: 100%;
+  min-width: 0; // Allow shrinking below 450px
+  max-width: 100%; // Ensure it doesn't exceed container width
 
   &.conservation {
     border-color: rgba(#2d9cdb, 0.1);

--- a/src/features/user/MFV2/PublicProfileLayout/PublicProfileLayout.module.scss
+++ b/src/features/user/MFV2/PublicProfileLayout/PublicProfileLayout.module.scss
@@ -12,8 +12,17 @@
     'progressContainer'
     'communityContributionsContainer'
     'myContributionsContainer'
-    'infoAndCtaContainer';
+    /* 'infoAndCtaContainer' */;
   gap: 16px;
+
+  &.noLeaderboard {
+    grid-template-areas:
+      'profileContainer'
+      'mapContainer'
+      'progressContainer'
+      'myContributionsContainer'
+      /* 'infoAndCtaContainer' */;
+  }
 
   > section {
     border-radius: 16px;
@@ -94,6 +103,14 @@
       'myContributionsContainer myContributionsContainer communityContributionsContainer communityContributionsContainer'
       'infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer';
 
+    &.noLeaderboard {
+      grid-template-areas:
+        'profileContainer mapContainer mapContainer mapContainer'
+        'progressContainer progressContainer progressContainer progressContainer'
+        'myContributionsContainer myContributionsContainer myContributionsContainer myContributionsContainer'
+        /* 'infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer' */;
+    }
+
     > section {
       border-radius: 24px;
     }
@@ -121,6 +138,14 @@
       'progressContainer progressContainer progressContainer progressContainer'
       'myContributionsContainer myContributionsContainer communityContributionsContainer communityContributionsContainer'
       'infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer';
+
+    &.noLeaderboard {
+      grid-template-areas:
+        'profileContainer mapContainer mapContainer mapContainer'
+        'progressContainer progressContainer progressContainer progressContainer'
+        'myContributionsContainer myContributionsContainer myContributionsContainer myContributionsContainer'
+        /* 'infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer' */;
+    }
   }
 }
 

--- a/src/features/user/MFV2/PublicProfileLayout/index.tsx
+++ b/src/features/user/MFV2/PublicProfileLayout/index.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 // We may choose to accept the components for each section as props depending on how we choose to pass data. In that case, we would need to add an interface to accept the components as props.
 const PublicProfileLayout = ({ tenantConfigId }: Props) => {
-  const showLeaderboard = true;
+  const showLeaderboard = false;
   const [profile, setProfile] = useState<null | UserPublicProfile>();
   const { user, contextLoaded } = useUserProps();
   const router = useRouter();
@@ -95,7 +95,11 @@ const PublicProfileLayout = ({ tenantConfigId }: Props) => {
     isContributionsLoaded && profile !== null && profile !== undefined;
 
   return (
-    <article className={styles.publicProfileLayout}>
+    <article
+      className={`${styles.publicProfileLayout} ${
+        !showLeaderboard ? styles.noLeaderboard : ''
+      }`}
+    >
       <section id="profile-container" className={styles.profileContainer}>
         {isProfileLoaded ? (
           <ProfileCard userProfile={profile} profilePageType="public" />


### PR DESCRIPTION
This handles the public profile layout when no leaderboard should be shown.

Changes:
1. When no leaderboard is shown, the My Contributions section takes the full width of the screen
2. When no leaderboard is shown, and space permits, the MyContributionsList can contain 2 columns (subject to a minimum card width of 450 px).

For testing, the leaderboard will always be hidden on the public profile.