### PR TITLE
Restrict profile contributions data to purpose = trees/conservation

### DIFF
--- a/src/server/procedures/myForestV2/contributions.ts
+++ b/src/server/procedures/myForestV2/contributions.ts
@@ -86,9 +86,9 @@ async function fetchContributions(
 				contribution c
 			WHERE
 				c.deleted_at is null AND 
-				c.profile_id IN (${Prisma.join(profileIds)}) AND
+				c.profile_id IN (${Prisma.join(profileIds)}) AND 
 				(
-					(c.contribution_type = 'donation' AND c.payment_status = 'paid')
+					(c.contribution_type = 'donation' AND c.payment_status = 'paid' AND c.purpose IN ('trees', 'conservation'))
 					OR 
 					(c.contribution_type = 'planting' AND c.is_verified = '1')
 				)


### PR DESCRIPTION
This pull request fixes an issue where profile contributions data was not properly restricted to the purpose of trees or conservation. The code change ensures that only contributions with the purpose of trees or conservation are included in the data.