### PR TITLE
Fix intervention_date in data explorer queries

### DIFF
--- a/pages/api/data-explorer/export.ts
+++ b/pages/api/data-explorer/export.ts
@@ -18,7 +18,7 @@ handler.post(async (req, response) => {
     const query =
       "SELECT \
           iv.hid, \
-          iv.intervention_date, \
+          iv.intervention_start_date, \
           COALESCE(ss.name, ps.other_species, iv.other_species) AS species, \
           CASE WHEN iv.type='single-tree-registration' THEN 1 ELSE ps.tree_count END AS tree_count, \
           iv.geometry, \
@@ -35,7 +35,7 @@ handler.post(async (req, response) => {
       LEFT JOIN planted_species ps ON ps.intervention_id = iv.id \
       LEFT JOIN scientific_species ss ON ps.scientific_species_id = ss.id \
       JOIN project pp ON iv.plant_project_id = pp.id \
-      WHERE pp.guid=? AND iv.type IN ('multi-tree-registration','single-tree-registration') AND iv.deleted_at IS NULL AND iv.intervention_date BETWEEN ? AND ?";
+      WHERE pp.guid=? AND iv.type IN ('multi-tree-registration','single-tree-registration') AND iv.deleted_at IS NULL AND iv.intervention_start_date BETWEEN ? AND ?";
 
     const res = await db.query<IExportData[]>(query, [
       projectId,

--- a/pages/api/data-explorer/map/plant-location/index.ts
+++ b/pages/api/data-explorer/map/plant-location/index.ts
@@ -30,14 +30,14 @@ handler.post(async (req, response) => {
     const values = [projectId];
 
     if (queryType !== QueryType.DATE) {
-      query += ' AND DATE(iv.intervention_date) BETWEEN ? AND ?';
+      query += ' AND DATE(iv.intervention_start_date) BETWEEN ? AND ?';
       values.push(fromDate, toDate);
     }
 
     if (queryType) {
       if (queryType === QueryType.DATE) {
         // Filter by date
-        query += ' AND DATE(iv.intervention_date) = ?';
+        query += ' AND DATE(iv.intervention_start_date) = ?';
         values.push(searchQuery);
       } else if (queryType === QueryType.HID) {
         // Filter by HID

--- a/pages/api/data-explorer/species-planted.ts
+++ b/pages/api/data-explorer/species-planted.ts
@@ -49,7 +49,7 @@ handler.post(async (req, response) => {
         INNER JOIN intervention iv ON ps.intervention_id = iv.id \
         LEFT JOIN scientific_species ss ON ps.scientific_species_id = ss.id \
         JOIN project pp ON iv.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ? \
+        WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ? \
         GROUP BY ps.scientific_species_id, ss.name, ps.other_species \
         ORDER BY total_tree_count DESC';
 

--- a/pages/api/data-explorer/total-species-planted.ts
+++ b/pages/api/data-explorer/total-species-planted.ts
@@ -48,7 +48,7 @@ handler.post(async (req, response) => {
         INNER JOIN intervention iv ON ps.intervention_id = iv.id \
         LEFT JOIN scientific_species ss ON ps.scientific_species_id = ss.id \
         JOIN project pp ON iv.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ?";
+        WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ?";
 
     const res = await db.query<TotalSpeciesPlanted[]>(query, [
       projectId,

--- a/pages/api/data-explorer/total-trees-planted.ts
+++ b/pages/api/data-explorer/total-trees-planted.ts
@@ -45,7 +45,7 @@ handler.post(async (req, response) => {
         COALESCE(SUM(iv.trees_planted), 0) AS totalTreesPlanted \
       FROM intervention iv \
       JOIN project pp ON iv.plant_project_id = pp.id \
-      WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ?';
+      WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ?';
 
     const res = await db.query<TotalTreesPlanted[]>(query, [
       projectId,

--- a/pages/api/data-explorer/trees-planted.ts
+++ b/pages/api/data-explorer/trees-planted.ts
@@ -53,66 +53,66 @@ handler.post(async (req, response) => {
     case TIME_FRAME.DAYS:
       query =
         'SELECT  \
-          iv.intervention_date AS plantedDate, \
+          iv.intervention_start_date AS plantedDate, \
           SUM(iv.trees_planted) AS treesPlanted \
         FROM intervention iv \
         JOIN project pp ON iv.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ? \
-        GROUP BY iv.intervention_date \
-        ORDER BY iv.intervention_date';
+        WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ? \
+        GROUP BY iv.intervention_start_date \
+        ORDER BY iv.intervention_start_date';
       break;
 
     case TIME_FRAME.WEEKS:
       query =
         'SELECT \
-          DATE_SUB(iv.intervention_date, INTERVAL WEEKDAY(iv.intervention_date) DAY) AS weekStartDate, \
-          DATE_ADD(DATE_SUB(iv.intervention_date, INTERVAL WEEKDAY(iv.intervention_date) DAY), INTERVAL 6 DAY) AS weekEndDate, \
-          WEEK(iv.intervention_date, 1) AS weekNum, \
-          LEFT(MONTHNAME(iv.intervention_date), 3) AS month, \
-          YEAR(iv.intervention_date) AS year, \
+          DATE_SUB(iv.intervention_start_date, INTERVAL WEEKDAY(iv.intervention_start_date) DAY) AS weekStartDate, \
+          DATE_ADD(DATE_SUB(iv.intervention_start_date, INTERVAL WEEKDAY(iv.intervention_start_date) DAY), INTERVAL 6 DAY) AS weekEndDate, \
+          WEEK(iv.intervention_start_date, 1) AS weekNum, \
+          LEFT(MONTHNAME(iv.intervention_start_date), 3) AS month, \
+          YEAR(iv.intervention_start_date) AS year, \
           SUM(iv.trees_planted) AS treesPlanted \
         FROM intervention iv \
         JOIN project pp ON iv.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ? \
+        WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ? \
         GROUP BY weekNum, weekStartDate, weekEndDate, month, year \
-        ORDER BY iv.intervention_date';
+        ORDER BY iv.intervention_start_date';
       break;
 
     case TIME_FRAME.MONTHS:
       query =
         'SELECT \
-          LEFT(MONTHNAME(iv.intervention_date), 3) AS month, \
-          YEAR(iv.intervention_date) AS year, \
+          LEFT(MONTHNAME(iv.intervention_start_date), 3) AS month, \
+          YEAR(iv.intervention_start_date) AS year, \
           SUM(iv.trees_planted) AS treesPlanted \
         FROM intervention iv \
         JOIN project pp ON iv.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ? \
+        WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ? \
         GROUP BY month, year \
-        ORDER BY iv.intervention_date;';
+        ORDER BY iv.intervention_start_date;';
       break;
 
     case TIME_FRAME.YEARS:
       query =
         'SELECT \
-          YEAR(iv.intervention_date) AS year, \
+          YEAR(iv.intervention_start_date) AS year, \
           SUM(iv.trees_planted) AS treesPlanted \
         FROM intervention iv \
         JOIN project pp ON iv.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ? \
+        WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ? \
         GROUP BY year \
-        ORDER BY iv.intervention_date';
+        ORDER BY iv.intervention_start_date';
       break;
 
     default:
       query =
         'SELECT \
-            YEAR(iv.intervention_date) AS year, \
+            YEAR(iv.intervention_start_date) AS year, \
             SUM(iv.trees_planted) AS treesPlanted \
           FROM intervention iv \
           JOIN project pp ON iv.plant_project_id = pp.id \
-          WHERE pp.guid = ? AND iv.intervention_date BETWEEN ? AND ? \
+          WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ? \
           GROUP BY year \
-          ORDER BY iv.intervention_date';
+          ORDER BY iv.intervention_start_date';
   }
 
   try {


### PR DESCRIPTION
This pull request fixes the usage of `intervention_date` in the data explorer queries. It replaces all instances of `intervention_date` with `intervention_start_date` to ensure consistency in the data retrieval.