### PR TITLE
Remove progressContainer from the grid when it isn't shown

### DIFF
--- a/src/features/user/MFV2/PublicProfileLayout/PublicProfileLayout.module.scss
+++ b/src/features/user/MFV2/PublicProfileLayout/PublicProfileLayout.module.scss
@@ -15,6 +15,15 @@
     /* 'infoAndCtaContainer' */;
   gap: 16px;
 
+  &.noProgress {
+    grid-template-areas:
+      'profileContainer'
+      'mapContainer'
+      'communityContributionsContainer'
+      'myContributionsContainer'
+      /* 'infoAndCtaContainer' */;
+  }
+
   &.noLeaderboard {
     grid-template-areas:
       'profileContainer'
@@ -22,6 +31,14 @@
       'progressContainer'
       'myContributionsContainer'
       /* 'infoAndCtaContainer' */;
+
+    &.noProgress {
+      grid-template-areas:
+        'profileContainer'
+        'mapContainer'
+        'myContributionsContainer'
+        /* 'infoAndCtaContainer' */;
+    }
   }
 
   > section {
@@ -101,7 +118,14 @@
       'profileContainer mapContainer mapContainer mapContainer'
       'progressContainer progressContainer progressContainer progressContainer'
       'myContributionsContainer myContributionsContainer communityContributionsContainer communityContributionsContainer'
-      'infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer';
+      /* 'infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer' */;
+
+    &.noProgress {
+      grid-template-areas:
+        'profileContainer mapContainer mapContainer mapContainer'
+        'myContributionsContainer myContributionsContainer communityContributionsContainer communityContributionsContainer'
+        /* 'infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer' */;
+    }
 
     &.noLeaderboard {
       grid-template-areas:
@@ -109,6 +133,13 @@
         'progressContainer progressContainer progressContainer progressContainer'
         'myContributionsContainer myContributionsContainer myContributionsContainer myContributionsContainer'
         /* 'infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer' */;
+
+      &.noProgress {
+        grid-template-areas:
+          'profileContainer mapContainer mapContainer mapContainer'
+          'myContributionsContainer myContributionsContainer myContributionsContainer myContributionsContainer'
+          /* 'infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer' */;
+      }
     }
 
     > section {
@@ -137,7 +168,14 @@
       'profileContainer mapContainer mapContainer mapContainer'
       'progressContainer progressContainer progressContainer progressContainer'
       'myContributionsContainer myContributionsContainer communityContributionsContainer communityContributionsContainer'
-      'infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer';
+      /* 'infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer' */;
+
+    &.noProgress {
+      grid-template-areas:
+        'profileContainer mapContainer mapContainer mapContainer'
+        'myContributionsContainer myContributionsContainer communityContributionsContainer communityContributionsContainer'
+        /* 'infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer' */;
+    }
 
     &.noLeaderboard {
       grid-template-areas:
@@ -145,6 +183,13 @@
         'progressContainer progressContainer progressContainer progressContainer'
         'myContributionsContainer myContributionsContainer myContributionsContainer myContributionsContainer'
         /* 'infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer' */;
+
+      &.noProgress {
+        grid-template-areas:
+          'profileContainer mapContainer mapContainer mapContainer'
+          'myContributionsContainer myContributionsContainer myContributionsContainer myContributionsContainer'
+          /* 'infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer infoAndCtaContainer' */;
+      }
     }
   }
 }

--- a/src/features/user/MFV2/PublicProfileLayout/index.tsx
+++ b/src/features/user/MFV2/PublicProfileLayout/index.tsx
@@ -5,7 +5,7 @@ import { ProfileLoader } from '../../../common/ContentLoaders/ProfileV2';
 import ForestProgress from '../ForestProgress';
 import ContributionsMap from '../ContributionsMap';
 import CommunityContributions from '../CommunityContributions';
-import { useState, useEffect, useContext } from 'react';
+import { useState, useEffect, useContext, useMemo } from 'react';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 import { useRouter } from 'next/router';
 import { handleError, APIError } from '@planet-sdk/common';
@@ -77,7 +77,7 @@ const PublicProfileLayout = ({ tenantConfigId }: Props) => {
   const restoreTarget = userInfo?.targets.areaRestored ?? 0;
   const conservTarget = userInfo?.targets.areaConserved ?? 0;
 
-  const isProgressBarDisabled = () => {
+  const isProgressBarDisabled = useMemo(() => {
     return (
       treesDonated === 0 &&
       areaRestored === 0 &&
@@ -86,7 +86,14 @@ const PublicProfileLayout = ({ tenantConfigId }: Props) => {
       restoreTarget === 0 &&
       conservTarget === 0
     );
-  };
+  }, [
+    treesDonated,
+    areaRestored,
+    areaConserved,
+    treeTarget,
+    restoreTarget,
+    conservTarget,
+  ]);
 
   const isProfileLoaded = profile !== null && profile !== undefined;
   const isContributionsDataLoaded =
@@ -98,7 +105,7 @@ const PublicProfileLayout = ({ tenantConfigId }: Props) => {
     <article
       className={`${styles.publicProfileLayout} ${
         !showLeaderboard ? styles.noLeaderboard : ''
-      }`}
+      } ${isProgressBarDisabled ? styles.noProgress : ''}`}
     >
       <section id="profile-container" className={styles.profileContainer}>
         {isProfileLoaded ? (
@@ -122,7 +129,7 @@ const PublicProfileLayout = ({ tenantConfigId }: Props) => {
           <ProfileLoader height={450} />
         )}
       </section>
-      {isProgressBarDisabled() ? (
+      {isProgressBarDisabled ? (
         <></>
       ) : (
         <section


### PR DESCRIPTION
This pull request removes an empty slot for the progressContainer from the grid when it is not shown. This improves the layout and removes unnecessary elements from the UI.