### PR TITLE
Adapt dataExplorer export for intervention_start_date

### DIFF
--- a/public/static/locales/en/treemapperAnalytics.json
+++ b/public/static/locales/en/treemapperAnalytics.json
@@ -28,7 +28,7 @@
     "dec": "Dec",
     "exportColumnHeaders": {
       "hid": "Human Readable ID for a plant location",
-      "plantDate": "Planted Date",
+      "interventionStartDate": "Starting date of intervention (e.g. Tree planting date)",
       "species": "Name of the species planted",
       "treeCount": "",
       "geometry": "GeoJson Co-ordinate of the polygon",

--- a/src/features/common/types/dataExplorer.d.ts
+++ b/src/features/common/types/dataExplorer.d.ts
@@ -34,7 +34,7 @@ export interface ISpeciesPlanted {
 
 export interface IExportData {
   hid: string;
-  plant_date: Date;
+  intervention_start_date: Date;
   species: string;
   tree_count: number;
   geometry: string;

--- a/src/features/common/types/plantLocation.d.ts
+++ b/src/features/common/types/plantLocation.d.ts
@@ -11,7 +11,6 @@ export interface PlantLocationBase {
   registrationDate: DateString;
   /** @deprecated */
   plantDate: DateString;
-  interventionDate: DateString;
   interventionStartDate: DateString | null; //should be the same as interventionDate
   interventionEndDate: DateString | null;
   lastMeasurementDate: DateString | null;

--- a/src/features/projects/components/PlantLocation/PlantLocationDetails.tsx
+++ b/src/features/projects/components/PlantLocation/PlantLocationDetails.tsx
@@ -207,7 +207,9 @@ export default function PlantLocationDetails({
               <div className={styles.singleDetail}>
                 <div className={styles.detailTitle}>{t('plantingDate')}</div>
                 <div className={styles.detailValue}>
-                  {formatDate(plantLocation.plantDate)}
+                  {plantLocation.interventionStartDate
+                    ? formatDate(plantLocation.interventionStartDate)
+                    : '-'}
                 </div>
               </div>
               {(plantLocation.type === 'sample-tree-registration' ||

--- a/src/features/projects/components/maps/PlantLocations.tsx
+++ b/src/features/projects/components/maps/PlantLocations.tsx
@@ -98,8 +98,10 @@ export default function PlantLocations(): ReactElement {
   };
 
   const getDateDiff = (pl: PlantLocation) => {
+    if (!pl.interventionStartDate) return null;
+
     const today = new Date();
-    const plantationDate = new Date(pl.plantDate?.substr(0, 10));
+    const plantationDate = new Date(pl.interventionStartDate?.slice(0, 10));
     const differenceInTime = today.getTime() - plantationDate.getTime();
     const differenceInDays = differenceInTime / (1000 * 3600 * 24);
     if (differenceInDays < 1) {

--- a/src/features/user/TreeMapper/Analytics/components/Export/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Export/index.tsx
@@ -78,8 +78,8 @@ export const Export = () => {
       description: t('exportColumnHeaders.hid'),
     },
     {
-      title: 'plant_date',
-      description: t('exportColumnHeaders.plantDate'),
+      title: 'intervention_start_date',
+      description: t('exportColumnHeaders.interventionStartDate'),
     },
     {
       title: 'species',
@@ -142,6 +142,7 @@ export const Export = () => {
   };
 
   const extractDataToXlsx = (data: IExportData[]) => {
+    console.log('Data for export:', data[0]);
     const worksheet = utils.json_to_sheet(data);
     const workbook = utils.book_new();
 
@@ -173,6 +174,7 @@ export const Export = () => {
   const handleExport = async () => {
     if (localProject) {
       const res = await makeRequest();
+      console.log('Data received from API:', res?.data[0]);
 
       if (res) {
         const { data } = res;

--- a/src/features/user/TreeMapper/Import/components/ReviewSubmit.tsx
+++ b/src/features/user/TreeMapper/Import/components/ReviewSubmit.tsx
@@ -60,14 +60,16 @@ export default function ReviewSubmit({
                     {plantLocation.captureMode}
                   </div>
                 </div>
-                <div className={styles.gridItem}>
-                  <div className={styles.gridItemTitle}>
-                    {tTreemapper('plantDate')}
+                {plantLocation.interventionStartDate !== null && (
+                  <div className={styles.gridItem}>
+                    <div className={styles.gridItemTitle}>
+                      {tTreemapper('plantDate')}
+                    </div>
+                    <div className={styles.gridItemValue}>
+                      {formatDate(plantLocation.interventionStartDate)}
+                    </div>
                   </div>
-                  <div className={styles.gridItemValue}>
-                    {formatDate(plantLocation.plantDate)}
-                  </div>
-                </div>
+                )}
                 <div className={styles.gridItem}>
                   <div className={styles.gridItemTitle}>
                     {tTreemapper('registrationDate')}

--- a/src/features/user/TreeMapper/components/Map.tsx
+++ b/src/features/user/TreeMapper/components/Map.tsx
@@ -108,24 +108,6 @@ export default function MyTreesMap({
     }
   };
 
-  // const getDateDiff = (pl: PlantLocation) => {
-  //   const today = new Date();
-  //   const plantationDate = new Date(pl.plantDate?.substr(0, 10));
-  //   const differenceInTime = today.getTime() - plantationDate.getTime();
-  //   const differenceInDays = differenceInTime / (1000 * 3600 * 24);
-  //   if (differenceInDays < 1) {
-  //     return t('today');
-  //   } else if (differenceInDays < 2) {
-  //     return t('yesterday');
-  //   } else if (differenceInDays < 30) {
-  //     return t('daysAgo', {
-  //       days: localizedAbbreviatedNumber(i18n.language, differenceInDays, 0),
-  //     });
-  //   } else {
-  //     return null;
-  //   }
-  // };
-
   const zoomToLocation = (geometry: turf.AllGeoJSON) => {
     if (viewport.width && viewport.height && geometry) {
       const bbox = turf.bbox(geometry);

--- a/src/features/user/TreeMapper/components/PlantLocationPage.tsx
+++ b/src/features/user/TreeMapper/components/PlantLocationPage.tsx
@@ -153,10 +153,14 @@ export function LocationDetails({
         ) : (
           []
         )}
-        <div className={styles.singleDetail}>
-          <p className={styles.title}>{tTreemapper('plantDate')}</p>
-          <div className={styles.value}>{formatDate(location.plantDate)}</div>
-        </div>
+        {location.interventionStartDate !== null && (
+          <div className={styles.singleDetail}>
+            <p className={styles.title}>{tTreemapper('plantDate')}</p>
+            <div className={styles.value}>
+              {formatDate(location.interventionStartDate)}
+            </div>
+          </div>
+        )}
         <div className={styles.singleDetail}>
           <p className={styles.title}>{tTreemapper('registrationDate')}</p>
           <div className={styles.value}>


### PR DESCRIPTION
This pull request includes changes to adapt the dataExplorer export for the new field `intervention_start_date`. The `plantDate` field has been deprecated in the `PlantLocationBase` type and replaced with `interventionStartDate`. The export data interface has also been updated to reflect this change. Additionally, various components and functions have been modified to handle the new field.