### PR TITLE
changed appDomain for default tenant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@mui/x-date-pickers": "^5.0.15",
         "@netlify/plugin-nextjs": "^4.33.0",
         "@next/bundle-analyzer": "^10.2.3",
-        "@planet-sdk/common": "^0.1.40",
+        "@planet-sdk/common": "^0.1.41",
         "@prisma/client": "^4.13.0",
         "@sentry/browser": "^6.15.0",
         "@sentry/integrations": "^6.19.2",
@@ -5511,9 +5511,9 @@
       }
     },
     "node_modules/@planet-sdk/common": {
-      "version": "0.1.40",
-      "resolved": "https://registry.npmjs.org/@planet-sdk/common/-/common-0.1.40.tgz",
-      "integrity": "sha512-Th3fvy3DU6tNYgK562QNFD2UvL7iKbsyhc18PP9HaimnMczXOoXChrVNI7RNrLq5iS6t6LRnZ4kjCPCV2nrgZg==",
+      "version": "0.1.41",
+      "resolved": "https://registry.npmjs.org/@planet-sdk/common/-/common-0.1.41.tgz",
+      "integrity": "sha512-GNl6UORtHI5t3UNisTHsONn9X/ZFJphnZvChmsWQtV0h9kCxberkdZxSyUSnWgzwHeupuiyl/RK0pYbxFgqH5g==",
       "dependencies": {
         "@types/geojson": "^7946.0.10"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@mui/x-date-pickers": "^5.0.15",
     "@netlify/plugin-nextjs": "^4.33.0",
     "@next/bundle-analyzer": "^10.2.3",
-    "@planet-sdk/common": "^0.1.40",
+    "@planet-sdk/common": "^0.1.41",
     "@prisma/client": "^4.13.0",
     "@sentry/browser": "^6.15.0",
     "@sentry/integrations": "^6.19.2",

--- a/tenant.config.ts
+++ b/tenant.config.ts
@@ -7,8 +7,8 @@ export const defaultTenant: Tenant = {
     externalUrl: 'https://web.plant-for-the-planet.org',
     customDomain: 'https://web.plant-for-the-planet.org',
     font: {
-      primaryFontURL: null,
-      secondaryFontURL: null,
+      primaryFontURL: undefined,
+      secondaryFontURL: undefined,
       primaryFontFamily:
         '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"',
       secondaryFontFamily:
@@ -97,14 +97,7 @@ export const defaultTenant: Tenant = {
       isSecondaryTenant: false,
     },
     manifest: '/tenants/planet/manifest.json',
-    languages: {
-      '0': 'en',
-      '1': 'de',
-      '2': 'es',
-      '3': 'fr',
-      '4': 'it',
-      '6': 'cs',
-    },
+    languages: ['en', 'de', 'es', 'fr', 'it', 'pt-BR', 'cs'],
     tenantURL: 'web.plant-for-the-planet.org',
     tenantGoal: null,
     footerLinks: [

--- a/tenant.config.ts
+++ b/tenant.config.ts
@@ -7,8 +7,8 @@ export const defaultTenant: Tenant = {
     externalUrl: 'https://web.plant-for-the-planet.org',
     customDomain: 'https://web.plant-for-the-planet.org',
     font: {
-      primaryFontURL: undefined,
-      secondaryFontURL: undefined,
+      primaryFontURL: null,
+      secondaryFontURL: null,
       primaryFontFamily:
         '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"',
       secondaryFontFamily:

--- a/tenant.config.ts
+++ b/tenant.config.ts
@@ -3,7 +3,7 @@ import { Tenant } from '@planet-sdk/common/build/types/tenant';
 export const defaultTenant: Tenant = {
   id: 'ten_NxJq55pm',
   config: {
-    appDomain: 'https://www1.plant-for-the-planet.org',
+    appDomain: 'https://web.plant-for-the-planet.org',
     slug: 'planet',
     tenantURL: 'www.plant-for-the-planet.org',
     tenantGoal: null,

--- a/tenant.config.ts
+++ b/tenant.config.ts
@@ -3,77 +3,69 @@ import { Tenant } from '@planet-sdk/common/build/types/tenant';
 export const defaultTenant: Tenant = {
   id: 'ten_NxJq55pm',
   config: {
-    appDomain: 'https://web.plant-for-the-planet.org',
-    slug: 'planet',
-    tenantURL: 'www.plant-for-the-planet.org',
-    tenantGoal: null,
-    showUNEPLogo: true,
-    showUNDecadeLogo: true,
-    showRedeemHint: true,
-    enableGuestSepa: false,
-    darkModeEnabled: false,
+    appDomain: 'https://web.plant-for-the-planet.org/',
+    externalUrl: 'https://web.plant-for-the-planet.org',
+    customDomain: 'https://web.plant-for-the-planet.org',
     font: {
+      primaryFontURL: null,
+      secondaryFontURL: null,
       primaryFontFamily:
         '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"',
       secondaryFontFamily:
         '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"',
     },
-    languages: ['en', 'de', 'es', 'fr', 'it', 'pt-BR', 'cs'],
+    meta: {
+      image:
+        'https://cdn.plant-for-the-planet.org/media/images/app/bg_layer.jpg',
+      title: 'Plant trees around the world - Plant-for-the-Planet',
+      locale: 'en_US',
+      appTitle: 'Plant for the Planet',
+      description:
+        "We are children and youth on a mission: bring back a trillion trees! No matter where you are, it's never been easier to plant trees and become part of the fight against climate crisis.",
+      twitterHandle: '',
+    },
+    slug: 'planet',
     header: {
-      isSecondaryTenant: false,
-      tenantLogoURL: 'https://cdn.plant-for-the-planet.org/logo/svg/planet.svg',
-      tenantLogoLink: '/',
       items: [
-        {
-          title: 'home',
-          onclick: '/',
-          visible: true,
-          headerKey: 'home',
-        },
-        {
-          title: 'shop',
-          onclick: 'https://thegoodshop.org',
-          visible: true,
-          headerKey: 'shop',
-        },
+        { title: 'home', onclick: '/', visible: true, headerKey: 'home' },
         {
           title: 'aboutUs',
-          onclick: 'https://a.plant-for-the-planet.org/',
+          onclick: 'https://www.plant-for-the-planet.org/',
           subMenu: [
             {
               title: 'overview',
-              onclick: 'https://a.plant-for-the-planet.org/',
+              onclick: 'https://www.plant-for-the-planet.org/',
               visible: true,
             },
             {
               title: 'childrenAndYouth',
-              onclick: 'https://a.plant-for-the-planet.org/children-youth/',
+              onclick: 'https://www.plant-for-the-planet.org/children-youth/',
               visible: true,
             },
             {
               title: 'trillionTrees',
-              onclick: 'https://a.plant-for-the-planet.org/trillion-trees/',
+              onclick: 'https://www.plant-for-the-planet.org/trillion-trees/',
               visible: true,
             },
             {
               title: 'yucatan',
-              onclick: 'https://a.plant-for-the-planet.org/yucatan/',
+              onclick: 'https://www.plant-for-the-planet.org/yucatan/',
               visible: true,
             },
             {
               title: 'partners',
-              onclick: 'https://a.plant-for-the-planet.org/partners/',
+              onclick: 'https://www.plant-for-the-planet.org/partners/',
               visible: true,
             },
             {
               title: 'changeChocolate',
-              onclick: 'https://a.plant-for-the-planet.org/change-chocolate/',
+              onclick: 'https://www.plant-for-the-planet.org/change-chocolate/',
               visible: true,
             },
             {
               title: 'stopTalkingStartPlanting',
               onclick:
-                'https://a.plant-for-the-planet.org/stop-talking-start-planting/',
+                'https://www.plant-for-the-planet.org/stop-talking-start-planting/',
               visible: true,
             },
           ],
@@ -93,18 +85,28 @@ export const defaultTenant: Tenant = {
           headerKey: 'me',
           loggedInTitle: 'me',
         },
+        {
+          title: 'shop',
+          onclick: 'https://thegoodshop.org',
+          visible: false,
+          headerKey: 'shop',
+        },
       ],
+      tenantLogoURL: 'https://cdn.plant-for-the-planet.org/logo/svg/planet.svg',
+      tenantLogoLink: '/',
+      isSecondaryTenant: false,
     },
-    meta: {
-      title: 'Plant trees around the world - Plant-for-the-Planet',
-      appTitle: 'Plant for the Planet',
-      description:
-        "We are children and youth on a mission: bring back a trillion trees! No matter where you are, it's never been easier to plant trees and become part of the fight against climate crisis.",
-      image:
-        'https://cdn.plant-for-the-planet.org/media/images/app/bg_layer.jpg',
-      twitterHandle: '',
-      locale: 'en_US',
+    manifest: '/tenants/planet/manifest.json',
+    languages: {
+      '0': 'en',
+      '1': 'de',
+      '2': 'es',
+      '3': 'fr',
+      '4': 'it',
+      '6': 'cs',
     },
+    tenantURL: 'web.plant-for-the-planet.org',
+    tenantGoal: null,
     footerLinks: [
       'shop',
       'privacy',
@@ -119,15 +121,18 @@ export const defaultTenant: Tenant = {
       'blogs',
       'faqs',
     ],
-    manifest: '/tenants/planet/manifest.json',
+    showUNEPLogo: true,
+    showRedeemHint: true,
+    darkModeEnabled: false,
+    enableGuestSepa: false,
+    fallbackCurrency: null,
+    showUNDecadeLogo: true,
   },
-  images: {
-    featuredImage: null,
-    bannerImage: null,
-  },
+  images: { featuredImage: null, bannerImage: null },
   name: 'Plant-for-the-Planet',
   description:
     'This Tenant is used for Beta version of the  Plant-for-the-Planet Web App. At the end of the beta period, all donations will be re-associated to the main Plant-for-the-Planet Tenant',
+  topProjectsOnly: false,
   image: null,
-  tenantGoal: null,
+  tenantGoal: 2147483647,
 };


### PR DESCRIPTION
Fixes #

Changes in this pull request:
- changed `appDomain` from `www1.` for default tenant to `web.`
- updated `defaultTenant` from API response of https://app.plant-for-the-planet.org/app/tenants/ten_NxJq55pm?_scope=deployment, but already set `appDomain` right and removed `auth0ClientId`
- adapted two returned values for `languages` and `font` as to apply to the type of `TenantConfig`

Open issue:
- the type of `header.items` of `TenantConfig` does not apply to the current values really used

@Shreyaschorge I am not sure of the effect  this has and wanted to ask why this value wasn't yet changed?