### PR TITLE
Remove unused axios dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -133,7 +133,6 @@
         "@typescript-eslint/eslint-plugin": "^5.41.0",
         "@typescript-eslint/parser": "^5.41.0",
         "ajv": "^8.16.0",
-        "axios": "^1.6.0",
         "babel-core": "^6.26.3",
         "babel-loader": "^7.1.5",
         "chromatic": "^6.24.1",
@@ -12267,17 +12266,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
-      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {

--- a/package.json
+++ b/package.json
@@ -166,7 +166,6 @@
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",
     "ajv": "^8.16.0",
-    "axios": "^1.6.0",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
     "chromatic": "^6.24.1",


### PR DESCRIPTION
This pull request removes the unused axios dependency from the project. The axios package was previously included in the dependencies but was not being used in the codebase directly. 

This does not affect places where axios is a sub-dependency of another package (like layer-manager and vizzuality-components)