### PR TITLE
Update meta info for public and private profile

### DIFF
--- a/pages/sites/[slug]/[locale]/profile/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/index.tsx
@@ -5,7 +5,7 @@ import {
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
-import { AbstractIntlMessages } from 'next-intl';
+import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
@@ -22,10 +22,12 @@ interface Props {
 }
 
 const MyForestPage = ({ pageProps: { tenantConfig } }: Props) => {
+  const t = useTranslations('Me');
+
   return tenantConfig ? (
     <UserLayout>
       <Head>
-        <title>My Forest V2</title>
+        <title>{t('profile')}</title>
       </Head>
       <MyForestProviderV2>
         <ProfileOuterContainer>

--- a/pages/sites/[slug]/[locale]/t/[profile].tsx
+++ b/pages/sites/[slug]/[locale]/t/[profile].tsx
@@ -54,7 +54,7 @@ const PublicProfilePage = ({ pageProps: { tenantConfig } }: Props) => {
   }
 
   useEffect(() => {
-    if (router && router.isReady && router.query.profile) {
+    if (router?.isReady && router?.query?.profile) {
       // reintiating the profile
       setProfile(null);
       loadPublicProfile(router.query.profile as string);

--- a/pages/sites/[slug]/[locale]/t/[profile].tsx
+++ b/pages/sites/[slug]/[locale]/t/[profile].tsx
@@ -12,14 +12,17 @@ import {
 } from '../../../../../src/utils/multiTenancy/helpers';
 import getMessagesForPage from '../../../../../src/utils/language/getMessagesForPage';
 import { defaultTenant } from '../../../../../tenant.config';
-import Head from 'next/head';
 import PublicProfileOuterContainer from '../../../../../src/features/user/MFV2/PublicProfileOuterContainer';
 import PublicProfileLayout from '../../../../../src/features/user/MFV2/PublicProfileLayout';
 import { v4 } from 'uuid';
 import { useTenant } from '../../../../../src/features/common/Layout/TenantContext';
 import { useRouter } from 'next/router';
 import { MyForestProviderV2 } from '../../../../../src/features/common/Layout/MyForestContextV2';
-import { useEffect } from 'react';
+import { useContext, useEffect, useState } from 'react';
+import { ErrorHandlingContext } from '../../../../../src/features/common/Layout/ErrorHandlingContext';
+import { APIError, handleError, UserPublicProfile } from '@planet-sdk/common';
+import { getRequest } from '../../../../../src/utils/apiRequests/api';
+import GetPublicUserProfileMeta from '../../../../../src/utils/getMetaTags/GetPublicUserProfileMeta';
 
 interface Props {
   pageProps: PageProps;
@@ -27,6 +30,8 @@ interface Props {
 
 const PublicProfilePage = ({ pageProps: { tenantConfig } }: Props) => {
   const { setTenantConfig } = useTenant();
+  const { setErrors, redirect } = useContext(ErrorHandlingContext);
+  const [profile, setProfile] = useState<null | UserPublicProfile>(null);
   const router = useRouter();
 
   useEffect(() => {
@@ -35,14 +40,36 @@ const PublicProfilePage = ({ pageProps: { tenantConfig } }: Props) => {
     }
   }, [router.isReady]);
 
+  async function loadPublicProfile(slug: string) {
+    try {
+      const profileData = await getRequest<UserPublicProfile>(
+        tenantConfig.id,
+        `/app/profiles/${slug}`
+      );
+      setProfile(profileData);
+    } catch (err) {
+      setErrors(handleError(err as APIError));
+      redirect('/');
+    }
+  }
+
+  useEffect(() => {
+    if (router && router.isReady && router.query.profile) {
+      // reintiating the profile
+      setProfile(null);
+      loadPublicProfile(router.query.profile as string);
+    }
+  }, [router]);
+
   return tenantConfig ? (
     <>
-      <Head>
-        <title>My Forest V2</title>
-      </Head>
+      <GetPublicUserProfileMeta userprofile={profile} />
       <MyForestProviderV2>
         <PublicProfileOuterContainer>
-          <PublicProfileLayout tenantConfigId={tenantConfig.id} />
+          <PublicProfileLayout
+            profile={profile}
+            isProfileLoaded={profile !== null}
+          />
         </PublicProfileOuterContainer>
       </MyForestProviderV2>
     </>


### PR DESCRIPTION
1. Populates page title for private profile
2. Populates meta info including page title for public profile

Dummy title 'My Forest V2' on both pages will no longer show.

This required a refactor to move the API call fetching public profile data to the page file instead of within the PublicProfileLayout component.