### PR TITLE
Fix cluster outline color issue

### DIFF
--- a/src/utils/myForestV2Utils.ts
+++ b/src/utils/myForestV2Utils.ts
@@ -46,7 +46,7 @@ export const getDonationClusterMarkerColors = (
     const mainProjectColor = getColor(purpose, unitType) ?? '';
     let tertiaryProjectColor = '',
       secondaryProjectColor = '';
-    const length = uniqueUnitTypePurposeProjects.length;
+    const length = uniqueUnitTypePurposeProjects?.length || 0;
     if (length === 0) {
       tertiaryProjectColor = secondaryProjectColor = mainProjectColor;
     } else if (length === 1) {
@@ -87,9 +87,9 @@ export const getDonationClusterMarkerColors = (
 export const extractAndClassifyProjectData = (
   clusterChildren: PointFeature<DonationProperties>[] | undefined
 ) => {
-  const uniqueProjectType = new Map<string, ExtractedProjectData>();
-  let maxContributingProject = null;
+  let maxContributingProject: ExtractedProjectData | null = null;
   let maxContributionCount = -Infinity;
+  const remainingProjects: ExtractedProjectData[] = [];
 
   if (!clusterChildren || clusterChildren.length === 0) {
     return { uniqueProjects: [], maxContributingProject: null };
@@ -109,13 +109,29 @@ export const extractAndClassifyProjectData = (
       maxContributingProject = extractedProjectData;
     }
 
-    const key = `${extractedProjectData.unitType}-${extractedProjectData.contributionCount}`;
-    if (!uniqueProjectType.has(key)) {
-      uniqueProjectType.set(key, extractedProjectData);
+    // Loop through the array to find the object with the unique purpose and unit type
+    if (
+      extractedProjectData.unitType !==
+        (maxContributingProject !== null && maxContributingProject.unitType) ||
+      extractedProjectData.purpose !==
+        (maxContributingProject !== null && maxContributingProject.purpose)
+    ) {
+      remainingProjects.push(extractedProjectData);
     }
   });
 
-  const uniqueProjects = Array.from(uniqueProjectType.values());
+  const uniqueCombinations = new Map();
+  // Loop through the array to find  the object with the unique purpose and unit type
+  remainingProjects.forEach((obj) => {
+    const { unitType, purpose } = obj;
+    const key = unitType + '-' + purpose;
+
+    if (!uniqueCombinations.has(key)) {
+      uniqueCombinations.set(key, obj);
+    }
+  });
+
+  const uniqueProjects = Array.from(uniqueCombinations.values());
   return { uniqueProjects, maxContributingProject };
 };
 

--- a/src/utils/myForestV2Utils.ts
+++ b/src/utils/myForestV2Utils.ts
@@ -86,7 +86,10 @@ export const getDonationClusterMarkerColors = (
 
 export const extractAndClassifyProjectData = (
   clusterChildren: PointFeature<DonationProperties>[] | undefined
-) => {
+): {
+  maxContributingProject: ExtractedProjectData | null;
+  uniqueProjects: ExtractedProjectData[];
+} => {
   let maxContributingProject: ExtractedProjectData | null = null;
   let maxContributionCount = -Infinity;
   const remainingProjects: ExtractedProjectData[] = [];
@@ -120,7 +123,7 @@ export const extractAndClassifyProjectData = (
     }
   });
 
-  const uniqueCombinations = new Map();
+  const uniqueCombinations = new Map<string, ExtractedProjectData>();
   // Loop through the array to find  the object with the unique purpose and unit type
   remainingProjects.forEach((obj) => {
     const { unitType, purpose } = obj;


### PR DESCRIPTION
Issue: Clusters don’t work correctly anymore. In the Cluster provided in the screenshot, a restoration project with unitType m2 is included. When originally testing, the correct cluster marker was shown (Green for main marker, right outline was purple), now all elements of the marker are green
<img width="100" alt="image" src="https://github.com/Plant-for-the-Planet-org/planet-webapp/assets/72646230/873d1094-3791-42d3-bd8b-1d4263d19816">


Expected behavior:  To show different colored outlines if cluster contains markers of multiple colors
<img width="97" alt="image" src="https://github.com/Plant-for-the-Planet-org/planet-webapp/assets/72646230/89e8b020-5510-477d-b3ef-6baf8fae5295">
