### PR TITLE
Fix for zero value in progress bar graph labels

### DIFF
--- a/src/features/user/MFV2/ForestProgress/microComponents/ProgressData.tsx
+++ b/src/features/user/MFV2/ForestProgress/microComponents/ProgressData.tsx
@@ -39,6 +39,7 @@ const ProgressData = ({
 }: ProgressDataProps) => {
   const tProfile = useTranslations('Profile.progressBar');
   const totalAchievment = gift + personal;
+
   const graphLabel = useMemo(() => {
     const isTargetSet = target > 0;
     const targetAchievedUnit = Number.isInteger(totalAchievment)
@@ -79,7 +80,7 @@ const ProgressData = ({
       default:
         return '';
     }
-  }, [dataType, target]);
+  }, [dataType, target, totalAchievment, tProfile]);
 
   const graphProps = {
     personalPercentage,


### PR DESCRIPTION
Resolves issue due to which progress bar graphs were displaying zero value for progress (in the label above the bar)