### PR TITLE
Projects redesign/basic mobile structure

### DIFF
--- a/pages/sites/[slug]/[locale]/prd/[p].tsx
+++ b/pages/sites/[slug]/[locale]/prd/[p].tsx
@@ -20,6 +20,7 @@ import {
   PageComponentProps,
   PageProps,
 } from '../../../../_app';
+import MobileProjectsLayout from '../../../../../src/features/common/Layout/ProjectsLayout/MobileProjectsLayout';
 
 const ProjectDetailsPage: NextPageWithLayout = ({ pageProps }) => {
   const router = useRouter();
@@ -44,10 +45,7 @@ ProjectDetailsPage.getLayout = function getLayout(
   pageComponentProps: PageComponentProps
 ): ReactElement {
   return pageComponentProps.isMobile ? (
-    // Temp div, remove when implementing mobile layout
-    <div className="mobile-layout" style={{ marginTop: '100px' }}>
-      {page}
-    </div>
+    <MobileProjectsLayout>{page}</MobileProjectsLayout>
   ) : (
     <ProjectsLayout setCurrencyCode={pageComponentProps.setCurrencyCode}>
       {page}

--- a/pages/sites/[slug]/[locale]/prd/index.tsx
+++ b/pages/sites/[slug]/[locale]/prd/index.tsx
@@ -19,6 +19,7 @@ import {
   PageComponentProps,
   PageProps,
 } from '../../../../_app';
+import MobileProjectsLayout from '../../../../../src/features/common/Layout/ProjectsLayout/MobileProjectsLayout';
 
 const ProjectListPage: NextPageWithLayout = ({ pageProps }) => {
   const router = useRouter();
@@ -43,10 +44,7 @@ ProjectListPage.getLayout = function getLayout(
   pageComponentProps: PageComponentProps
 ): ReactElement {
   return pageComponentProps.isMobile ? (
-    // Temp div, remove when implementing mobile layout
-    <div className="mobile-layout" style={{ marginTop: '100px' }}>
-      {page}
-    </div>
+    <MobileProjectsLayout>{page}</MobileProjectsLayout>
   ) : (
     <ProjectsLayout setCurrencyCode={pageComponentProps.setCurrencyCode}>
       {page}

--- a/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
+++ b/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
@@ -1,0 +1,33 @@
+import { ReactElement, useState } from 'react';
+import style from './ProjectsLayout.module.scss';
+import ProjectsMap from './ProjectsMap';
+import WebappButton from '../../WebappButton';
+
+const MobileProjectsLayout = ({ children }: { children: ReactElement }) => {
+  const [isMap, setIsMap] = useState(false);
+
+  const mobileLayoutClass = `${style.mobileProjectsLayout} ${
+    isMap ? style.compact : ''
+  }`;
+
+  return (
+    <main className={mobileLayoutClass}>
+      <WebappButton
+        text="Map"
+        variant="primary"
+        elementType="button"
+        onClick={() => setIsMap(!isMap)}
+        buttonClasses={style.mapButton}
+      />
+      {isMap ? (
+        <section className={style.mobileMapContainer}>
+          <ProjectsMap />
+        </section>
+      ) : (
+        <section className={style.projectlistAndDetail}>{children}</section>
+      )}
+    </main>
+  );
+};
+
+export default MobileProjectsLayout;

--- a/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
+++ b/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
@@ -7,7 +7,7 @@ const MobileProjectsLayout = ({ children }: { children: ReactElement }) => {
   const [isMapMode, setIsMapMode] = useState(false);
 
   const mobileLayoutClass = `${style.mobileProjectsLayout} ${
-    isMapMode ? style.compact : ''
+    isMapMode ? style.mapMode : ''
   }`;
 
   const viewButtonClass = `${style.viewButton} ${

--- a/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
+++ b/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
@@ -4,27 +4,31 @@ import ProjectsMap from './ProjectsMap';
 import WebappButton from '../../WebappButton';
 
 const MobileProjectsLayout = ({ children }: { children: ReactElement }) => {
-  const [isMap, setIsMap] = useState(false);
+  const [isMapMode, setIsMapMode] = useState(false);
 
   const mobileLayoutClass = `${style.mobileProjectsLayout} ${
-    isMap ? style.compact : ''
+    isMapMode ? style.compact : ''
+  }`;
+
+  const viewButtonClass = `${style.viewButton} ${
+    isMapMode ? style.viewButtonShifted : ''
   }`;
 
   return (
     <main className={mobileLayoutClass}>
       <WebappButton
-        text="Map"
+        text={isMapMode ? 'View Info' : 'View Map'}
         variant="primary"
         elementType="button"
-        onClick={() => setIsMap(!isMap)}
-        buttonClasses={style.mapButton}
+        onClick={() => setIsMapMode(!isMapMode)}
+        buttonClasses={viewButtonClass}
       />
-      {isMap ? (
+      {isMapMode ? (
         <section className={style.mobileMapContainer}>
           <ProjectsMap />
         </section>
       ) : (
-        <section className={style.projectlistAndDetail}>{children}</section>
+        <section className={style.mobileContentContainer}>{children}</section>
       )}
     </main>
   );

--- a/src/features/common/Layout/ProjectsLayout/ProjectsLayout.module.scss
+++ b/src/features/common/Layout/ProjectsLayout/ProjectsLayout.module.scss
@@ -31,3 +31,36 @@
   border-radius: 16px;
   overflow: hidden;
 }
+
+// styles for mobile layout
+
+.mobileProjectsLayout {
+  width: 100%;
+  height: 100vh;
+  position: relative;
+  padding: 100px 5px 20px 5px;
+  display: flex;
+  justify-content: center;
+
+  &.compact {
+    padding: 0px;
+  }
+}
+
+.mapButton {
+  position: absolute;
+  top: 100px;
+  right: 20px;
+  z-index: 1;
+}
+
+.projectlistAndDetail {
+  background: grey;
+  height: 100%;
+  width: 94%;
+}
+
+.mobileMapContainer {
+  width: inherit;
+  height: 100%;
+}

--- a/src/features/common/Layout/ProjectsLayout/ProjectsLayout.module.scss
+++ b/src/features/common/Layout/ProjectsLayout/ProjectsLayout.module.scss
@@ -36,12 +36,13 @@
 
 .mobileProjectsLayout {
   width: 100%;
-  height: calc(100vh - 100px);
+  height: calc(100vh - 80px);
   position: relative;
   display: flex;
   justify-content: center;
-  margin-top: 90px;
-  &.compact {
+  margin-top: 80px;
+  padding-top: 24px;
+  &.mapMode {
     height: 100vh;
     margin-top: 0px;
   }
@@ -60,7 +61,7 @@
 .mobileContentContainer {
   background: grey;
   height: 100%;
-  width: calc(100vw - 20px);
+  width: 100%;
 }
 
 .mobileMapContainer {

--- a/src/features/common/Layout/ProjectsLayout/ProjectsLayout.module.scss
+++ b/src/features/common/Layout/ProjectsLayout/ProjectsLayout.module.scss
@@ -36,28 +36,31 @@
 
 .mobileProjectsLayout {
   width: 100%;
-  height: 100vh;
+  height: calc(100vh - 100px);
   position: relative;
-  padding: 100px 5px 20px 5px;
   display: flex;
   justify-content: center;
-
+  margin-top: 90px;
   &.compact {
-    padding: 0px;
+    height: 100vh;
+    margin-top: 0px;
   }
 }
 
-.mapButton {
+.viewButton {
   position: absolute;
-  top: 100px;
+  top: 13px;
   right: 20px;
   z-index: 1;
+  &.viewButtonShifted {
+    top: 95px;
+  }
 }
 
-.projectlistAndDetail {
+.mobileContentContainer {
   background: grey;
   height: 100%;
-  width: 94%;
+  width: calc(100vw - 20px);
 }
 
 .mobileMapContainer {


### PR DESCRIPTION
summary: Implemented the `MobileProjectsLayout` component to enhance the mobile user experience by allowing users to toggle between a `map view` and a project list/detail view.

How to Test
1.  visit to the route `/locale/prd` for mobile landing page view  
2. Click the "Map" button to toggle between the map view and the project list/detail view.
3. Verify that the layout updates correctly and the styles are applied as expected.