### PR TITLE
fix: align popup properly by removing offset and anchor properties

### DIFF
--- a/src/features/user/MFV2/ContributionsMap/Markers/PointMarkers.tsx
+++ b/src/features/user/MFV2/ContributionsMap/Markers/PointMarkers.tsx
@@ -45,9 +45,13 @@ const PointMarkers = ({
     setIsCursorOnPopup,
   };
 
+  const handleMouseLeaveFromMarker = () => {
+    setTimeout(() => setIsCursorOnMarker(false), 2000);
+  };
+
   return (
     <div
-      onMouseLeave={() => setIsCursorOnMarker(false)}
+      onMouseLeave={handleMouseLeaveFromMarker}
       onMouseEnter={() => setIsCursorOnMarker(true)}
     >
       <Marker

--- a/src/features/user/MFV2/ContributionsMap/Markers/PointMarkers.tsx
+++ b/src/features/user/MFV2/ContributionsMap/Markers/PointMarkers.tsx
@@ -46,7 +46,7 @@ const PointMarkers = ({
   };
 
   const handleMouseLeaveFromMarker = () => {
-    setTimeout(() => setIsCursorOnMarker(false), 2000);
+    setTimeout(() => setIsCursorOnMarker(false), 800);
   };
 
   return (

--- a/src/features/user/MFV2/ContributionsMap/Popup/DonationPopup.tsx
+++ b/src/features/user/MFV2/ContributionsMap/Popup/DonationPopup.tsx
@@ -34,9 +34,7 @@ const DonationPopup = ({
       latitude={coordinates[1]}
       longitude={coordinates[0]}
       className={style.contributionPopup}
-      offset={30}
       closeButton={false}
-      anchor="bottom"
     >
       <div
         className={style.donationPopupContainer}

--- a/src/features/user/MFV2/ContributionsMap/Popup/RegisteredTreesPopup.tsx
+++ b/src/features/user/MFV2/ContributionsMap/Popup/RegisteredTreesPopup.tsx
@@ -54,10 +54,8 @@ const RegisteredTreesPopup = ({
     <Popup
       latitude={coordinates[1]}
       longitude={coordinates[0]}
-      offset={20}
       className={style.registeredTreePopup}
       closeButton={false}
-      anchor="bottom"
     >
       <div
         className={style.registeredTreesPopupContainer}


### PR DESCRIPTION
Remove offset and anchor properties to properly align popup

- Eliminated unnecessary offset and anchor properties
- Ensured popup aligns correctly without these adjustments
- Tested and verified alignment across different scenarios