### PR TITLE
Fix issue with login button on small screens (Apple devices)

### DIFF
--- a/src/features/common/Layout/Navbar/Navbar.scss
+++ b/src/features/common/Layout/Navbar/Navbar.scss
@@ -201,8 +201,13 @@
 
 .mobileSignInButton {
   width: 24px;
+  height: 24px;
   display: flex;
   align-items: center;
+
+  svg {
+    height: 100%;
+  }
 }
 
 .profileImageButton {
@@ -222,6 +227,9 @@
     @include xsPhoneView {
       width: 24px;
       height: 24px;
+    }
+    svg {
+      height: 100%;
     }
   }
 }


### PR DESCRIPTION
This pull request resolves an issue where the login/profile button was hidden on small screens, specifically on Apple devices. 

The changes include adding a height property to the .mobileSignInButton class and updating the svg height property to 100% in both the .mobileSignInButton and .profileImageButton classes.