### PR TITLE
Update webapp to adapt for new plant locations API

### DIFF
--- a/pages/api/data-explorer/export.ts
+++ b/pages/api/data-explorer/export.ts
@@ -17,25 +17,25 @@ handler.post(async (req, response) => {
   try {
     const query =
       "SELECT \
-          pl.hid, \
-          pl.plant_date, \
-          COALESCE(ss.name, ps.other_species, pl.other_species) AS species, \
-          CASE WHEN pl.type='single' THEN 1 ELSE ps.tree_count END AS tree_count, \
-          pl.geometry, \
-          pl.type, \
-          pl.trees_allocated, \
-          pl.trees_planted, \
-          pl.metadata, \
-          pl.description, \
-          pl.plant_project_id, \
-          pl.sample_tree_count, \
-          pl.capture_status, \
-          pl.created \
-      FROM plant_location pl \
-      LEFT JOIN planted_species ps ON ps.plant_location_id = pl.id \
+          iv.hid, \
+          iv.intervention_date, \
+          COALESCE(ss.name, ps.other_species, iv.other_species) AS species, \
+          CASE WHEN iv.type='single-tree-registration' THEN 1 ELSE ps.tree_count END AS tree_count, \
+          iv.geometry, \
+          iv.type, \
+          iv.trees_allocated, \
+          iv.trees_planted, \
+          iv.metadata, \
+          iv.description, \
+          iv.plant_project_id, \
+          iv.sample_tree_count, \
+          iv.capture_status, \
+          iv.created \
+      FROM intervention iv \
+      LEFT JOIN planted_species ps ON ps.intervention_id = iv.id \
       LEFT JOIN scientific_species ss ON ps.scientific_species_id = ss.id \
-      JOIN project pp ON pl.plant_project_id = pp.id \
-      WHERE pp.guid=? AND pl.type IN ('multi','single') AND pl.deleted_at IS NULL AND pl.plant_date BETWEEN ? AND ?";
+      JOIN project pp ON iv.plant_project_id = pp.id \
+      WHERE pp.guid=? AND iv.type IN ('multi-tree-registration','single-tree-registration') AND iv.deleted_at IS NULL AND iv.intervention_date BETWEEN ? AND ?";
 
     const res = await db.query<IExportData[]>(query, [
       projectId,

--- a/pages/api/data-explorer/species-planted.ts
+++ b/pages/api/data-explorer/species-planted.ts
@@ -43,13 +43,13 @@ handler.post(async (req, response) => {
       'SELECT \
           ps.other_species, \
           ps.scientific_species_id, \
-          COALESCE(ss.name, ps.other_species, pl.other_species) AS name, \
+          COALESCE(ss.name, ps.other_species, iv.other_species) AS name, \
           SUM(ps.tree_count) AS total_tree_count \
         FROM planted_species ps \
-        INNER JOIN plant_location pl ON ps.plant_location_id = pl.id \
+        INNER JOIN intervention iv ON ps.intervention_id = iv.id \
         LEFT JOIN scientific_species ss ON ps.scientific_species_id = ss.id \
-        JOIN project pp ON pl.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND pl.plant_date BETWEEN ? AND ? \
+        JOIN project pp ON iv.plant_project_id = pp.id \
+        WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ? \
         GROUP BY ps.scientific_species_id, ss.name, ps.other_species \
         ORDER BY total_tree_count DESC';
 

--- a/pages/api/data-explorer/total-species-planted.ts
+++ b/pages/api/data-explorer/total-species-planted.ts
@@ -43,12 +43,12 @@ handler.post(async (req, response) => {
     const query =
       "SELECT \
             COUNT(DISTINCT COALESCE(ss.name, CASE WHEN ps.other_species='Unknown' THEN null ELSE ps.other_species END, \
-            CASE WHEN pl.other_species='Unknown' THEN null ELSE pl.other_species END)) as totalSpeciesPlanted \
+            CASE WHEN iv.other_species='Unknown' THEN null ELSE iv.other_species END)) as totalSpeciesPlanted \
             FROM planted_species ps \
-        INNER JOIN plant_location pl ON ps.plant_location_id = pl.id \
+        INNER JOIN intervention iv ON ps.intervention_id = iv.id \
         LEFT JOIN scientific_species ss ON ps.scientific_species_id = ss.id \
-        JOIN project pp ON pl.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND pl.plant_date BETWEEN ? AND ?";
+        JOIN project pp ON iv.plant_project_id = pp.id \
+        WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ?";
 
     const res = await db.query<TotalSpeciesPlanted[]>(query, [
       projectId,

--- a/pages/api/data-explorer/total-trees-planted.ts
+++ b/pages/api/data-explorer/total-trees-planted.ts
@@ -42,10 +42,10 @@ handler.post(async (req, response) => {
   try {
     const query =
       'SELECT \
-        COALESCE(SUM(pl.trees_planted), 0) AS totalTreesPlanted \
-      FROM plant_location pl \
-      JOIN project pp ON pl.plant_project_id = pp.id \
-      WHERE pp.guid = ? AND pl.plant_date BETWEEN ? AND ?';
+        COALESCE(SUM(iv.trees_planted), 0) AS totalTreesPlanted \
+      FROM intervention iv \
+      JOIN project pp ON iv.plant_project_id = pp.id \
+      WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ?';
 
     const res = await db.query<TotalTreesPlanted[]>(query, [
       projectId,

--- a/pages/api/data-explorer/trees-planted.ts
+++ b/pages/api/data-explorer/trees-planted.ts
@@ -53,66 +53,66 @@ handler.post(async (req, response) => {
     case TIME_FRAME.DAYS:
       query =
         'SELECT  \
-          pl.plant_date AS plantedDate, \
-          SUM(pl.trees_planted) AS treesPlanted \
-        FROM plant_location pl \
-        JOIN project pp ON pl.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND pl.plant_date BETWEEN ? AND ? \
-        GROUP BY pl.plant_date \
-        ORDER BY pl.plant_date';
+          iv.intervention_date AS plantedDate, \
+          SUM(iv.trees_planted) AS treesPlanted \
+        FROM intervention iv \
+        JOIN project pp ON iv.plant_project_id = pp.id \
+        WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ? \
+        GROUP BY iv.intervention_date \
+        ORDER BY iv.intervention_date';
       break;
 
     case TIME_FRAME.WEEKS:
       query =
         'SELECT \
-          DATE_SUB(pl.plant_date, INTERVAL WEEKDAY(pl.plant_date) DAY) AS weekStartDate, \
-          DATE_ADD(DATE_SUB(pl.plant_date, INTERVAL WEEKDAY(pl.plant_date) DAY), INTERVAL 6 DAY) AS weekEndDate, \
-          WEEK(pl.plant_date, 1) AS weekNum, \
-          LEFT(MONTHNAME(pl.plant_date), 3) AS month, \
-          YEAR(pl.plant_date) AS year, \
-          SUM(pl.trees_planted) AS treesPlanted \
-        FROM plant_location pl \
-        JOIN project pp ON pl.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND pl.plant_date BETWEEN ? AND ? \
+          DATE_SUB(iv.intervention_date, INTERVAL WEEKDAY(iv.intervention_date) DAY) AS weekStartDate, \
+          DATE_ADD(DATE_SUB(iv.intervention_date, INTERVAL WEEKDAY(iv.intervention_date) DAY), INTERVAL 6 DAY) AS weekEndDate, \
+          WEEK(iv.intervention_date, 1) AS weekNum, \
+          LEFT(MONTHNAME(iv.intervention_date), 3) AS month, \
+          YEAR(iv.intervention_date) AS year, \
+          SUM(iv.trees_planted) AS treesPlanted \
+        FROM intervention iv \
+        JOIN project pp ON iv.plant_project_id = pp.id \
+        WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ? \
         GROUP BY weekNum, weekStartDate, weekEndDate, month, year \
-        ORDER BY pl.plant_date';
+        ORDER BY iv.intervention_date';
       break;
 
     case TIME_FRAME.MONTHS:
       query =
         'SELECT \
-          LEFT(MONTHNAME(pl.plant_date), 3) AS month, \
-          YEAR(pl.plant_date) AS year, \
-          SUM(pl.trees_planted) AS treesPlanted \
-        FROM plant_location pl \
-        JOIN project pp ON pl.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND pl.plant_date BETWEEN ? AND ? \
+          LEFT(MONTHNAME(iv.intervention_date), 3) AS month, \
+          YEAR(iv.intervention_date) AS year, \
+          SUM(iv.trees_planted) AS treesPlanted \
+        FROM intervention iv \
+        JOIN project pp ON iv.plant_project_id = pp.id \
+        WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ? \
         GROUP BY month, year \
-        ORDER BY pl.plant_date;';
+        ORDER BY iv.intervention_date;';
       break;
 
     case TIME_FRAME.YEARS:
       query =
         'SELECT \
-          YEAR(pl.plant_date) AS year, \
-          SUM(pl.trees_planted) AS treesPlanted \
-        FROM plant_location pl \
-        JOIN project pp ON pl.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND pl.plant_date BETWEEN ? AND ? \
+          YEAR(iv.intervention_date) AS year, \
+          SUM(iv.trees_planted) AS treesPlanted \
+        FROM intervention iv \
+        JOIN project pp ON iv.plant_project_id = pp.id \
+        WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ? \
         GROUP BY year \
-        ORDER BY pl.plant_date';
+        ORDER BY iv.intervention_date';
       break;
 
     default:
       query =
         'SELECT \
-            YEAR(pl.plant_date) AS year, \
-            SUM(pl.trees_planted) AS treesPlanted \
-          FROM plant_location pl \
-          JOIN project pp ON pl.plant_project_id = pp.id \
-          WHERE pp.guid = ? AND pl.plant_date BETWEEN ? AND ? \
+            YEAR(iv.intervention_date) AS year, \
+            SUM(iv.trees_planted) AS treesPlanted \
+          FROM intervention iv \
+          JOIN project pp ON iv.plant_project_id = pp.id \
+          WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ? \
           GROUP BY year \
-          ORDER BY pl.plant_date';
+          ORDER BY iv.intervention_date';
   }
 
   try {

--- a/src/features/common/Layout/ProjectPropsContext.tsx
+++ b/src/features/common/Layout/ProjectPropsContext.tsx
@@ -177,7 +177,10 @@ const ProjectPropsProvider: FC = ({ children }) => {
       for (const key in plantLocations) {
         if (Object.prototype.hasOwnProperty.call(plantLocations, key)) {
           const element = plantLocations[key];
-          if (element.type === 'multi' && element.captureStatus === 'complete')
+          if (
+            element.type === 'multi-tree-registration' &&
+            element.captureStatus === 'complete'
+          )
             ids.push(element.id + '-layer');
         }
       }

--- a/src/features/common/types/dataExplorer.d.ts
+++ b/src/features/common/types/dataExplorer.d.ts
@@ -156,3 +156,12 @@ export interface PlantLocationDetailsApiResponse {
     totalSamplePlantLocations: number;
   };
 }
+
+export interface SinglePlantLocationApiResponse {
+  geometry: Geometry;
+  properties: {
+    guid: string;
+    treeCount: number;
+  };
+  type: 'Feature';
+}

--- a/src/features/common/types/plantLocation.d.ts
+++ b/src/features/common/types/plantLocation.d.ts
@@ -2,21 +2,6 @@ import { DateString } from './common';
 import { Links } from './payments';
 import { Polygon, Point } from 'geojson';
 
-export interface Geometry {
-  coordinates: number[][][];
-  type: string;
-  properties: Properties;
-}
-export interface GeometryOfSinglePlant {
-  coordinates: number[];
-  type: string;
-  properties: Properties;
-}
-
-export interface Properties {
-  id: string;
-}
-
 export interface PlantLocationBase {
   hid: string;
   id: string;
@@ -24,62 +9,63 @@ export interface PlantLocationBase {
   plantProject: string;
   metadata: Metadata;
   registrationDate: DateString;
+  /** @deprecated */
   plantDate: DateString;
+  interventionDate: DateString;
+  interventionStartDate: DateString | null; //should be the same as interventionDate
+  interventionEndDate: DateString | null;
+  lastMeasurementDate: DateString | null;
+  nextMeasurementDate: DateString | null; //only relevant for single and sample plant locations for now
   coordinates: PlantLocationCoordinate[];
   history: History[];
   captureMode: CaptureMode;
   captureStatus: CaptureStatus;
-  deviceLocation: DeviceLocation;
+  deviceLocation: Point;
   otherSpecies: string | null;
   description: string | null;
   geometryUpdatesCount: number;
   plantProjectSite: string | null;
-  image: string | null; //deprecate if not being used?
-  status: string | null; // currently always null. Should we do something here?
-  statusReason: string | null; // currently always null. Should we do something here?
+  image: string | null;
+  status: InterventionStatus | null;
+  statusReason: InterventionStatusReasons | null;
 }
+
 export interface PlantLocationSingle extends PlantLocationBase {
-  type: 'single';
+  type: 'single-tree-registration';
   scientificName: string | null;
   scientificSpecies: string | null;
   tag: string | null;
   measurements: Measurements;
   originalGeometry: Point;
   geometry: Point;
-  sampleTrees: SamplePlantLocation[];
 }
 
 export interface PlantLocationMulti extends PlantLocationBase {
-  type: 'multi';
+  type: 'multi-tree-registration';
   nextMeasurementDate: DateString | null;
-  plantDateStart: DateString | null;
-  plantDateEnd: DateString | null;
   sampleTreeCount: number;
-  samplePlantLocations: SamplePlantLocation[];
+  sampleInterventions: SamplePlantLocation[];
   plantedSpecies: PlantedSpecies[];
   originalGeometry: Polygon;
   geometry: Point | Polygon;
-  sampleTrees: SamplePlantLocation[];
+  measurements: null;
+  nextMeasurementDate: null;
 }
 
 export type PlantLocation = PlantLocationSingle | PlantLocationMulti;
 
-export interface SamplePlantLocation
-  extends Omit<PlantLocationBase, 'plantProject'> {
-  type: 'sample';
-  /** parent plant location */
+export interface SamplePlantLocation extends PlantLocationBase {
+  type: 'sample-tree-registration';
+  // /** parent plant location */
   parent: string;
-  /** tpo profile id */
+  // /** tpo profile id */
   profile: string;
-  nextMeasurementDate: DateString | null;
-  lastMeasurementDate: LastMeasurementDate;
   scientificName: string;
   scientificSpecies: string;
   tag: string | null;
   measurements: Measurements;
   originalGeometry: Point;
   geometry: Point;
-  sampleTrees?: PlantLocation[];
 }
 
 export interface Metadata {
@@ -97,15 +83,13 @@ export interface DeviceLocation {
   type: string;
 }
 
-type PlantLocationType = 'single' | 'multi' | 'sample';
-
 export interface PlantLocationCoordinate {
   image?: string;
-  created: DateString;
   coordinateIndex: string;
   id: string;
-  updated: DateString;
   status: string;
+  created: DateString;
+  updated: DateString;
 }
 
 export interface Measurements {
@@ -147,6 +131,10 @@ type CaptureMode = 'off-site' | 'on-site';
 type CaptureStatus = 'partial' | 'complete';
 
 type HistoryEvent = 'created' | 'measurement' | 'skip-measurement' | 'status';
+
+type InterventionStatus = 'dead' | 'alive';
+
+type InterventionStatusReasons = 'flood' | 'fire' | 'drought' | 'other';
 
 export interface LastMeasurementDate {
   date: DateString;

--- a/src/features/common/types/plantLocation.d.ts
+++ b/src/features/common/types/plantLocation.d.ts
@@ -126,7 +126,7 @@ export interface PlantedSpecies {
 
 type TreeStatus = 'alive' | 'sick' | 'dead';
 
-type CaptureMode = 'off-site' | 'on-site';
+type CaptureMode = 'off-site' | 'on-site' | 'external';
 
 type CaptureStatus = 'partial' | 'complete';
 

--- a/src/features/projects/components/PlantLocation/PlantLocationDetails.tsx
+++ b/src/features/projects/components/PlantLocation/PlantLocationDetails.tsx
@@ -54,7 +54,7 @@ export default function PlantLocationDetails({
     let count = 0;
     if (
       plantLocation &&
-      plantLocation.type === 'multi' &&
+      plantLocation.type === 'multi-tree-registration' &&
       plantLocation.plantedSpecies
     ) {
       for (const key in plantLocation.plantedSpecies) {
@@ -70,7 +70,7 @@ export default function PlantLocationDetails({
       }
       setTreeCount(count);
     }
-    if (plantLocation && plantLocation.type === 'multi') {
+    if (plantLocation && plantLocation.type === 'multi-tree-registration') {
       const area = turf.area(plantLocation.geometry);
       setPlantationArea(area / 10000);
     }
@@ -79,19 +79,19 @@ export default function PlantLocationDetails({
   React.useEffect(() => {
     if (
       plantLocation &&
-      plantLocation.type === 'multi' &&
-      plantLocation.samplePlantLocations &&
-      plantLocation.samplePlantLocations.length > 0
+      plantLocation.type === 'multi-tree-registration' &&
+      plantLocation.sampleInterventions &&
+      plantLocation.sampleInterventions.length > 0
     ) {
       const images: SliderImage[] = [];
-      for (const key in plantLocation.samplePlantLocations) {
+      for (const key in plantLocation.sampleInterventions) {
         if (
           Object.prototype.hasOwnProperty.call(
-            plantLocation.samplePlantLocations,
+            plantLocation.sampleInterventions,
             key
           )
         ) {
-          const element = plantLocation.samplePlantLocations[key];
+          const element = plantLocation.sampleInterventions[key];
 
           if (element.coordinates?.[0]) {
             images.push({
@@ -113,17 +113,17 @@ export default function PlantLocationDetails({
     setHoveredPl(null);
     if (
       plantLocation &&
-      plantLocation.type === 'multi' &&
-      plantLocation.samplePlantLocations
+      plantLocation.type === 'multi-tree-registration' &&
+      plantLocation.sampleInterventions
     ) {
-      for (const key in plantLocation.samplePlantLocations) {
+      for (const key in plantLocation.sampleInterventions) {
         if (
           Object.prototype.hasOwnProperty.call(
-            plantLocation.samplePlantLocations,
+            plantLocation.sampleInterventions,
             key
           )
         ) {
-          const element = plantLocation.samplePlantLocations[key];
+          const element = plantLocation.sampleInterventions[key];
 
           if (element.id === id) setSamplePlantLocation(element);
         }
@@ -148,7 +148,7 @@ export default function PlantLocationDetails({
         <div className={'singleProjectDetails'}>
           <div className={styles.treeCount}>
             <div>
-              {plantLocation.type === 'multi' && (
+              {plantLocation.type === 'multi-tree-registration' && (
                 <>
                   <span>
                     {localizedAbbreviatedNumber(locale, Number(treeCount), 1)}{' '}
@@ -163,8 +163,10 @@ export default function PlantLocationDetails({
                   {t('ha')})
                 </>
               )}
-              {plantLocation.type === 'single' && <span>{t('1Tree')} </span>}
-              {plantLocation.type === 'sample' && (
+              {plantLocation.type === 'single-tree-registration' && (
+                <span>{t('1Tree')} </span>
+              )}
+              {plantLocation.type === 'sample-tree-registration' && (
                 <span>{t('sampleTree')} </span>
               )}
             </div>
@@ -176,17 +178,18 @@ export default function PlantLocationDetails({
                 : null}
             </div>
           </div>
-          {plantLocation.type === 'multi' && sampleTreeImages.length > 0 && (
-            <div className={styles.projectImageSliderContainer}>
-              <ImageSlider
-                images={sampleTreeImages}
-                height={233}
-                imageSize="large"
-                type="coordinate"
-              />
-            </div>
-          )}
-          {plantLocation.type !== 'multi' &&
+          {plantLocation.type === 'multi-tree-registration' &&
+            sampleTreeImages.length > 0 && (
+              <div className={styles.projectImageSliderContainer}>
+                <ImageSlider
+                  images={sampleTreeImages}
+                  height={233}
+                  imageSize="large"
+                  type="coordinate"
+                />
+              </div>
+            )}
+          {plantLocation.type !== 'multi-tree-registration' &&
             plantLocation.coordinates?.length > 0 && (
               <div
                 className={`${styles.projectImageSliderContainer} ${styles.singlePl}`}
@@ -207,8 +210,8 @@ export default function PlantLocationDetails({
                   {formatDate(plantLocation.plantDate)}
                 </div>
               </div>
-              {(plantLocation.type === 'sample' ||
-                plantLocation.type === 'single') &&
+              {(plantLocation.type === 'sample-tree-registration' ||
+                plantLocation.type === 'single-tree-registration') &&
                 plantLocation.tag && (
                   <div className={styles.singleDetail}>
                     <div className={styles.detailTitle}>{t('treeTag')}</div>
@@ -219,7 +222,7 @@ export default function PlantLocationDetails({
                 )}
             </div>
 
-            {plantLocation.type === 'multi' && (
+            {plantLocation.type === 'multi-tree-registration' && (
               <div className={styles.singleDetail}>
                 <div className={styles.detailTitle}>
                   {t('plantingDensity')}
@@ -245,34 +248,36 @@ export default function PlantLocationDetails({
                 </div>
               </div>
             )}
-            {plantLocation.type === 'multi' && plantLocation.plantedSpecies && (
-              <div className={styles.singleDetail}>
-                <div className={styles.detailTitle}>
-                  {t('speciesPlanted')} ({plantLocation.plantedSpecies.length})
+            {plantLocation.type === 'multi-tree-registration' &&
+              plantLocation.plantedSpecies && (
+                <div className={styles.singleDetail}>
+                  <div className={styles.detailTitle}>
+                    {t('speciesPlanted')} ({plantLocation.plantedSpecies.length}
+                    )
+                  </div>
+                  {plantLocation.plantedSpecies.map((sp, index) => {
+                    // const speciesName = getSpeciesName(sp.scientificSpecies);
+                    return (
+                      <div key={index} className={styles.detailValue}>
+                        {sp.treeCount}{' '}
+                        <span>
+                          {' '}
+                          {sp.scientificName ? sp.scientificName : t('unknown')}
+                        </span>
+                      </div>
+                    );
+                  })}
                 </div>
-                {plantLocation.plantedSpecies.map((sp, index) => {
-                  // const speciesName = getSpeciesName(sp.scientificSpecies);
-                  return (
-                    <div key={index} className={styles.detailValue}>
-                      {sp.treeCount}{' '}
-                      <span>
-                        {' '}
-                        {sp.scientificName ? sp.scientificName : t('unknown')}
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
+              )}
 
-            {plantLocation.type === 'multi' && (
+            {plantLocation.type === 'multi-tree-registration' && (
               <div className={styles.singleDetail}>
                 <div className={styles.detailTitle}>
                   {t('sampleTrees')} (
-                  {plantLocation?.samplePlantLocations?.length})
+                  {plantLocation?.sampleInterventions?.length})
                 </div>
-                {plantLocation.samplePlantLocations &&
-                  plantLocation.samplePlantLocations.map((spl, index) => {
+                {plantLocation.sampleInterventions &&
+                  plantLocation.sampleInterventions.map((spl, index) => {
                     // const speciesName = getSpeciesName(spl.scientificSpecies);
                     return (
                       <div key={index} className={styles.detailValue}>
@@ -297,8 +302,8 @@ export default function PlantLocationDetails({
                   })}
               </div>
             )}
-            {(plantLocation.type === 'sample' ||
-              plantLocation.type === 'single') && (
+            {(plantLocation.type === 'sample-tree-registration' ||
+              plantLocation.type === 'single-tree-registration') && (
               <div className={styles.singleDetail}>
                 <div className={styles.detailTitle}>{t('scientificName')}</div>
                 <div className={styles.detailValue}>
@@ -312,8 +317,8 @@ export default function PlantLocationDetails({
                 </div>
               </div>
             )}
-            {(plantLocation.type === 'sample' ||
-              plantLocation.type === 'single') &&
+            {(plantLocation.type === 'sample-tree-registration' ||
+              plantLocation.type === 'single-tree-registration') &&
               plantLocation.measurements && (
                 <div className={styles.singleDetail}>
                   <div className={styles.detailTitle}>{t('measurements')}</div>
@@ -325,19 +330,20 @@ export default function PlantLocationDetails({
                 </div>
               )}
 
-            {plantLocation.type === 'sample' && plantLocation.parent && (
-              <div className={styles.singleDetail}>
-                <div className={styles.detailTitle}>{t('plot')}</div>
-                <div className={styles.detailValue}>
-                  <span
-                    onClick={() => openParent(plantLocation.parent)}
-                    className={styles.link}
-                  >
-                    {t('showWholeArea')}
-                  </span>
+            {plantLocation.type === 'sample-tree-registration' &&
+              plantLocation.parent && (
+                <div className={styles.singleDetail}>
+                  <div className={styles.detailTitle}>{t('plot')}</div>
+                  <div className={styles.detailValue}>
+                    <span
+                      onClick={() => openParent(plantLocation.parent)}
+                      className={styles.link}
+                    >
+                      {t('showWholeArea')}
+                    </span>
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
             {/* <div className={styles.singleDetail}>
                 <div className={styles.detailTitle}>Recruits (per HA)</div>
                 <div className={styles.detailValue}>710,421</div>

--- a/src/features/projects/components/maps/PlantLocations.tsx
+++ b/src/features/projects/components/maps/PlantLocations.tsx
@@ -32,10 +32,10 @@ export default function PlantLocations(): ReactElement {
 
   const openPl = (pl: PlantLocationSingle | SamplePlantLocation) => {
     switch (pl.type) {
-      case 'sample':
+      case 'sample-tree-registration':
         setSamplePlantLocation(pl);
         break;
-      case 'single':
+      case 'single-tree-registration':
         setSelectedPl(pl);
         break;
       default:
@@ -50,7 +50,8 @@ export default function PlantLocations(): ReactElement {
   const onHoverEnd = () => {
     if (
       hoveredPl &&
-      (hoveredPl.type === 'single' || hoveredPl.type === 'sample')
+      (hoveredPl.type === 'single-tree-registration' ||
+        hoveredPl.type === 'sample-tree-registration')
     )
       setHoveredPl(null);
   };
@@ -71,7 +72,7 @@ export default function PlantLocations(): ReactElement {
   };
 
   const getPlArea = (pl: PlantLocationMulti) => {
-    if (pl && pl.type === 'multi') {
+    if (pl && pl.type === 'multi-tree-registration') {
       const area = turf.area(pl.geometry);
       return area / 10000;
     } else {
@@ -140,7 +141,8 @@ export default function PlantLocations(): ReactElement {
     const isHovered = hoveredPl && hoveredPl.id === el.id;
     const GeoJSON = makeInterventionGeoJson(el.geometry, el.id, {
       highlightLine: isSelected || isHovered,
-      opacity: el.type === 'multi' ? getPolygonColor(el) : 0.5,
+      opacity:
+        el.type === 'multi-tree-registration' ? getPolygonColor(el) : 0.5,
       dateDiff: getDateDiff(el),
     });
     return GeoJSON;
@@ -197,9 +199,9 @@ export default function PlantLocations(): ReactElement {
           filter={['!=', ['get', 'dateDiff'], null]}
         />
         {selectedPl &&
-        selectedPl.type === 'multi' &&
-        selectedPl.samplePlantLocations
-          ? selectedPl.samplePlantLocations.map((spl) => {
+        selectedPl.type === 'multi-tree-registration' &&
+        selectedPl.sampleInterventions
+          ? selectedPl.sampleInterventions.map((spl) => {
               return (
                 <Marker
                   key={`${spl.id}-sample`}

--- a/src/features/projects/components/maps/Project.tsx
+++ b/src/features/projects/components/maps/Project.tsx
@@ -6,7 +6,7 @@ import { useProjectProps } from '../../../common/Layout/ProjectPropsContext';
 import Location from './Location';
 import Sites from './Sites';
 import { useRouter } from 'next/router';
-import { zoomToPlantLocation } from '../../../../../src/utils/maps/plantLocations';
+import { zoomToPolygonPlantLocation } from '../../../../../src/utils/maps/plantLocations';
 import {
   TreeProjectExtended,
   ConservationProjectExtended,
@@ -92,7 +92,12 @@ export default function Project({
   }
 
   React.useEffect(() => {
-    if (plantLocations && selectedPl && selectedPl.type === 'multi') {
+    if (
+      plantLocations &&
+      selectedPl &&
+      selectedPl.type === 'multi-tree-registration' &&
+      selectedPl.geometry.type === 'Polygon'
+    ) {
       setPlantPolygonCoordinates(selectedPl.geometry.coordinates[0]);
     }
     if (selectedPl) router.push(`/${project.slug}?ploc=${selectedPl?.hid}`);
@@ -100,17 +105,26 @@ export default function Project({
 
   React.useEffect(() => {
     if (selectedPl) {
-      const locationCoordinates =
-        selectedPl.type === 'multi'
-          ? selectedPl.geometry.coordinates[0]
-          : selectedPl.geometry.coordinates;
-      zoomToPlantLocation(
-        locationCoordinates,
-        viewport,
-        isMobile,
-        setViewPort,
-        1200
-      );
+      if (selectedPl.geometry.type === 'Polygon') {
+        const locationCoordinates = selectedPl.geometry.coordinates[0];
+        zoomToPolygonPlantLocation(
+          locationCoordinates,
+          viewport,
+          isMobile,
+          setViewPort,
+          1200
+        );
+      } else {
+        const locationCoordinates = selectedPl.geometry.coordinates;
+        zoomToLocation(
+          viewport,
+          setViewPort,
+          locationCoordinates[0],
+          locationCoordinates[1],
+          18,
+          1200
+        );
+      }
       return;
     }
 

--- a/src/features/user/TreeMapper/Import/components/PlantingLocation.tsx
+++ b/src/features/user/TreeMapper/Import/components/PlantingLocation.tsx
@@ -37,8 +37,11 @@ import {
   Geometry,
   GeometryObject,
 } from 'geojson';
-import { Species } from '../../../../common/types/plantLocation';
-import { PlantLocation, PlantingLocationFormData } from '../../Treemapper';
+import {
+  Species,
+  PlantLocation as PlantLocationType,
+} from '../../../../common/types/plantLocation';
+import { PlantingLocationFormData } from '../../Treemapper';
 // import { DevTool } from '@hookform/devtools';
 import { SetState } from '../../../../common/types/common';
 
@@ -156,7 +159,7 @@ function PlantedSpecies({
 interface Props {
   handleNext: () => void;
   userLang: string;
-  setPlantLocation: SetState<PlantLocation | null>;
+  setPlantLocation: SetState<PlantLocationType | null>;
   geoJson: Geometry | null;
   setGeoJson: Function;
   activeMethod: string;
@@ -328,7 +331,7 @@ export default function PlantingLocation({
     if (geoJson) {
       setIsUploadingData(true);
       const submitData = {
-        type: 'multi',
+        type: 'multi-tree-registration',
         captureMode: 'external',
         geometry: geoJson,
         plantedSpecies: data.plantedSpecies,
@@ -338,9 +341,9 @@ export default function PlantingLocation({
       };
 
       try {
-        const res = await postAuthenticatedRequest<PlantLocation>(
+        const res = await postAuthenticatedRequest<PlantLocationType>(
           tenantConfig?.id,
-          `/treemapper/plantLocations`,
+          `/treemapper/interventions`,
           submitData,
           token,
           logoutUser

--- a/src/features/user/TreeMapper/Import/components/ReviewSubmit.tsx
+++ b/src/features/user/TreeMapper/Import/components/ReviewSubmit.tsx
@@ -4,13 +4,11 @@ import { useTranslations } from 'next-intl';
 import formatDate from '../../../../../utils/countryCurrency/getFormattedDate';
 import { useRouter } from 'next/router';
 import { Button } from '@mui/material';
-import { PlantLocation } from '../../Treemapper';
+import { PlantLocationMulti } from '../../../../common/types/plantLocation';
 
 interface Props {
-  plantLocation: PlantLocation;
+  plantLocation: PlantLocationMulti;
   handleBack: () => void;
-  errorMessage: string;
-  setErrorMessage: (errorMessage: string) => void;
 }
 
 export default function ReviewSubmit({
@@ -99,15 +97,15 @@ export default function ReviewSubmit({
                     : []}
                 </span>
               </div>
-              {plantLocation.type === 'multi' &&
+              {plantLocation.type === 'multi-tree-registration' &&
               plantLocation.captureMode === 'external' ? (
                 <>
                   <p className={styles.gridItemTitle}>
                     {tTreemapper('sampleTrees')}
                   </p>
                   <div className={styles.gridItemValue}>
-                    {plantLocation.samplePlantLocations &&
-                      plantLocation.samplePlantLocations.map((spl, index) => {
+                    {plantLocation.sampleInterventions &&
+                      plantLocation.sampleInterventions.map((spl, index) => {
                         return (
                           <div key={index} className={styles.value}>
                             {index + 1}.{' '}

--- a/src/features/user/TreeMapper/Import/components/SampleTreeCard.tsx
+++ b/src/features/user/TreeMapper/Import/components/SampleTreeCard.tsx
@@ -15,7 +15,8 @@ import { MobileDatePicker as MuiDatePicker } from '@mui/x-date-pickers/MobileDat
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import themeProperties from '../../../../../theme/themeProperties';
-import { PlantLocation, PlantedSpecies } from '../../Treemapper';
+import { PlantLocationMulti } from '../../../../common/types/plantLocation';
+
 import { SampleTree } from '../../../../common/types/plantLocation';
 
 const dialogSx: SxProps = {
@@ -46,7 +47,7 @@ interface Props {
   control: Control<SampleTreeFormData>;
   userLang: string;
   item: FieldArrayWithId<SampleTreeFormData, 'sampleTrees', 'id'>;
-  plantLocation: PlantLocation;
+  plantLocation: PlantLocationMulti;
   errors: FieldErrors<SampleTreeFormData>;
   key: string;
 }
@@ -261,38 +262,36 @@ export default function SampleTreeCard({
                 value={value}
                 select
               >
-                {plantLocation?.plantedSpecies.map(
-                  (species: PlantedSpecies, index: number) => {
-                    if (!species.otherSpecies) return;
-                    if (plantLocation?.plantedSpecies.length === 1) {
-                      return (
-                        <MenuItem
-                          key={index}
-                          value={species.otherSpecies}
-                          selected={true}
-                        >
-                          {species.otherSpecies}
-                        </MenuItem>
-                      );
-                    } else if (species.otherSpecies === item.otherSpecies) {
-                      return (
-                        <MenuItem
-                          key={index}
-                          value={species.otherSpecies}
-                          selected={true}
-                        >
-                          {species.otherSpecies}
-                        </MenuItem>
-                      );
-                    } else {
-                      return (
-                        <MenuItem key={index} value={species.otherSpecies}>
-                          {species.otherSpecies}
-                        </MenuItem>
-                      );
-                    }
+                {plantLocation?.plantedSpecies.map((species, index) => {
+                  if (!species.otherSpecies) return;
+                  if (plantLocation?.plantedSpecies.length === 1) {
+                    return (
+                      <MenuItem
+                        key={index}
+                        value={species.otherSpecies}
+                        selected={true}
+                      >
+                        {species.otherSpecies}
+                      </MenuItem>
+                    );
+                  } else if (species.otherSpecies === item.otherSpecies) {
+                    return (
+                      <MenuItem
+                        key={index}
+                        value={species.otherSpecies}
+                        selected={true}
+                      >
+                        {species.otherSpecies}
+                      </MenuItem>
+                    );
+                  } else {
+                    return (
+                      <MenuItem key={index} value={species.otherSpecies}>
+                        {species.otherSpecies}
+                      </MenuItem>
+                    );
                   }
-                )}
+                })}
               </TextField>
             )}
           />

--- a/src/features/user/TreeMapper/Import/components/SampleTrees.tsx
+++ b/src/features/user/TreeMapper/Import/components/SampleTrees.tsx
@@ -13,17 +13,16 @@ import { Button } from '@mui/material';
 import { useTenant } from '../../../../common/Layout/TenantContext';
 import {
   Measurements,
+  PlantLocationMulti,
   SampleTree,
 } from '../../../../common/types/plantLocation';
 import { Geometry } from '@turf/turf';
-import { PlantLocation } from '../../Treemapper';
 import { FileImportError } from '../../../BulkCodes/BulkCodesTypes';
 
 interface Props {
   handleNext: Function;
-  plantLocation: PlantLocation;
+  plantLocation: PlantLocationMulti;
   userLang: string;
-  setPlantLocation: React.Dispatch<React.SetStateAction<PlantLocation | null>>;
 }
 
 type FormData = {
@@ -143,7 +142,7 @@ export default function SampleTrees({
     try {
       const res: SampleTree = await postAuthenticatedRequest(
         tenantConfig?.id,
-        `/treemapper/plantLocations`,
+        `/treemapper/interventions`,
         sampleTree,
         token,
         logoutUser
@@ -167,7 +166,7 @@ export default function SampleTrees({
       setIsUploadingData(true);
       for (const [index, sampleTree] of data.sampleTrees.entries()) {
         const samplePl = {
-          type: 'sample',
+          type: 'sample-tree-registration',
           captureMode: 'external',
           geometry: {
             coordinates: [
@@ -185,6 +184,7 @@ export default function SampleTrees({
           tag: sampleTree.treeTag,
           otherSpecies: sampleTree.otherSpecies,
           parent: plantLocation?.id,
+          plantProject: plantLocation?.plantProject,
         };
         await uploadSampleTree(samplePl, index);
       }
@@ -348,4 +348,5 @@ interface SampleTreeRequestData {
   tag: string;
   otherSpecies: string;
   parent: string | undefined;
+  plantProject: string;
 }

--- a/src/features/user/TreeMapper/Import/index.tsx
+++ b/src/features/user/TreeMapper/Import/index.tsx
@@ -18,7 +18,7 @@ import theme from '../../../../theme/themeProperties';
 import { handleError, APIError } from '@planet-sdk/common';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
 import { useTenant } from '../../../common/Layout/TenantContext';
-import { PlantLocation } from '../Treemapper';
+import { type PlantLocation as PlantLocationType } from '../../../common/types/plantLocation';
 
 const Stepper = styled(MuiStepper)({
   '&': {
@@ -57,18 +57,17 @@ export default function ImportData(): ReactElement {
     ];
   }
   const [activeStep, setActiveStep] = React.useState(0);
-  const [errorMessage, setErrorMessage] = React.useState('');
   const steps = getSteps();
   const [plantLocation, setPlantLocation] =
-    React.useState<PlantLocation | null>(null);
+    React.useState<PlantLocationType | null>(null);
   const [userLang, setUserLang] = React.useState('en');
   const [geoJson, setGeoJson] = React.useState(null);
 
   const fetchPlantLocation = async (id: string) => {
     try {
-      const result = await getAuthenticatedRequest<PlantLocation>(
+      const result = await getAuthenticatedRequest<PlantLocationType>(
         tenantConfig?.id,
-        `/treemapper/plantLocations/${id}?_scope=extended`,
+        `/treemapper/interventions/${id}?_scope=extended`,
         token,
         logoutUser
       );
@@ -116,24 +115,20 @@ export default function ImportData(): ReactElement {
           />
         );
       case 1:
-        return plantLocation ? (
+        return plantLocation &&
+          plantLocation.type === 'multi-tree-registration' ? (
           <SampleTrees
             handleNext={handleNext}
             plantLocation={plantLocation}
-            setPlantLocation={setPlantLocation}
             userLang={userLang}
           />
         ) : (
           <p> {tCommon('some_error')}</p>
         );
       case 2:
-        return plantLocation ? (
-          <ReviewSubmit
-            plantLocation={plantLocation}
-            handleBack={handleBack}
-            errorMessage={errorMessage}
-            setErrorMessage={setErrorMessage}
-          />
+        return plantLocation &&
+          plantLocation.type === 'multi-tree-registration' ? (
+          <ReviewSubmit plantLocation={plantLocation} handleBack={handleBack} />
         ) : (
           <p> {tCommon('some_error')}</p>
         );

--- a/src/features/user/TreeMapper/components/Map.tsx
+++ b/src/features/user/TreeMapper/components/Map.tsx
@@ -28,7 +28,7 @@ import { ViewPort } from '../../../common/types/ProjectPropsContextInterface';
 interface Props {
   locations: PlantLocation[] | SamplePlantLocation[] | null;
   selectedLocation: PlantLocation | SamplePlantLocation | null;
-  setselectedLocation: Function;
+  setSelectedLocation: Function;
 }
 
 interface GeoJson {
@@ -46,7 +46,7 @@ interface GeoJson {
 export default function MyTreesMap({
   locations,
   selectedLocation,
-  setselectedLocation,
+  setSelectedLocation,
 }: Props): ReactElement {
   const router = useRouter();
   const { isMobile } = useProjectProps();
@@ -83,7 +83,7 @@ export default function MyTreesMap({
   };
 
   const getPlArea = (pl: PlantLocationMulti) => {
-    if (pl && pl.type === 'multi') {
+    if (pl && pl.type === 'multi-tree-registration') {
       const area = turf.area(pl.geometry);
       return area / 10000;
     } else {
@@ -190,7 +190,7 @@ export default function MyTreesMap({
             },
           };
           features.push(newFeature);
-          if (pl.type === 'multi') ids.push(`${pl.id}-layer`);
+          if (pl.type === 'multi-tree-registration') ids.push(`${pl.id}-layer`);
         }
       }
       setGeoJson({
@@ -215,7 +215,7 @@ export default function MyTreesMap({
   const _onViewportChange = (view: ViewPort) => setViewPort({ ...view });
 
   const onMapClick = (e: MapEvent) => {
-    setselectedLocation(null);
+    setSelectedLocation(null);
     if (e.features !== undefined && e.features?.length !== 0) {
       if (e.features[0].layer?.source) {
         const source = e.features[0].layer.source;
@@ -252,7 +252,7 @@ export default function MyTreesMap({
           const newPl = pl.geometry;
           newPl.properties = { id: '' };
           newPl.properties.id = pl.id;
-          if (pl.type === 'multi') {
+          if (pl.type === 'multi-tree-registration') {
             return (
               <>
                 <Source
@@ -285,8 +285,8 @@ export default function MyTreesMap({
                   )}
                 </Source>
                 {pl &&
-                  pl.samplePlantLocations &&
-                  pl.samplePlantLocations
+                  pl.sampleInterventions &&
+                  pl.sampleInterventions
                     .filter((item) => {
                       if (item.captureStatus === 'complete') {
                         return true;
@@ -311,7 +311,7 @@ export default function MyTreesMap({
                               }`}
                               role="button"
                               tabIndex={0}
-                              onClick={() => setselectedLocation(spl)}
+                              onClick={() => setSelectedLocation(spl)}
                               // onMouseEnter={() => onHover(spl)}
                               // onMouseLeave={() => onHoverEnd(spl)}
                             />
@@ -321,7 +321,7 @@ export default function MyTreesMap({
                     })}
               </>
             );
-          } else if (pl.type === 'single') {
+          } else if (pl.type === 'single-tree-registration') {
             return (
               <Marker
                 key={`${pl.id}-single`}
@@ -335,7 +335,7 @@ export default function MyTreesMap({
                   <div
                     key={`${pl.id}-marker`}
                     onClick={() => {
-                      setselectedLocation(pl);
+                      setSelectedLocation(pl);
                     }}
                     // onMouseEnter={() => onHover(pl)}
                     // onMouseLeave={() => onHoverEnd(pl)}

--- a/src/features/user/TreeMapper/components/PlantLocation.tsx
+++ b/src/features/user/TreeMapper/components/PlantLocation.tsx
@@ -23,7 +23,7 @@ interface Props {
     | PlantLocationMulti
     | SamplePlantLocation
     | null;
-  setselectedLocation: Function;
+  setSelectedLocation: Function;
 }
 
 function PlantLocation({
@@ -31,7 +31,7 @@ function PlantLocation({
   index,
   locations,
   selectedLocation,
-  setselectedLocation,
+  setSelectedLocation,
 }: Props) {
   const t = useTranslations('Treemapper');
   const locale = useLocale();
@@ -56,7 +56,7 @@ function PlantLocation({
       selectedLocation &&
       (selectedLocation as PlantLocationBase).id === location.id
     ) {
-      setselectedLocation(null);
+      setSelectedLocation(null);
     } else {
       router.replace(`/profile/treemapper/?l=${location.id}`);
     }
@@ -65,7 +65,10 @@ function PlantLocation({
   const [plantationArea, setPlantationArea] = React.useState(0);
 
   React.useEffect(() => {
-    if (location && (location as PlantLocationMulti).type === 'multi') {
+    if (
+      location &&
+      (location as PlantLocationMulti).type === 'multi-tree-registration'
+    ) {
       const area = turf.area((location as PlantLocationMulti).geometry);
       setPlantationArea(area / 10000);
     }
@@ -87,7 +90,8 @@ function PlantLocation({
                   (location as PlantLocationBase).hid.substring(3)
                 : null
             } ${
-              (location as PlantLocationMulti).type === 'multi'
+              (location as PlantLocationMulti).type ===
+              'multi-tree-registration'
                 ? '• ' +
                   localizedAbbreviatedNumber(
                     locale,
@@ -106,7 +110,8 @@ function PlantLocation({
         </div>
         <div className={styles.right}>
           <div className={styles.status}>
-            {(location as PlantLocationMulti).type === 'multi' && treeCount
+            {(location as PlantLocationMulti).type ===
+              'multi-tree-registration' && treeCount
               ? `${treeCount}`
               : `1`}
             <TreeIcon width={'19px'} height={'19.25px'} />

--- a/src/features/user/TreeMapper/components/PlantLocationPage.tsx
+++ b/src/features/user/TreeMapper/components/PlantLocationPage.tsx
@@ -32,7 +32,7 @@ const ImageSliderSingle = dynamic(
 );
 
 interface Props {
-  setselectedLocation: SetState<
+  setSelectedLocation: SetState<
     SamplePlantLocation | PlantLocationMulti | PlantLocationSingle | null
   >;
   location:
@@ -50,7 +50,7 @@ interface SampleTreeImageProps {
 
 export function LocationDetails({
   location,
-  setselectedLocation,
+  setSelectedLocation,
 }: Props): ReactElement {
   const tTreemapper = useTranslations('Treemapper');
   const tMaps = useTranslations('Maps');
@@ -64,23 +64,23 @@ export function LocationDetails({
   })}`;
 
   React.useEffect(() => {
-    if (location?.type === 'multi') {
+    if (location?.type === 'multi-tree-registration') {
       if (
         location &&
-        (location as PlantLocationMulti).samplePlantLocations &&
-        (location as PlantLocationMulti).samplePlantLocations.length > 0
+        (location as PlantLocationMulti).sampleInterventions &&
+        (location as PlantLocationMulti).sampleInterventions.length > 0
       ) {
         const images = [];
         for (const key in (location as PlantLocationMulti)
-          .samplePlantLocations) {
+          .sampleInterventions) {
           if (
             Object.prototype.hasOwnProperty.call(
-              (location as PlantLocationMulti).samplePlantLocations,
+              (location as PlantLocationMulti).sampleInterventions,
               key
             )
           ) {
             const element = (location as PlantLocationMulti)
-              .samplePlantLocations[key];
+              .sampleInterventions[key];
 
             if (element.coordinates?.[0]) {
               images.push({
@@ -100,28 +100,30 @@ export function LocationDetails({
   }, [location]);
   return location ? (
     <>
-      {location.type === 'multi' && sampleTreeImages.length > 0 && (
-        <div className={styles.projectImageSliderContainer}>
-          <ImageSlider
-            images={sampleTreeImages}
-            height={233}
-            imageSize="large"
-            type="coordinate"
-          />
-        </div>
-      )}
-      {location.type !== 'multi' && location.coordinates?.length > 0 && (
-        <div
-          className={`${styles.projectImageSliderContainer} ${styles.singlePl}`}
-        >
-          <ImageSliderSingle
-            images={location.coordinates}
-            height={233}
-            imageSize="large"
-            type="coordinate"
-          />
-        </div>
-      )}
+      {location.type === 'multi-tree-registration' &&
+        sampleTreeImages.length > 0 && (
+          <div className={styles.projectImageSliderContainer}>
+            <ImageSlider
+              images={sampleTreeImages}
+              height={233}
+              imageSize="large"
+              type="coordinate"
+            />
+          </div>
+        )}
+      {location.type !== 'multi-tree-registration' &&
+        location.coordinates?.length > 0 && (
+          <div
+            className={`${styles.projectImageSliderContainer} ${styles.singlePl}`}
+          >
+            <ImageSliderSingle
+              images={location.coordinates}
+              height={233}
+              imageSize="large"
+              type="coordinate"
+            />
+          </div>
+        )}
       <div className={styles.details}>
         <div className={styles.singleDetail}>
           <p className={styles.title}>{tTreemapper('captureMode')}</p>
@@ -235,39 +237,40 @@ export function LocationDetails({
             </div>
           </div>
         )}
-        {location.type === 'multi' && location.captureMode === 'on-site' && (
-          <div className={styles.singleDetail}>
-            <p className={styles.title}>{tMaps('sampleTree')}</p>
-            {/* <div className={styles.value}> */}
-            {(location as PlantLocationMulti).samplePlantLocations &&
-              (location as PlantLocationMulti).samplePlantLocations.map(
-                (spl, index: number) => {
-                  return (
-                    <div key={index} className={styles.value}>
-                      {index + 1}.{' '}
-                      <span
-                        onClick={() => setselectedLocation(spl)}
-                        className={styles.link}
-                      >
-                        {spl.scientificName
-                          ? spl.scientificName
-                          : spl.scientificSpecies &&
-                            spl.scientificSpecies !== 'Unknown'
-                          ? spl.scientificSpecies
-                          : tMaps('unknown')}
-                      </span>
-                      <br />
-                      {spl.tag ? `${tMaps('tag')} #${spl.tag} • ` : null}
-                      {spl?.measurements?.height}
-                      {tMaps('meterHigh')} • {spl?.measurements?.width}
-                      {tMaps('cmWide')}
-                    </div>
-                  );
-                }
-              )}
-            {/* </div> */}
-          </div>
-        )}
+        {location.type === 'multi-tree-registration' &&
+          location.captureMode === 'on-site' && (
+            <div className={styles.singleDetail}>
+              <p className={styles.title}>{tMaps('sampleTree')}</p>
+              {/* <div className={styles.value}> */}
+              {(location as PlantLocationMulti).sampleInterventions &&
+                (location as PlantLocationMulti).sampleInterventions.map(
+                  (spl, index: number) => {
+                    return (
+                      <div key={index} className={styles.value}>
+                        {index + 1}.{' '}
+                        <span
+                          onClick={() => setSelectedLocation(spl)}
+                          className={styles.link}
+                        >
+                          {spl.scientificName
+                            ? spl.scientificName
+                            : spl.scientificSpecies &&
+                              spl.scientificSpecies !== 'Unknown'
+                            ? spl.scientificSpecies
+                            : tMaps('unknown')}
+                        </span>
+                        <br />
+                        {spl.tag ? `${tMaps('tag')} #${spl.tag} • ` : null}
+                        {spl?.measurements?.height}
+                        {tMaps('meterHigh')} • {spl?.measurements?.width}
+                        {tMaps('cmWide')}
+                      </div>
+                    );
+                  }
+                )}
+              {/* </div> */}
+            </div>
+          )}
       </div>
     </>
   ) : (
@@ -277,19 +280,19 @@ export function LocationDetails({
 
 export default function PlantLocationPage({
   location,
-  setselectedLocation,
+  setSelectedLocation,
   plantLocations,
 }: Props): ReactElement {
   const router = useRouter();
 
   const handleBackButton = () => {
-    if (location?.type === 'sample') {
+    if (location?.type === 'sample-tree-registration') {
       for (const iKey in plantLocations) {
         const i = iKey as keyof typeof plantLocations;
         if (Object.prototype.hasOwnProperty.call(plantLocations, i)) {
           const pl = plantLocations[i] as PlantLocation;
           if (pl.id === (location as SamplePlantLocation)?.parent) {
-            setselectedLocation(pl);
+            setSelectedLocation(pl);
             break;
           }
         }
@@ -301,7 +304,7 @@ export default function PlantLocationPage({
 
   const DetailProps = {
     location,
-    setselectedLocation,
+    setSelectedLocation,
   };
 
   return (

--- a/src/features/user/TreeMapper/components/TreeMapperList.tsx
+++ b/src/features/user/TreeMapper/components/TreeMapperList.tsx
@@ -4,7 +4,6 @@ import TransactionsNotFound from '../../../../../public/assets/images/icons/Tran
 import styles from '../TreeMapper.module.scss';
 import { useTranslations } from 'next-intl';
 import {
-  SamplePlantLocation,
   PlantLocation as PlantLocationType,
   PlantLocationSingle,
   PlantLocationMulti,

--- a/src/features/user/TreeMapper/components/TreeMapperList.tsx
+++ b/src/features/user/TreeMapper/components/TreeMapperList.tsx
@@ -15,7 +15,7 @@ import { SetState } from '../../../common/types/common';
 
 interface Props {
   selectedLocation: PlantLocationSingle | PlantLocationMulti | null;
-  setselectedLocation: SetState<
+  setSelectedLocation: SetState<
     PlantLocationSingle | PlantLocationMulti | null
   >;
   plantLocations: PlantLocationType[];
@@ -27,7 +27,7 @@ interface Props {
 
 export default function TreeMapperList({
   selectedLocation,
-  setselectedLocation,
+  setSelectedLocation,
   plantLocations,
   isDataLoading,
   location,
@@ -63,7 +63,7 @@ export default function TreeMapperList({
         <>
           {plantLocations ? (
             plantLocations.map((location, index: number) => {
-              if (location.type !== 'sample')
+              if (location.type !== 'sample-tree-registration')
                 return (
                   <PlantLocation
                     key={index}
@@ -71,7 +71,7 @@ export default function TreeMapperList({
                     locations={plantLocations}
                     index={index}
                     selectedLocation={selectedLocation}
-                    setselectedLocation={setselectedLocation}
+                    setSelectedLocation={setSelectedLocation}
                   />
                 );
             })

--- a/src/features/user/TreeMapper/index.tsx
+++ b/src/features/user/TreeMapper/index.tsx
@@ -83,6 +83,7 @@ function TreeMapper(): ReactElement {
             ...plantLocations,
             ...newPlantLocations,
           ] as PlantLocationType[]);
+          setLinks(response._links);
         }
       } catch (err) {
         setErrors(handleError(err as APIError));

--- a/src/features/user/TreeMapper/index.tsx
+++ b/src/features/user/TreeMapper/index.tsx
@@ -33,7 +33,7 @@ function TreeMapper(): ReactElement {
   const [plantLocations, setPlantLocations] = React.useState<
     PlantLocationType[]
   >([]);
-  const [selectedLocation, setselectedLocation] = React.useState<
+  const [selectedLocation, setSelectedLocation] = React.useState<
     PlantLocationSingle | PlantLocationMulti | null
   >(null);
   const [links, setLinks] = React.useState<Links>();
@@ -61,7 +61,7 @@ function TreeMapper(): ReactElement {
             if (Object.prototype.hasOwnProperty.call(newPlantLocations, itr)) {
               const ind = Number(itr);
               const location = newPlantLocations[ind];
-              if (location.type === 'multi') {
+              if (location.type === 'multi-tree-registration') {
                 location.sampleTrees = [];
                 for (const key in newPlantLocations) {
                   if (
@@ -69,7 +69,7 @@ function TreeMapper(): ReactElement {
                   ) {
                     const item = newPlantLocations[key] as PlantLocationMulti &
                       SamplePlantLocation;
-                    if (item.type === 'sample') {
+                    if (item.type === 'sample-tree-registration') {
                       if (item.parent === location.id) {
                         location.sampleTrees.push(item);
                       }
@@ -93,7 +93,7 @@ function TreeMapper(): ReactElement {
         const response =
           await getAuthenticatedRequest<ExtendedScopePlantLocations>(
             tenantConfig?.id,
-            '/treemapper/plantLocations?_scope=extended&limit=15',
+            '/treemapper/interventions?_scope=extended&limit=15',
             token,
             logoutUser,
 
@@ -109,7 +109,7 @@ function TreeMapper(): ReactElement {
             for (const itr in plantLocations) {
               if (Object.prototype.hasOwnProperty.call(plantLocations, itr)) {
                 const location = plantLocations[itr];
-                if (location && location.type === 'multi') {
+                if (location && location.type === 'multi-tree-registration') {
                   location.sampleTrees = [];
                   for (const key in plantLocations) {
                     if (
@@ -117,7 +117,7 @@ function TreeMapper(): ReactElement {
                     ) {
                       const item = plantLocations[key] as PlantLocationMulti &
                         SamplePlantLocation;
-                      if (item.type === 'sample') {
+                      if (item.type === 'sample-tree-registration') {
                         if (item.parent === location.id) {
                           location.sampleTrees.push(item);
                         }
@@ -152,21 +152,21 @@ function TreeMapper(): ReactElement {
           if (Object.prototype.hasOwnProperty.call(plantLocations, key)) {
             const plantLocation = plantLocations[key];
             if (plantLocation.id === router.query.l) {
-              setselectedLocation(plantLocation);
+              setSelectedLocation(plantLocation);
               break;
             }
           }
         }
       }
     } else {
-      setselectedLocation(null);
+      setSelectedLocation(null);
     }
   }, [router.query.l, plantLocations]);
 
   const TreeMapperProps = {
     location: selectedLocation,
     selectedLocation,
-    setselectedLocation,
+    setSelectedLocation,
     plantLocations,
     isDataLoading,
     fetchTreemapperData,
@@ -195,7 +195,7 @@ function TreeMapper(): ReactElement {
           <PlantLocationMap
             locations={plantLocations}
             selectedLocation={selectedLocation}
-            setselectedLocation={setselectedLocation}
+            setSelectedLocation={setSelectedLocation}
           />
         </div>
       </div>

--- a/src/utils/maps/plantLocations.ts
+++ b/src/utils/maps/plantLocations.ts
@@ -15,7 +15,7 @@ import { ViewPort } from '../../features/common/types/ProjectPropsContextInterfa
  * @param setViewPort - function to set the viewport
  * @param {number} duration - in ms
  */
-export function zoomToPlantLocation(
+export function zoomToPolygonPlantLocation(
   coordinates: Position[],
   viewport: ViewPort,
   isMobile: boolean,


### PR DESCRIPTION
Changes:

- [x] Update PlantLocation type (and related types)
- [x] Adapts project details (plant locations and sample plant locations view) for new plant locations API
- [x] Adapts data explorer to replace plant_locations with interventions table
- [x] Update treemapper (import and Plant Locations) to use `interventions` APIs and `sampleInterventions`

Key changes:
1. `type` can now be `multi-tree-registration`, `single-tree-registration`, `sample-tree-registration` in place of the earlier types of `multi`, `single`, `sample`.
2. The `samplePlantLocations` property is replaced with `sampleInterventions`
3. APIs for data explorer use the `interventions` table instead of `plant_locations`, and relevant foreign keys are also renamed accordingly