### PR TITLE
Refactor cache key prefix logic

### DIFF
--- a/pages/api/data-explorer/map/distinct-species/[projectId].ts
+++ b/pages/api/data-explorer/map/distinct-species/[projectId].ts
@@ -10,11 +10,12 @@ import {
   UncleanDistinctSpecies,
 } from '../../../../../src/features/common/types/dataExplorer';
 import redisClient from '../../../../../src/redis-client';
+import { cacheKeyPrefix } from '../../../../../src/utils/constants/cacheKeyPrefix';
 
 const ONE_HOUR_IN_SEC = 60 * 60;
 const TWO_HOURS = ONE_HOUR_IN_SEC * 2;
 
-const KEY = 'DISTINCT_SPECIES';
+const KEY = `${cacheKeyPrefix}_DISTINCT_SPECIES`;
 
 const handler = nc<NextApiRequest, NextApiResponse>();
 

--- a/pages/api/data-explorer/map/sites/[projectId].ts
+++ b/pages/api/data-explorer/map/sites/[projectId].ts
@@ -10,11 +10,12 @@ import {
   UncleanSite,
 } from '../../../../../src/features/common/types/dataExplorer';
 import redisClient from '../../../../../src/redis-client';
+import { cacheKeyPrefix } from '../../../../../src/utils/constants/cacheKeyPrefix';
 
 const ONE_HOUR_IN_SEC = 60 * 60;
 const TWO_HOURS = ONE_HOUR_IN_SEC * 2;
 
-const KEY = 'SITES';
+const KEY = `${cacheKeyPrefix}_SITES`;
 
 const handler = nc<NextApiRequest, NextApiResponse>();
 

--- a/pages/api/data-explorer/species-planted.ts
+++ b/pages/api/data-explorer/species-planted.ts
@@ -8,6 +8,7 @@ import {
 import { getCachedKey } from '../../../src/utils/getCachedKey';
 import { ISpeciesPlanted } from '../../../src/features/common/types/dataExplorer';
 import redisClient from '../../../src/redis-client';
+import { cacheKeyPrefix } from '../../../src/utils/constants/cacheKeyPrefix';
 
 const ONE_HOUR_IN_SEC = 60 * 60;
 const TWO_HOURS = ONE_HOUR_IN_SEC * 2;
@@ -26,11 +27,7 @@ handler.post(async (req, response) => {
 
   const { projectId, startDate, endDate } = req.body;
 
-  const cachingKeyPrefix =
-    process.env.API_ENDPOINT?.replace('https://', '').split('.')[0] ||
-    'env_missing';
-
-  const CACHE_KEY = `${cachingKeyPrefix}_SPECIES_PLANTED__${getCachedKey(
+  const CACHE_KEY = `${cacheKeyPrefix}_SPECIES_PLANTED__${getCachedKey(
     projectId,
     startDate,
     endDate

--- a/pages/api/data-explorer/total-species-planted.ts
+++ b/pages/api/data-explorer/total-species-planted.ts
@@ -8,6 +8,7 @@ import {
 import { getCachedKey } from '../../../src/utils/getCachedKey';
 import { TotalSpeciesPlanted } from '../../../src/features/common/types/dataExplorer';
 import redisClient from '../../../src/redis-client';
+import { cacheKeyPrefix } from '../../../src/utils/constants/cacheKeyPrefix';
 
 const ONE_HOUR_IN_SEC = 60 * 60;
 const TWO_HOURS = ONE_HOUR_IN_SEC * 2;
@@ -26,11 +27,7 @@ handler.post(async (req, response) => {
 
   const { projectId, startDate, endDate } = req.body;
 
-  const cachingKeyPrefix =
-    process.env.API_ENDPOINT?.replace('https://', '').split('.')[0] ||
-    'env_missing';
-
-  const CACHE_KEY = `${cachingKeyPrefix}_TOTAL_SPECIES_PLANTED__${getCachedKey(
+  const CACHE_KEY = `${cacheKeyPrefix}_TOTAL_SPECIES_PLANTED__${getCachedKey(
     projectId,
     startDate,
     endDate

--- a/pages/api/data-explorer/total-trees-planted.ts
+++ b/pages/api/data-explorer/total-trees-planted.ts
@@ -8,6 +8,7 @@ import {
 import { getCachedKey } from '../../../src/utils/getCachedKey';
 import { TotalTreesPlanted } from '../../../src/features/common/types/dataExplorer';
 import redisClient from '../../../src/redis-client';
+import { cacheKeyPrefix } from '../../../src/utils/constants/cacheKeyPrefix';
 
 const ONE_HOUR_IN_SEC = 60 * 60;
 const TWO_HOURS = ONE_HOUR_IN_SEC * 2;
@@ -26,11 +27,7 @@ handler.post(async (req, response) => {
 
   const { projectId, startDate, endDate } = req.body;
 
-  const cachingKeyPrefix =
-    process.env.API_ENDPOINT?.replace('https://', '').split('.')[0] ||
-    'env_missing';
-
-  const CACHE_KEY = `${cachingKeyPrefix}_TOTAL_TREES_PLANTED__${getCachedKey(
+  const CACHE_KEY = `${cacheKeyPrefix}_TOTAL_TREES_PLANTED__${getCachedKey(
     projectId,
     startDate,
     endDate

--- a/pages/api/data-explorer/trees-planted.ts
+++ b/pages/api/data-explorer/trees-planted.ts
@@ -14,6 +14,7 @@ import {
   IYearlyFrame,
 } from '../../../src/features/common/types/dataExplorer';
 import redisClient from '../../../src/redis-client';
+import { cacheKeyPrefix } from '../../../src/utils/constants/cacheKeyPrefix';
 
 const ONE_HOUR_IN_SEC = 60 * 60;
 const TWO_HOURS = ONE_HOUR_IN_SEC * 2;
@@ -33,11 +34,7 @@ handler.post(async (req, response) => {
   const { projectId, startDate, endDate } = req.body;
   const { timeFrame } = req.query;
 
-  const cachingKeyPrefix =
-    process.env.API_ENDPOINT?.replace('https://', '').split('.')[0] ||
-    'env_missing';
-
-  const CACHE_KEY = `${cachingKeyPrefix}_TREES_PLANTED__${getCachedKey(
+  const CACHE_KEY = `${cacheKeyPrefix}_TREES_PLANTED__${getCachedKey(
     projectId,
     startDate,
     endDate,

--- a/src/utils/constants/cacheKeyPrefix.ts
+++ b/src/utils/constants/cacheKeyPrefix.ts
@@ -1,0 +1,4 @@
+// If the API_ENDPOINT is https://app-staging.planet.com, the cachePrefix will be 'staging'
+export const cacheKeyPrefix =
+  process.env.API_ENDPOINT?.replace('https://', '').split('.')[0] ||
+  'env_missing';

--- a/src/utils/multiTenancy/helpers.ts
+++ b/src/utils/multiTenancy/helpers.ts
@@ -1,5 +1,6 @@
 import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import redisClient from '../../redis-client';
+import { cacheKeyPrefix } from '../constants/cacheKeyPrefix';
 
 const ONE_HOUR_IN_SEC = 60 * 60;
 const FIVE_HOURS = ONE_HOUR_IN_SEC * 5;
@@ -58,11 +59,7 @@ export async function constructPathsForTenantSlug() {
  */
 export const getTenantConfig = async (slug: string): Promise<Tenant> => {
   try {
-    // If the API_ENDPOINT is https://app-staging.planet.com, the cachingKeyPrefix will be 'staging'
-    const cachingKeyPrefix =
-      process.env.API_ENDPOINT?.replace('https://', '').split('.')[0] ||
-      'env_missing';
-    const caching_key = `${cachingKeyPrefix}_TENANT_CONFIG_${slug}`;
+    const caching_key = `${cacheKeyPrefix}_TENANT_CONFIG_${slug}`;
 
     const tenant =
       redisClient !== null ? await redisClient.get<Tenant>(caching_key) : null;


### PR DESCRIPTION
Extracts the cache key prefix logic to a common location. This ensures that the cache key prefix is consistent across different parts of the codebase. The cache key prefix is now imported from the `cacheKeyPrefix` constant defined in the `utils/constants` module. This change improves code maintainability and reduces duplication.