### PR TITLE
Update @emotion dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "dependencies": {
         "@auth0/auth0-react": "^1.6.0",
         "@date-io/date-fns": "1.3.13",
-        "@emotion/react": "^11.11.1",
+        "@emotion/react": "^11.13.3",
         "@emotion/server": "^11.11.0",
-        "@emotion/styled": "^11.11.0",
+        "@emotion/styled": "^11.13.0",
         "@formatjs/intl-localematcher": "^0.5.4",
         "@mapbox/mapbox-gl-draw": "^1.3.0",
         "@mapbox/togeojson": "^0.16.1",
@@ -107,8 +107,8 @@
       },
       "devDependencies": {
         "@babel/plugin-transform-unicode-regex": "^7.23.3",
-        "@emotion/babel-plugin": "^11.9.2",
-        "@emotion/eslint-plugin": "^11.7.0",
+        "@emotion/babel-plugin": "^11.12.0",
+        "@emotion/eslint-plugin": "^11.12.0",
         "@hookform/devtools": "^4.3.1",
         "@storybook/addon-actions": "^7.6.7",
         "@storybook/addon-essentials": "^7.6.7",
@@ -2624,14 +2624,14 @@
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
     },
     "node_modules/@emotion/react": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.13.0.tgz",
-      "integrity": "sha512-WkL+bw1REC2VNV1goQyfxjx1GYJkcc23CRQkXX+vZNLINyfI7o+uUn/rTGPt/xJ3bJHd5GcljgnxHf4wRw5VWQ==",
+      "version": "11.13.3",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.13.3.tgz",
+      "integrity": "sha512-lIsdU6JNrmYfJ5EbUCf4xW1ovy5wKQ2CkPRM4xogziOxH1nXxBSjpC9YqbFAP7circxMfYp+6x676BqWcEiixg==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.12.0",
         "@emotion/cache": "^11.13.0",
-        "@emotion/serialize": "^1.3.0",
+        "@emotion/serialize": "^1.3.1",
         "@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
         "@emotion/utils": "^1.4.0",
         "@emotion/weak-memoize": "^0.4.0",
@@ -2647,13 +2647,13 @@
       }
     },
     "node_modules/@emotion/serialize": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.0.tgz",
-      "integrity": "sha512-jACuBa9SlYajnpIVXB+XOXnfJHyckDfe6fOpORIM6yhBDlqGuExvDdZYHDQGoDf3bZXGv7tNr+LpLjJqiEQ6EA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.1.tgz",
+      "integrity": "sha512-dEPNKzBPU+vFPGa+z3axPRn8XVDetYORmDC0wAiej+TNcOZE70ZMJa0X7JdeoM6q/nWTMZeLpN/fTnD9o8MQBA==",
       "dependencies": {
         "@emotion/hash": "^0.9.2",
         "@emotion/memoize": "^0.9.0",
-        "@emotion/unitless": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
         "@emotion/utils": "^1.4.0",
         "csstype": "^3.0.2"
       }
@@ -2705,9 +2705,9 @@
       }
     },
     "node_modules/@emotion/unitless": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.9.0.tgz",
-      "integrity": "sha512-TP6GgNZtmtFaFcsOgExdnfxLLpRDla4Q66tnenA9CktvVSdNKDvMVuUah4QvWPIpNjrWsGg3qeGo9a43QooGZQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
   "dependencies": {
     "@auth0/auth0-react": "^1.6.0",
     "@date-io/date-fns": "1.3.13",
-    "@emotion/react": "^11.11.1",
+    "@emotion/react": "^11.13.3",
     "@emotion/server": "^11.11.0",
-    "@emotion/styled": "^11.11.0",
+    "@emotion/styled": "^11.13.0",
     "@formatjs/intl-localematcher": "^0.5.4",
     "@mapbox/mapbox-gl-draw": "^1.3.0",
     "@mapbox/togeojson": "^0.16.1",
@@ -140,8 +140,8 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-unicode-regex": "^7.23.3",
-    "@emotion/babel-plugin": "^11.9.2",
-    "@emotion/eslint-plugin": "^11.7.0",
+    "@emotion/babel-plugin": "^11.12.0",
+    "@emotion/eslint-plugin": "^11.12.0",
     "@hookform/devtools": "^4.3.1",
     "@storybook/addon-actions": "^7.6.7",
     "@storybook/addon-essentials": "^7.6.7",


### PR DESCRIPTION
This pull request updates the @emotion dependencies to the latest versions. 

- updates @emotion/react from version 11.11.1 to 11.13.3 
- updates @emotion/styled from version 11.11.0 to 11.13.0. 
- updates @emotion/babel-plugin and @emotion/eslint-plugin from versions 11.9.2 and 11.7.0 to version 11.12.0.