### PR TITLE
Fixes loss of embed state when project details page loads

### DIFF
--- a/pages/sites/[slug]/[locale]/[p].tsx
+++ b/pages/sites/[slug]/[locale]/[p].tsx
@@ -155,9 +155,21 @@ export default function Donate({
       !router.query.ploc &&
       project
     ) {
-      router.push(
-        `/${locale}/${project.slug}?site=${geoJson.features[0].properties.id}`
-      );
+      const currentUrl = new URL(window.location.href);
+      const searchParams = currentUrl.searchParams;
+
+      // Delete the existing site parameter from the displayed URL (if it exists). Unlikely to happen as router.query.site is not set
+      searchParams.delete('site');
+
+      // Add the new 'site' parameter
+      searchParams.append('site', geoJson.features[0].properties.id);
+
+      const newSearch = searchParams.toString();
+      const newPath = `/${locale}/${project.slug}${
+        newSearch.length > 0 ? `?${newSearch}` : ''
+      }`;
+
+      router.push(newPath);
     }
   }, [project?.slug, router.query.site, router.query.ploc, locale, geoJson]);
 


### PR DESCRIPTION
Preserves query parameters when project details page loads and the initial site is selected.

When a page e.g.`en/yucatan?embed=true` was visited directly, the embed parameters in the URL were lost before storing the state in QueryParamsContext. This fixes that issue.

Note that window.location.search is used instead of the router object, as the router object no longer contained the original query parameters after NextResponse.rewrite in the middleware.