### PR TITLE
feat: handle route for a project which has no site

### DIFF
--- a/src/features/projectsV2/ProjectsContext.tsx
+++ b/src/features/projectsV2/ProjectsContext.tsx
@@ -267,12 +267,16 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
   const updateSiteAndUrl = (
     locale: string,
     projectSlug: string,
-    siteIndex: number
+    siteIndex: number | null
   ) => {
-    if (singleProject?.sites?.length === 0) return;
+    if (!singleProject?.sites?.length) return;
+
     setSelectedSite(siteIndex);
-    const siteId = singleProject?.sites?.[siteIndex].properties.id;
-    if (siteId) updateUrlWithSiteId(locale, projectSlug, siteId);
+
+    const siteId =
+      siteIndex !== null ? singleProject.sites[siteIndex]?.properties.id : null;
+
+    updateUrlWithSiteId(locale, projectSlug, siteId);
   };
 
   useEffect(() => {
@@ -291,7 +295,7 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
 
       if (hasNoSites) {
         //Case when a direct link requests a specific plant location but no sites exist for a project(e.g projectSlug: mothersforest).
-        updateUrlWithSiteId(locale, singleProject.slug, null);
+        updateSiteAndUrl(locale, singleProject.slug, null);
       } else {
         // Handle the case where a direct link requests a specific plant location (via URL query).
         // This will update the ploc param based on the requestedPlantLocation. If the requested hid is invalid,

--- a/src/features/projectsV2/ProjectsContext.tsx
+++ b/src/features/projectsV2/ProjectsContext.tsx
@@ -254,7 +254,7 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
   const updateUrlWithSiteId = (
     locale: string,
     projectSlug: string,
-    siteId: string
+    siteId: string | null
   ) => {
     const updatedQueryParams = updateUrlWithParams(
       router.asPath,
@@ -286,17 +286,22 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
     )
       return;
 
-    // Handle the case where a direct link requests a specific plant location (via URL query).
-    // This will update the ploc param based on the requestedPlantLocation. If the requested hid is invalid,
-    // it falls back to the default (first) site.
     if (requestedPlantLocation && selectedPlantLocation === null) {
-      const result = plantLocations?.find(
-        (plantLocation) => plantLocation.hid === requestedPlantLocation
-      );
-      if (result) {
-        setSelectedPlantLocation(result);
+      const hasNoSites = singleProject.sites?.length === 0;
+
+      if (hasNoSites) {
+        //Case when a direct link requests a specific plant location but no sites exist for a project(e.g projectSlug: mothersforest).
+        updateUrlWithSiteId(locale, singleProject.slug, null);
       } else {
-        updateSiteAndUrl(locale, singleProject.slug, 0);
+        // Handle the case where a direct link requests a specific plant location (via URL query).
+        // This will update the ploc param based on the requestedPlantLocation. If the requested hid is invalid,
+        // it falls back to the default (first) site.
+        const result = plantLocations?.find(
+          (plantLocation) => plantLocation.hid === requestedPlantLocation
+        );
+        result
+          ? setSelectedPlantLocation(result)
+          : updateSiteAndUrl(locale, singleProject.slug, 0);
       }
     }
 
@@ -324,7 +329,6 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
       selectedPlantLocation !== null
     )
       return;
-
     // Handle the case where a direct link requests a specific site (via URL query)
     // This will update the site param based on the requestedSite. If the requested site ID is invalid,
     // it falls back to the default (first) site.

--- a/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
+++ b/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
@@ -77,7 +77,7 @@ const SingleProjectView = ({ mapRef, setIsOnSampleMarker }: Props) => {
         zoomToLocation(setViewState, longitude, latitude, 10, 4000, mapRef);
       }
     }
-  }, [selectedSite, router.isReady]);
+  }, [selectedSite, router.isReady, selectedPlantLocation]);
 
   return (
     <>

--- a/src/features/projectsV2/ProjectsMap/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/index.tsx
@@ -74,21 +74,30 @@ function ProjectsMap(props: ProjectsMapProps) {
   const onClick = useCallback(
     (e) => {
       if (props.page !== 'project-details') return;
+      const hasNoSites =
+        singleProject?.sites && singleProject?.sites?.length === 0;
       const result = getPlantLocationInfo(plantLocations, mapRef, e.point);
-      const isClickedOnSamePlantLocation =
+
+      const isSamePlantLocation =
         result?.geometry.type === 'Point' &&
-        result.id === selectedPlantLocation?.id &&
-        singleProject?.slug;
+        result.id === selectedPlantLocation?.id;
 
-      //Clear the sample plant state if the parent plant location (polygon) is selected
-      if (isOnSampleMarker === false) setSelectedSamplePlantLocation(null);
+      const isSingleTree =
+        selectedPlantLocation?.type === 'single-tree-registration';
+      const isMultiTree =
+        selectedPlantLocation?.type === 'multi-tree-registration';
 
-      //Clear plant location info (single-tree-registration) if it is clicked twice
-      if (isClickedOnSamePlantLocation) {
-        setSelectedSite(0);
+      // Clear the sample plant state if the parent plant location (polygon) is selected
+      if (!isOnSampleMarker) setSelectedSamplePlantLocation(null);
+
+      // Clear plant location info if clicked twice (single or multi tree)
+      if (isSamePlantLocation && (isSingleTree || isMultiTree)) {
         setSelectedPlantLocation(null);
+        setSelectedSite(hasNoSites ? null : 0);
         return;
       }
+
+      // Set selected plant location if a result is found
       if (result) {
         setSelectedSite(null);
         setSelectedPlantLocation(result);

--- a/src/features/projectsV2/ProjectsMap/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/index.tsx
@@ -92,8 +92,7 @@ function ProjectsMap(props: ProjectsMapProps) {
   const onClick = useCallback(
     (e) => {
       if (props.page !== 'project-details') return;
-      const hasNoSites =
-        singleProject?.sites && singleProject?.sites?.length === 0;
+      const hasNoSites = singleProject?.sites?.length === 0;
       const result = getPlantLocationInfo(plantLocations, mapRef, e.point);
 
       const isSamePlantLocation =

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -11,7 +11,6 @@ import {
   PlantLocationSingle,
   SamplePlantLocation,
 } from '../features/common/types/plantLocation';
-import { NextRouter } from 'next/router';
 
 const paramsToPreserve = [
   'embed',
@@ -35,7 +34,7 @@ const paramsToDelete = ['locale', 'slug', 'p', 'ploc'];
 export const updateUrlWithParams = (
   asPath: string,
   query: ParsedUrlQuery,
-  siteId: string
+  siteId: string | null
 ) => {
   const [, queryString] = asPath.split('?');
   const currentUrlParams = new URLSearchParams(queryString || '');
@@ -47,7 +46,7 @@ export const updateUrlWithParams = (
   });
   paramsToDelete.forEach((param) => delete currentQuery[param]);
   //add project site param
-  currentQuery.site = siteId;
+  if (siteId) currentQuery.site = siteId;
   return currentQuery;
 };
 


### PR DESCRIPTION
- [ ] Handle case of setting site id to null when project has no sites. example (mothersforest project unselecting a plant location; ploc param remains in the url) (visit to -> `en/prd/mothersforest`) 