### PR TITLE
hotfix: hide website button if url is missing

### DIFF
--- a/src/features/user/MFV2/ProfileCard/ProfileActions/index.tsx
+++ b/src/features/user/MFV2/ProfileCard/ProfileActions/index.tsx
@@ -15,7 +15,7 @@ import WebappButton from '../../../../common/WebappButton';
 const ProfileActions = ({ profilePageType, userProfile }: ProfileV2Props) => {
   const [isRedeemModalOpen, setIsRedeemModalOpen] = useState(false);
   const t = useTranslations('Profile');
-
+  const userWebsiteUrl = userProfile?.url;
   const handleRedeemModalOpen = () => {
     setIsRedeemModalOpen(true);
   };
@@ -69,13 +69,15 @@ const ProfileActions = ({ profilePageType, userProfile }: ProfileV2Props) => {
         href={`/s/${userProfile?.slug}`}
       />
       <div className={styles.websiteShareActions}>
-        <WebappButton
-          icon={<WebsiteLinkIcon />}
-          text={t('feature.website')}
-          elementType={'link'}
-          href={handleWebsiteShareUrl()}
-          target={'_blank'}
-        />
+        {userWebsiteUrl && (
+          <WebappButton
+            icon={<WebsiteLinkIcon />}
+            text={t('feature.website')}
+            elementType={'link'}
+            href={handleWebsiteShareUrl()}
+            target={'_blank'}
+          />
+        )}
         <SocialMediaShareButton userProfile={userProfile} />
       </div>
     </div>

--- a/src/features/user/MFV2/ProfileCard/ProfileActions/index.tsx
+++ b/src/features/user/MFV2/ProfileCard/ProfileActions/index.tsx
@@ -15,7 +15,6 @@ import WebappButton from '../../../../common/WebappButton';
 const ProfileActions = ({ profilePageType, userProfile }: ProfileV2Props) => {
   const [isRedeemModalOpen, setIsRedeemModalOpen] = useState(false);
   const t = useTranslations('Profile');
-  const userWebsiteUrl = userProfile?.url;
   const handleRedeemModalOpen = () => {
     setIsRedeemModalOpen(true);
   };
@@ -69,7 +68,7 @@ const ProfileActions = ({ profilePageType, userProfile }: ProfileV2Props) => {
         href={`/s/${userProfile?.slug}`}
       />
       <div className={styles.websiteShareActions}>
-        {userWebsiteUrl && (
+        {userProfile?.url !== null && (
           <WebappButton
             icon={<WebsiteLinkIcon />}
             text={t('feature.website')}


### PR DESCRIPTION
Purpose: Hide the website button in the public profile if the user's URL is missing.

Changes:

Added a conditional check for userProfile?.url before rendering the `WebappButton.`
If userProfile?.url is not present, the `my website`  button will not be displayed.