### PR TITLE
Use higher resolution image for nav avatar

### DIFF
--- a/src/features/common/Layout/Navbar/Navbar.scss
+++ b/src/features/common/Layout/Navbar/Navbar.scss
@@ -211,6 +211,7 @@
   cursor: pointer;
   > img {
     border-radius: 50%;
+    height: 50px;
     @include xsPhoneView {
       height: 24px;
     }

--- a/src/features/common/Layout/Navbar/microComponents/UserProfileButton.tsx
+++ b/src/features/common/Layout/Navbar/microComponents/UserProfileButton.tsx
@@ -38,7 +38,7 @@ const UserProfileButton = () => {
       onClick={() => router.push(`/profile`)}
     >
       {user.image ? (
-        <img src={getImageUrl('profile', 'avatar', user.image)} alt="Profile" />
+        <img src={getImageUrl('profile', 'thumb', user.image)} alt="Profile" />
       ) : (
         <div className="userDefaultIconContainer">
           <DefaultProfileImageIcon />


### PR DESCRIPTION
This pull request fixes an issue where a low-resolution image was being used for the navigation menu avatar. The commit updates the code to use a higher resolution image for the avatar, improving the visual quality.