### PR TITLE
Fix profile contributions restriction and theme color

### DIFF
--- a/src/features/common/InputTypes/NewToggleSwitch.tsx
+++ b/src/features/common/InputTypes/NewToggleSwitch.tsx
@@ -26,7 +26,7 @@ export default function NewToggleSwitch(props: ToggleSwitchProps) {
         transform: 'translateX(24px)',
         color: '#fff',
         '& + .MuiSwitch-track': {
-          backgroundColor: theme.primaryDarkColorX,
+          backgroundColor: theme.primaryColorNew,
           opacity: 1,
           border: 0,
         },

--- a/src/features/user/MFV2/ContributionsMap/Markers/ProjectTypeIcon.tsx
+++ b/src/features/user/MFV2/ContributionsMap/Markers/ProjectTypeIcon.tsx
@@ -31,9 +31,9 @@ const ProjectTypeIcon = ({
       case 'trees':
         return unitType === 'm2'
           ? themeProperties.electricPurpleColor
-          : themeProperties.primaryDarkColorX;
+          : themeProperties.primaryColorNew;
       default:
-        return themeProperties.primaryDarkColorX;
+        return themeProperties.primaryColorNew;
     }
   };
   const pointMarkerColor = useMemo(

--- a/src/server/procedures/myForestV2/contributions.ts
+++ b/src/server/procedures/myForestV2/contributions.ts
@@ -88,7 +88,7 @@ async function fetchContributions(
 				c.deleted_at is null AND 
 				c.profile_id IN (${Prisma.join(profileIds)}) AND
 				(
-					(c.contribution_type = 'donation' AND c.payment_status = 'paid')
+					(c.contribution_type = 'donation' AND c.payment_status = 'paid' AND c.purpose IN ('trees', 'conservation'))
 					OR 
 					(c.contribution_type = 'planting' AND c.is_verified = '1')
 				)

--- a/src/utils/myForestV2Utils.ts
+++ b/src/utils/myForestV2Utils.ts
@@ -19,14 +19,14 @@ export type Accumulator = {
  */
 
 export const getColor = (purpose: ProjectPurposeTypes, unitType: UnitTypes) => {
-  const { primaryDarkColorX, electricPurpleColor, mediumBlueColor } =
+  const { primaryColorNew, electricPurpleColor, mediumBlueColor } =
     themeProperties;
   if (unitType === 'm2' && purpose === 'trees') {
     return electricPurpleColor;
   } else if (purpose === 'conservation') {
     return mediumBlueColor;
   } else {
-    return primaryDarkColorX;
+    return primaryColorNew;
   }
 };
 


### PR DESCRIPTION
1. Fixes a bug where profile contributions were not being restricted to purpose = trees/conservation. 
2. Also, replaces the renamed theme color `primaryDarkColorX` with `primaryColorNew` in multiple files.