### PR TITLE
add viewbox parameters for some icons to render them smaller in mfv2

### DIFF
--- a/public/assets/images/icons/myForestMapIcons/PointMarkerIcons.tsx
+++ b/public/assets/images/icons/myForestMapIcons/PointMarkerIcons.tsx
@@ -2,7 +2,7 @@ import { IconProps } from '../../../../../src/features/common/types/common';
 
 export const Agroforestry = ({ color }: IconProps) => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 42 49">
       <g filter="url(#a)">
         <path
           fill={color}
@@ -59,7 +59,7 @@ export const Agroforestry = ({ color }: IconProps) => {
 
 export const Conservation = ({ color }: IconProps) => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 42 49">
       <path
         fill={color}
         fillRule="evenodd"
@@ -176,7 +176,7 @@ export const NaturalRegeneration = ({ color }: IconProps) => {
 
 export const OtherPlanting = ({ color }: IconProps) => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 42 49">
       <g filter="url(#a)">
         <path
           fill={color}
@@ -285,7 +285,7 @@ export const TreePlanting = ({ color }: IconProps) => {
 
 export const UrbanRestoration = ({ color }: IconProps) => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 42 49">
       <path
         fill={color}
         fillRule="evenodd"


### PR DESCRIPTION
Fixes oversized icons in new contributions map of my forest v2.

Changes in this pull request:
- added viewbox parameter where not present for all icons used in component `ProjectTypeIcon`

This fixed the icons in the above mentioned app. Problem is I do not know if these icons are also used anywhere else where the smaller size is not wanted, but they should be displayed in a larger form?

@