### PR TITLE
Separate cache key based on API env

### DIFF
--- a/pages/api/data-explorer/species-planted.ts
+++ b/pages/api/data-explorer/species-planted.ts
@@ -26,7 +26,11 @@ handler.post(async (req, response) => {
 
   const { projectId, startDate, endDate } = req.body;
 
-  const CACHE_KEY = `SPECIES_PLANTED__${getCachedKey(
+  const cachingKeyPrefix =
+    process.env.API_ENDPOINT?.replace('https://', '').split('.')[0] ||
+    'env_missing';
+
+  const CACHE_KEY = `${cachingKeyPrefix}_SPECIES_PLANTED__${getCachedKey(
     projectId,
     startDate,
     endDate

--- a/pages/api/data-explorer/total-species-planted.ts
+++ b/pages/api/data-explorer/total-species-planted.ts
@@ -26,7 +26,11 @@ handler.post(async (req, response) => {
 
   const { projectId, startDate, endDate } = req.body;
 
-  const CACHE_KEY = `TOTAL_SPECIES_PLANTED__${getCachedKey(
+  const cachingKeyPrefix =
+    process.env.API_ENDPOINT?.replace('https://', '').split('.')[0] ||
+    'env_missing';
+
+  const CACHE_KEY = `${cachingKeyPrefix}_TOTAL_SPECIES_PLANTED__${getCachedKey(
     projectId,
     startDate,
     endDate

--- a/pages/api/data-explorer/total-trees-planted.ts
+++ b/pages/api/data-explorer/total-trees-planted.ts
@@ -26,7 +26,11 @@ handler.post(async (req, response) => {
 
   const { projectId, startDate, endDate } = req.body;
 
-  const CACHE_KEY = `TOTAL_TREES_PLANTED__${getCachedKey(
+  const cachingKeyPrefix =
+    process.env.API_ENDPOINT?.replace('https://', '').split('.')[0] ||
+    'env_missing';
+
+  const CACHE_KEY = `${cachingKeyPrefix}_TOTAL_TREES_PLANTED__${getCachedKey(
     projectId,
     startDate,
     endDate

--- a/pages/api/data-explorer/trees-planted.ts
+++ b/pages/api/data-explorer/trees-planted.ts
@@ -33,7 +33,11 @@ handler.post(async (req, response) => {
   const { projectId, startDate, endDate } = req.body;
   const { timeFrame } = req.query;
 
-  const CACHE_KEY = `TREES_PLANTED__${getCachedKey(
+  const cachingKeyPrefix =
+    process.env.API_ENDPOINT?.replace('https://', '').split('.')[0] ||
+    'env_missing';
+
+  const CACHE_KEY = `${cachingKeyPrefix}_TREES_PLANTED__${getCachedKey(
     projectId,
     startDate,
     endDate,


### PR DESCRIPTION
This pull request separates the cache key for data explorer APIs based on the API_ENDPOINT env var to avoid data crossing between systems. The cache key is now prefixed with the API endpoint or 'env_missing' if the endpoint is not available. This change affects multiple files and ensures that the cache key is unique for each environment.

Note: while data explorer APIs do not use the API_ENDPOINT, they access the same set of data.