### PR TITLE
Projects redesign/project markers

### DIFF
--- a/public/assets/images/icons/myForestMapIcons/PointMarkerIcons.tsx
+++ b/public/assets/images/icons/myForestMapIcons/PointMarkerIcons.tsx
@@ -1,3 +1,4 @@
+// Todo - move to a common location
 import { IconProps } from '../../../../../src/features/common/types/common';
 
 export const Agroforestry = ({ color }: IconProps) => {

--- a/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
+++ b/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
@@ -1,6 +1,6 @@
 import { FC, useState } from 'react';
 import style from './ProjectsLayout.module.scss';
-import ProjectsMap from './ProjectsMap';
+import ProjectsMap from '../../../projectsV2/ProjectsMap';
 import WebappButton from '../../WebappButton';
 import { SetState } from '../../types/common';
 import { ProjectsProvider } from '../../../projectsV2/ProjectsContext';

--- a/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
+++ b/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
@@ -4,6 +4,7 @@ import ProjectsMap from './ProjectsMap';
 import WebappButton from '../../WebappButton';
 import { SetState } from '../../types/common';
 import { ProjectsProvider } from '../../../projectsV2/ProjectsContext';
+import { ProjectsMapProvider } from '../../../projectsV2/ProjectsMapContext';
 
 interface ProjectsLayoutProps {
   currencyCode: string;
@@ -33,22 +34,26 @@ const MobileProjectsLayout: FC<ProjectsLayoutProps> = ({
       currencyCode={currencyCode}
       setCurrencyCode={setCurrencyCode}
     >
-      <main className={mobileLayoutClass}>
-        <WebappButton
-          text={isMapMode ? 'View Info' : 'View Map'}
-          variant="primary"
-          elementType="button"
-          onClick={() => setIsMapMode(!isMapMode)}
-          buttonClasses={viewButtonClass}
-        />
-        {isMapMode ? (
-          <section className={style.mobileMapContainer}>
-            <ProjectsMap />
-          </section>
-        ) : (
-          <section className={style.mobileContentContainer}>{children}</section>
-        )}
-      </main>
+      <ProjectsMapProvider>
+        <main className={mobileLayoutClass}>
+          <WebappButton
+            text={isMapMode ? 'View Info' : 'View Map'}
+            variant="primary"
+            elementType="button"
+            onClick={() => setIsMapMode(!isMapMode)}
+            buttonClasses={viewButtonClass}
+          />
+          {isMapMode ? (
+            <section className={style.mobileMapContainer}>
+              <ProjectsMap />
+            </section>
+          ) : (
+            <section className={style.mobileContentContainer}>
+              {children}
+            </section>
+          )}
+        </main>
+      </ProjectsMapProvider>
     </ProjectsProvider>
   );
 };

--- a/src/features/common/Layout/ProjectsLayout/ProjectsMap.tsx
+++ b/src/features/common/Layout/ProjectsLayout/ProjectsMap.tsx
@@ -1,54 +1,12 @@
-import { useEffect, useState } from 'react';
-import Map, { MapStyle } from 'react-map-gl-v7/maplibre';
-import getMapStyle from '../../../../utils/maps/getMapStyle';
+import Map from 'react-map-gl-v7/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { NavigationControl } from 'react-map-gl-v7/maplibre';
 import { useRef, MutableRefObject } from 'react';
-import { ViewState } from 'react-map-gl-v7';
-
-interface MapState {
-  mapStyle: MapStyle;
-  dragPan: boolean;
-  scrollZoom: boolean;
-  minZoom: number;
-  maxZoom: number;
-}
-
-const EMPTY_STYLE = {
-  version: 8,
-  sources: {},
-  layers: [] as MapStyle['layers'],
-} as const;
+import { useProjectsMap } from '../../../projectsV2/ProjectsMapContext';
 
 function ProjectsMap() {
   const mapRef: MutableRefObject<null> = useRef(null);
-  // mapState and viewState logic will need to be refined and move elsewhere (either context or props) once we fetch data from the API
-  const [mapState, setMapState] = useState<MapState>({
-    mapStyle: EMPTY_STYLE,
-    dragPan: true,
-    scrollZoom: false,
-    minZoom: 1,
-    maxZoom: 15,
-  });
-
-  const [viewState, setViewState] = useState<ViewState>({
-    longitude: 0,
-    latitude: 0,
-    zoom: 2,
-    bearing: 0,
-    pitch: 0,
-    padding: { top: 0, bottom: 0, left: 0, right: 0 },
-  });
-
-  useEffect(() => {
-    async function loadMapStyle() {
-      const result = await getMapStyle('default');
-      if (result) {
-        setMapState({ ...mapState, mapStyle: result });
-      }
-    }
-    loadMapStyle();
-  }, []);
+  const { viewState, setViewState, mapState } = useProjectsMap();
 
   return (
     <Map

--- a/src/features/common/Layout/ProjectsLayout/index.tsx
+++ b/src/features/common/Layout/ProjectsLayout/index.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import styles from './ProjectsLayout.module.scss';
 import Credits from '../../../projects/components/maps/Credits';
 import { SetState } from '../../types/common';
-import ProjectsMap from './ProjectsMap';
+import ProjectsMap from '../../../projectsV2/ProjectsMap';
 import { ProjectsProvider } from '../../../projectsV2/ProjectsContext';
 import { ProjectsMapProvider } from '../../../projectsV2/ProjectsMapContext';
 

--- a/src/features/common/Layout/ProjectsLayout/index.tsx
+++ b/src/features/common/Layout/ProjectsLayout/index.tsx
@@ -4,6 +4,7 @@ import Credits from '../../../projects/components/maps/Credits';
 import { SetState } from '../../types/common';
 import ProjectsMap from './ProjectsMap';
 import { ProjectsProvider } from '../../../projectsV2/ProjectsContext';
+import { ProjectsMapProvider } from '../../../projectsV2/ProjectsMapContext';
 
 interface ProjectsLayoutProps {
   currencyCode: string;
@@ -23,15 +24,17 @@ const ProjectsLayout: FC<ProjectsLayoutProps> = ({
       currencyCode={currencyCode}
       setCurrencyCode={setCurrencyCode}
     >
-      <div className={styles.projectsLayout}>
-        <main className={styles.mainContent}>
-          <section className={styles.contentContainer}>{children}</section>
-          <section className={styles.mapContainer}>
-            <ProjectsMap />
-          </section>
-        </main>
-        <Credits setCurrencyCode={setCurrencyCode} />
-      </div>
+      <ProjectsMapProvider>
+        <div className={styles.projectsLayout}>
+          <main className={styles.mainContent}>
+            <section className={styles.contentContainer}>{children}</section>
+            <section className={styles.mapContainer}>
+              <ProjectsMap />
+            </section>
+          </main>
+          <Credits setCurrencyCode={setCurrencyCode} />
+        </div>
+      </ProjectsMapProvider>
     </ProjectsProvider>
   );
 };

--- a/src/features/common/types/projectv2.d.ts
+++ b/src/features/common/types/projectv2.d.ts
@@ -1,0 +1,11 @@
+import {
+  ProjectMapInfo,
+  TreeProjectConcise,
+  ConservationProjectConcise,
+} from '@planet-sdk/common/build/types/project/map';
+
+export type MapProjectProperties =
+  | TreeProjectConcise
+  | ConservationProjectConcise;
+
+export type MapProject = ProjectMapInfo<MapProjectProperties>;

--- a/src/features/projectsV2/ProjectsContext.tsx
+++ b/src/features/projectsV2/ProjectsContext.tsx
@@ -6,7 +6,7 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { MapProject } from '../common/types/ProjectPropsContextInterface';
+import { MapProject } from '../common/types/projectv2';
 import { useLocale } from 'next-intl';
 import getStoredCurrency from '../../utils/countryCurrency/getStoredCurrency';
 import { getRequest } from '../../utils/apiRequests/api';

--- a/src/features/projectsV2/ProjectsMap/MultipleProjectsView.tsx
+++ b/src/features/projectsV2/ProjectsMap/MultipleProjectsView.tsx
@@ -1,0 +1,64 @@
+import { useMemo } from 'react';
+import { MapProject } from '../../common/types/projectv2';
+import { useProjects } from '../ProjectsContext';
+import ProjectMarkers from './ProjectMarkers';
+import { getProjectType } from './utils';
+
+type CategorizedProjects = {
+  topApprovedProjects: MapProject[];
+  nonDonatableProjects: MapProject[];
+  regularDonatableProjects: MapProject[];
+};
+
+const MultipleProjectsView = () => {
+  const { projects, isLoading, isError } = useProjects();
+
+  if (isLoading || isError || !projects) {
+    return null;
+  }
+
+  const categorizedProjects = useMemo(() => {
+    return projects.reduce<CategorizedProjects>(
+      (categorizedProjects, project) => {
+        const projectType = getProjectType(project.properties);
+        switch (projectType) {
+          case 'topProject':
+            categorizedProjects.topApprovedProjects.push(project);
+            break;
+          case 'regularProject':
+            categorizedProjects.regularDonatableProjects.push(project);
+            break;
+          case 'nonDonatableProject':
+            categorizedProjects.nonDonatableProjects.push(project);
+            break;
+        }
+        return categorizedProjects;
+      },
+      {
+        topApprovedProjects: [],
+        nonDonatableProjects: [],
+        regularDonatableProjects: [],
+      }
+    );
+  }, [projects, isLoading, isError]);
+
+  const {
+    topApprovedProjects,
+    nonDonatableProjects,
+    regularDonatableProjects,
+  } = categorizedProjects;
+
+  const renderMarkers = (projects: MapProject[]) => (
+    <ProjectMarkers projects={projects} />
+  );
+
+  return (
+    <>
+      {renderMarkers(nonDonatableProjects)}
+      {renderMarkers(regularDonatableProjects)}
+      {renderMarkers(topApprovedProjects)}
+    </>
+  );
+};
+
+export default MultipleProjectsView;

--- a/src/features/projectsV2/ProjectsMap/MultipleProjectsView.tsx
+++ b/src/features/projectsV2/ProjectsMap/MultipleProjectsView.tsx
@@ -1,14 +1,7 @@
 import { useMemo } from 'react';
-import { MapProject } from '../../common/types/projectv2';
 import { useProjects } from '../ProjectsContext';
-import ProjectMarkers from './ProjectMarkers';
+import ProjectMarkers, { CategorizedProjects } from './ProjectMarkers';
 import { getProjectType } from './utils';
-
-type CategorizedProjects = {
-  topApprovedProjects: MapProject[];
-  nonDonatableProjects: MapProject[];
-  regularDonatableProjects: MapProject[];
-};
 
 const MultipleProjectsView = () => {
   const { projects, isLoading, isError } = useProjects();
@@ -42,23 +35,7 @@ const MultipleProjectsView = () => {
     );
   }, [projects, isLoading, isError]);
 
-  const {
-    topApprovedProjects,
-    nonDonatableProjects,
-    regularDonatableProjects,
-  } = categorizedProjects;
-
-  const renderMarkers = (projects: MapProject[]) => (
-    <ProjectMarkers projects={projects} />
-  );
-
-  return (
-    <>
-      {renderMarkers(nonDonatableProjects)}
-      {renderMarkers(regularDonatableProjects)}
-      {renderMarkers(topApprovedProjects)}
-    </>
-  );
+  return <ProjectMarkers categorizedProjects={categorizedProjects} />;
 };
 
 export default MultipleProjectsView;

--- a/src/features/projectsV2/ProjectsMap/MultipleProjectsView.tsx
+++ b/src/features/projectsV2/ProjectsMap/MultipleProjectsView.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useProjects } from '../ProjectsContext';
 import ProjectMarkers, { CategorizedProjects } from './ProjectMarkers';
-import { getProjectType } from './utils';
+import { getProjectCategory } from './utils';
 
 const MultipleProjectsView = () => {
   const { projects, isLoading, isError } = useProjects();
@@ -13,8 +13,8 @@ const MultipleProjectsView = () => {
   const categorizedProjects = useMemo(() => {
     return projects.reduce<CategorizedProjects>(
       (categorizedProjects, project) => {
-        const projectType = getProjectType(project.properties);
-        switch (projectType) {
+        const projectCategory = getProjectCategory(project.properties);
+        switch (projectCategory) {
           case 'topProject':
             categorizedProjects.topApprovedProjects.push(project);
             break;

--- a/src/features/projectsV2/ProjectsMap/ProjectMarkers/ProjectMarkerIcon.tsx
+++ b/src/features/projectsV2/ProjectsMap/ProjectMarkers/ProjectMarkerIcon.tsx
@@ -9,7 +9,7 @@ import {
   UrbanRestoration,
 } from '../../../../../public/assets/images/icons/myForestMapIcons/PointMarkerIcons';
 import { MapProjectProperties } from '../../../common/types/projectv2';
-import { getProjectType } from '../utils';
+import { getProjectCategory } from '../utils';
 import themeProperties from '../../../../theme/themeProperties';
 
 type Props = {
@@ -17,12 +17,12 @@ type Props = {
 };
 
 const ProjectMarkerIcon = ({ projectProperties }: Props) => {
-  const projectType = getProjectType(projectProperties);
+  const projectCategory = getProjectCategory(projectProperties);
 
   const getIconColor = (
-    projectType: 'topProject' | 'regularProject' | 'nonDonatableProject'
+    projectCategory: 'topProject' | 'regularProject' | 'nonDonatableProject'
   ) => {
-    switch (projectType) {
+    switch (projectCategory) {
       case 'topProject':
         return themeProperties.topProjectBackgroundColor;
       case 'regularProject':
@@ -32,7 +32,7 @@ const ProjectMarkerIcon = ({ projectProperties }: Props) => {
     }
   };
 
-  const iconColor = getIconColor(projectType);
+  const iconColor = getIconColor(projectCategory);
 
   // return the correct pin based on project classification and purpose
   if (projectProperties.purpose === 'conservation') {

--- a/src/features/projectsV2/ProjectsMap/ProjectMarkers/ProjectMarkerIcon.tsx
+++ b/src/features/projectsV2/ProjectsMap/ProjectMarkers/ProjectMarkerIcon.tsx
@@ -1,0 +1,62 @@
+import {
+  Agroforestry,
+  Conservation,
+  ManagedRegeneration,
+  Mangroves,
+  NaturalRegeneration,
+  OtherPlanting,
+  TreePlanting,
+  UrbanRestoration,
+} from '../../../../../public/assets/images/icons/myForestMapIcons/PointMarkerIcons';
+import { MapProjectProperties } from '../../../common/types/projectv2';
+import { getProjectType } from '../utils';
+import themeProperties from '../../../../theme/themeProperties';
+
+type Props = {
+  projectProperties: MapProjectProperties;
+};
+
+const ProjectMarkerIcon = ({ projectProperties }: Props) => {
+  const projectType = getProjectType(projectProperties);
+
+  const getIconColor = (
+    projectType: 'topProject' | 'regularProject' | 'nonDonatableProject'
+  ) => {
+    switch (projectType) {
+      case 'topProject':
+        return themeProperties.topProjectBackgroundColor;
+      case 'regularProject':
+        return themeProperties.greenTwo;
+      case 'nonDonatableProject':
+        return themeProperties.nonDonatableProjectBackgroundColor;
+    }
+  };
+
+  const iconColor = getIconColor(projectType);
+
+  // return the correct pin based on project classification and purpose
+  if (projectProperties.purpose === 'conservation') {
+    return <Conservation color={iconColor} />;
+  }
+
+  switch (projectProperties.classification) {
+    case 'natural-regeneration':
+      return <NaturalRegeneration color={iconColor} />;
+    case 'mangroves':
+      return <Mangroves color={iconColor} />;
+    case 'managed-regeneration':
+      return <ManagedRegeneration color={iconColor} />;
+    case 'agroforestry':
+      return <Agroforestry color={iconColor} />;
+    case 'urban-planting':
+      return <UrbanRestoration color={iconColor} />;
+    case 'large-scale-planting':
+      return <TreePlanting color={iconColor} />;
+    case 'other-planting':
+      return <OtherPlanting color={iconColor} />;
+    default:
+      return null;
+  }
+};
+
+export default ProjectMarkerIcon;

--- a/src/features/projectsV2/ProjectsMap/ProjectMarkers/ProjectMarkers.module.scss
+++ b/src/features/projectsV2/ProjectsMap/ProjectMarkers/ProjectMarkers.module.scss
@@ -4,6 +4,7 @@
 
 .marker {
   width: 30px;
+  cursor: pointer;
 
   > svg {
     filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));

--- a/src/features/projectsV2/ProjectsMap/ProjectMarkers/ProjectMarkers.module.scss
+++ b/src/features/projectsV2/ProjectsMap/ProjectMarkers/ProjectMarkers.module.scss
@@ -1,0 +1,11 @@
+.markerContainer {
+  position: relative;
+}
+
+.marker {
+  width: 30px;
+
+  > svg {
+    filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+  }
+}

--- a/src/features/projectsV2/ProjectsMap/ProjectMarkers/SingleMarker.tsx
+++ b/src/features/projectsV2/ProjectsMap/ProjectMarkers/SingleMarker.tsx
@@ -1,0 +1,46 @@
+import { Marker } from 'react-map-gl-v7';
+import ProjectMarkerIcon from './ProjectMarkerIcon';
+import { MapProject } from '../../../common/types/projectv2';
+import styles from './ProjectMarkers.module.scss';
+
+type Props = {
+  project: MapProject;
+  onMouseOver: () => void;
+  onMouseLeave: () => void;
+  visitProject: (projectSlug: string) => void;
+};
+
+const SingleMarker = ({
+  project,
+  onMouseOver,
+  onMouseLeave,
+  visitProject,
+}: Props) => {
+  return (
+    <>
+      <Marker
+        latitude={project.geometry.coordinates[1]}
+        longitude={project.geometry.coordinates[0]}
+        anchor="bottom"
+        offset={[0, 0]}
+      >
+        <div className={styles.markerContainer}>
+          <div
+            className={styles.marker}
+            onClick={() => visitProject(project.properties.slug)}
+            onKeyDown={() => visitProject(project.properties.slug)}
+            role="button"
+            tabIndex={0}
+            onFocus={() => {}} //Do we want to allow keyboard navigation for the map? In that case, perhaps we should make it obvious that the marker is focused
+            onMouseOver={onMouseOver}
+            onMouseLeave={onMouseLeave}
+          >
+            <ProjectMarkerIcon projectProperties={project.properties} />
+          </div>
+        </div>
+      </Marker>
+    </>
+  );
+};
+
+export default SingleMarker;

--- a/src/features/projectsV2/ProjectsMap/ProjectMarkers/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/ProjectMarkers/index.tsx
@@ -1,0 +1,59 @@
+import { Marker } from 'react-map-gl-v7/maplibre';
+import { MapProject } from '../../../common/types/projectv2';
+import styles from './ProjectMarkers.module.scss';
+import router from 'next/router';
+import { useLocale } from 'next-intl';
+import { useContext } from 'react';
+import { ParamsContext } from '../../../common/Layout/QueryParamsContext';
+import ProjectMarkerIcon from './ProjectMarkerIcon';
+
+interface ProjectMarkersProps {
+  projects: MapProject[];
+}
+
+const ProjectMarkers = ({ projects }: ProjectMarkersProps) => {
+  const locale = useLocale();
+  const { embed, callbackUrl } = useContext(ParamsContext);
+
+  const visitProject = (projectSlug: string): void => {
+    router.push(
+      `/${locale}/${projectSlug}/${
+        embed === 'true'
+          ? `${
+              callbackUrl != undefined
+                ? `?embed=true&callback=${callbackUrl}`
+                : '?embed=true'
+            }`
+          : ''
+      }`
+    );
+  };
+
+  return (
+    <>
+      {projects.map((project) => (
+        <Marker
+          key={project.properties.id}
+          latitude={project.geometry.coordinates[1]}
+          longitude={project.geometry.coordinates[0]}
+          anchor="bottom"
+          offset={[0, 0]}
+        >
+          <div className={styles.markerContainer}>
+            <div
+              className={styles.marker}
+              onClick={() => visitProject(project.properties.slug)}
+              onKeyDown={() => visitProject(project.properties.slug)}
+              role="button"
+              tabIndex={0}
+              onFocus={() => {}} //Do we want to allow keyboard navigation for the map? In that case, perhaps we should make it obvious that the marker is focused
+            >
+              <ProjectMarkerIcon projectProperties={project.properties} />
+            </div>
+          </div>
+        </Marker>
+      ))}
+    </>
+  );
+};
+export default ProjectMarkers;

--- a/src/features/projectsV2/ProjectsMap/ProjectMarkers/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/ProjectMarkers/index.tsx
@@ -17,7 +17,7 @@ const ProjectMarkers = ({ projects }: ProjectMarkersProps) => {
 
   const visitProject = (projectSlug: string): void => {
     router.push(
-      `/${locale}/${projectSlug}/${
+      `/${locale}/prd/${projectSlug}/${
         embed === 'true'
           ? `${
               callbackUrl != undefined

--- a/src/features/projectsV2/ProjectsMap/ProjectPopup/ProjectPopup.module.scss
+++ b/src/features/projectsV2/ProjectsMap/ProjectPopup/ProjectPopup.module.scss
@@ -1,0 +1,3 @@
+.projectPopup :global(.maplibregl-popup-tip) {
+  display: none;
+}

--- a/src/features/projectsV2/ProjectsMap/ProjectPopup/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/ProjectPopup/index.tsx
@@ -1,0 +1,33 @@
+import { Popup } from 'react-map-gl-v7/maplibre';
+import { MapProject } from '../../../common/types/projectv2';
+import styles from './ProjectPopup.module.scss';
+
+type Props = {
+  project: MapProject;
+  handlePopupLeave: () => void;
+  visitProject: (projectSlug: string) => void;
+};
+
+const ProjectPopup = ({ project, handlePopupLeave, visitProject }: Props) => {
+  const { coordinates } = project.geometry;
+
+  return (
+    <Popup
+      latitude={coordinates[1]}
+      longitude={coordinates[0]}
+      closeButton={false}
+      className={styles.projectPopup}
+    >
+      <div
+        onMouseLeave={handlePopupLeave}
+        onClick={() => visitProject(project.properties.slug)}
+        onKeyDown={() => visitProject(project.properties.slug)}
+      >
+        {/* Dummy content to be replaced with actual ProjectSnippet once ready */}
+        <h3>{project.properties.name}</h3>
+      </div>
+    </Popup>
+  );
+};
+
+export default ProjectPopup;

--- a/src/features/projectsV2/ProjectsMap/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/index.tsx
@@ -3,10 +3,13 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import { NavigationControl } from 'react-map-gl-v7/maplibre';
 import { useRef, MutableRefObject } from 'react';
 import { useProjectsMap } from '../ProjectsMapContext';
+import MultipleProjectsView from './MultipleProjectsView';
+import { useProjects } from '../ProjectsContext';
 
 function ProjectsMap() {
   const mapRef: MutableRefObject<null> = useRef(null);
   const { viewState, setViewState, mapState } = useProjectsMap();
+  const { projects } = useProjects();
 
   return (
     <Map
@@ -16,6 +19,7 @@ function ProjectsMap() {
       attributionControl={false}
       ref={mapRef}
     >
+      {projects && <MultipleProjectsView />}
       <NavigationControl position="bottom-right" showCompass={false} />
     </Map>
   );

--- a/src/features/projectsV2/ProjectsMap/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/index.tsx
@@ -2,7 +2,7 @@ import Map from 'react-map-gl-v7/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { NavigationControl } from 'react-map-gl-v7/maplibre';
 import { useRef, MutableRefObject } from 'react';
-import { useProjectsMap } from '../../../projectsV2/ProjectsMapContext';
+import { useProjectsMap } from '../ProjectsMapContext';
 
 function ProjectsMap() {
   const mapRef: MutableRefObject<null> = useRef(null);

--- a/src/features/projectsV2/ProjectsMap/utils.tsx
+++ b/src/features/projectsV2/ProjectsMap/utils.tsx
@@ -1,0 +1,11 @@
+import { MapProjectProperties } from '../../common/types/projectv2';
+
+export const getProjectType = (projectProperties: MapProjectProperties) => {
+  return projectProperties.purpose === 'trees' &&
+    projectProperties.isTopProject &&
+    projectProperties.isApproved
+    ? 'topProject'
+    : projectProperties.allowDonations
+    ? 'regularProject'
+    : 'nonDonatableProject';
+};

--- a/src/features/projectsV2/ProjectsMap/utils.tsx
+++ b/src/features/projectsV2/ProjectsMap/utils.tsx
@@ -1,11 +1,15 @@
 import { MapProjectProperties } from '../../common/types/projectv2';
 
-export const getProjectType = (projectProperties: MapProjectProperties) => {
-  return projectProperties.purpose === 'trees' &&
+export const getProjectCategory = (projectProperties: MapProjectProperties) => {
+  if (
+    projectProperties.purpose === 'trees' &&
     projectProperties.isTopProject &&
     projectProperties.isApproved
-    ? 'topProject'
-    : projectProperties.allowDonations
-    ? 'regularProject'
-    : 'nonDonatableProject';
+  ) {
+    return 'topProject';
+  } else if (projectProperties.allowDonations) {
+    return 'regularProject';
+  } else {
+    return 'nonDonatableProject';
+  }
 };

--- a/src/features/projectsV2/ProjectsMapContext.tsx
+++ b/src/features/projectsV2/ProjectsMapContext.tsx
@@ -1,0 +1,87 @@
+import {
+  FC,
+  useContext,
+  useMemo,
+  createContext,
+  useState,
+  useEffect,
+} from 'react';
+import { ViewState } from 'react-map-gl-v7';
+import { MapStyle } from 'react-map-gl-v7/maplibre';
+import getMapStyle from '../../utils/maps/getMapStyle';
+import { SetState } from '../common/types/common';
+
+interface MapState {
+  mapStyle: MapStyle;
+  dragPan: boolean;
+  scrollZoom: boolean;
+  minZoom: number;
+  maxZoom: number;
+}
+
+const EMPTY_STYLE = {
+  version: 8,
+  sources: {},
+  layers: [] as MapStyle['layers'],
+} as const;
+
+const DEFAULT_VIEW_STATE: ViewState = {
+  longitude: 0,
+  latitude: 0,
+  zoom: 2,
+  bearing: 0,
+  pitch: 0,
+  padding: { top: 0, bottom: 0, left: 0, right: 0 },
+};
+
+const DEFAULT_MAP_STATE: MapState = {
+  mapStyle: EMPTY_STYLE,
+  dragPan: true,
+  scrollZoom: false,
+  minZoom: 1,
+  maxZoom: 15,
+};
+
+interface ProjectsMapState {
+  viewState: ViewState;
+  setViewState: SetState<ViewState>;
+  mapState: MapState;
+}
+
+const ProjectsMapContext = createContext<ProjectsMapState | null>(null);
+
+export const ProjectsMapProvider: FC = ({ children }) => {
+  const [mapState, setMapState] = useState<MapState>(DEFAULT_MAP_STATE);
+  const [viewState, setViewState] = useState<ViewState>(DEFAULT_VIEW_STATE);
+
+  useEffect(() => {
+    async function loadMapStyle() {
+      const result = await getMapStyle('default');
+      if (result) {
+        setMapState({ ...mapState, mapStyle: result });
+      }
+    }
+    loadMapStyle();
+  }, []);
+
+  const value: ProjectsMapState | null = useMemo(
+    () => ({ mapState, viewState, setViewState }),
+    [mapState, viewState]
+  );
+
+  return (
+    <ProjectsMapContext.Provider value={value}>
+      {children}
+    </ProjectsMapContext.Provider>
+  );
+};
+
+export const useProjectsMap = (): ProjectsMapState => {
+  const context = useContext(ProjectsMapContext);
+  if (!context) {
+    throw new Error(
+      'ProjectsMapContext must be used within ProjectsMapProvider'
+    );
+  }
+  return context;
+};

--- a/src/theme/themeProperties.ts
+++ b/src/theme/themeProperties.ts
@@ -43,6 +43,7 @@ const themeProperties = {
   restorationToggleColorNew: '#2f80ed',
   deforestrationToggleColorNew: 'rgba(235, 87, 87, 1)',
   exploreDescriptionBackground: '242, 242, 242',
+  greenTwo: '#27ae60',
   light: {
     primaryFontColor: '#2f3336',
     dividerColor: '#d5d5d5',


### PR DESCRIPTION
1. Sets up an initial ProjectsMap context
2. Shows project markers on the project list map through the MultipleProjectsView
3. Adds popup functionality (only project name currently shown, to be replaced with ProjectSnippet when ready), and container UI
4. Memoizes marker rendering for smoother map performance

While based on the existing code in [src/features/projects/components/maps/Markers.tsx](https://github.com/Plant-for-the-Planet-org/planet-webapp/blob/2bc9a5c41508f8f8924483a676e8573a50f8e92f/src/features/projects/components/maps/Markers.tsx), the new code uses SVGs for the complete marker instead of a rotated div (similar to my forest v2) while showing the markers, to avoid having 2 different approaches for a similar UI.