### PR TITLE
Fix data explorer queries for single tree registrations

### DIFF
--- a/pages/api/data-explorer/map/sites/[projectId].ts
+++ b/pages/api/data-explorer/map/sites/[projectId].ts
@@ -40,10 +40,13 @@ handler.get(async (req, response) => {
   }
 
   try {
-    const query =
-      'SELECT s.name, s.geometry FROM plant_project_site s \
-        INNER JOIN project p ON s.plant_project_id = p.id \
-        WHERE p.guid = ?';
+    const query = `
+			SELECT 
+					s.name, s.geometry 
+				FROM plant_project_site s
+        INNER JOIN project p ON s.plant_project_id = p.id
+        WHERE 
+						p.guid = ?`;
 
     const res = await db.query<UncleanSite[]>(query, [projectId]);
 

--- a/pages/api/data-explorer/species-planted.ts
+++ b/pages/api/data-explorer/species-planted.ts
@@ -40,19 +40,28 @@ handler.post(async (req, response) => {
   }
 
   try {
-    const query =
-      'SELECT \
-          ps.other_species, \
-          ps.scientific_species_id, \
-          COALESCE(ss.name, ps.other_species, iv.other_species) AS name, \
-          SUM(ps.tree_count) AS total_tree_count \
-        FROM planted_species ps \
-        INNER JOIN intervention iv ON ps.intervention_id = iv.id \
-        LEFT JOIN scientific_species ss ON ps.scientific_species_id = ss.id \
-        JOIN project pp ON iv.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ? \
-        GROUP BY ps.scientific_species_id, ss.name, ps.other_species \
-        ORDER BY total_tree_count DESC';
+    const query = `
+			SELECT 
+					ps.other_species,
+					COALESCE(iv.scientific_species_id,
+									ps.scientific_species_id) AS scientific_species_id,
+					COALESCE(ss.name,
+									ps.other_species,
+									iv.other_species, 'Unknown') AS name,
+					SUM(COALESCE(ps.tree_count, iv.trees_planted, 0)) AS total_tree_count
+				FROM intervention iv
+				LEFT JOIN planted_species ps ON iv.id = ps.intervention_id
+				LEFT JOIN scientific_species ss ON COALESCE(iv.scientific_species_id, ps.scientific_species_id) = ss.id
+				JOIN project pp ON iv.plant_project_id = pp.id
+				WHERE
+						iv.deleted_at IS NULL
+						AND iv.type IN ('single-tree-registration', 'multi-tree-registration')
+						AND pp.guid = ? 
+						AND iv.intervention_start_date BETWEEN ? AND ?
+				GROUP BY 
+						COALESCE(iv.scientific_species_id, ps.scientific_species_id), 
+						COALESCE(ss.name, ps.other_species, iv.other_species, 'Unknown')
+				ORDER BY total_tree_count DESC`;
 
     const res = await db.query<ISpeciesPlanted[]>(query, [
       projectId,

--- a/pages/api/data-explorer/total-species-planted.ts
+++ b/pages/api/data-explorer/total-species-planted.ts
@@ -41,15 +41,23 @@ handler.post(async (req, response) => {
   }
 
   try {
-    const query =
-      "SELECT \
-            COUNT(DISTINCT COALESCE(ss.name, CASE WHEN ps.other_species='Unknown' THEN null ELSE ps.other_species END, \
-            CASE WHEN iv.other_species='Unknown' THEN null ELSE iv.other_species END)) as totalSpeciesPlanted \
-            FROM planted_species ps \
-        INNER JOIN intervention iv ON ps.intervention_id = iv.id \
-        LEFT JOIN scientific_species ss ON ps.scientific_species_id = ss.id \
-        JOIN project pp ON iv.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ?";
+    const query = `
+			SELECT 
+					COUNT(DISTINCT COALESCE(
+							ss.name,
+							NULLIF(ps.other_species, 'Unknown'),
+							NULLIF(iv.other_species, 'Unknown')
+							)) AS totalSpeciesPlanted
+				FROM intervention iv
+				LEFT JOIN planted_species ps ON iv.id = ps.intervention_id
+				LEFT JOIN scientific_species ss ON COALESCE(ps.scientific_species_id, iv.scientific_species_id) = ss.id
+				JOIN project pp ON iv.plant_project_id = pp.id
+				WHERE
+						iv.deleted_at IS NULL
+						AND iv.type IN ('single-tree-registration', 'multi-tree-registration')
+						AND pp.guid = ?
+						AND iv.intervention_start_date BETWEEN ? AND ?
+			`;
 
     const res = await db.query<TotalSpeciesPlanted[]>(query, [
       projectId,

--- a/pages/api/data-explorer/total-trees-planted.ts
+++ b/pages/api/data-explorer/total-trees-planted.ts
@@ -41,12 +41,16 @@ handler.post(async (req, response) => {
   }
 
   try {
-    const query =
-      'SELECT \
-        COALESCE(SUM(iv.trees_planted), 0) AS totalTreesPlanted \
-      FROM intervention iv \
-      JOIN project pp ON iv.plant_project_id = pp.id \
-      WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ?';
+    const query = `
+			SELECT
+					COALESCE(SUM(iv.trees_planted), 0) AS totalTreesPlanted
+				FROM intervention iv
+				JOIN project pp ON iv.plant_project_id = pp.id
+				WHERE 
+						iv.deleted_at IS NULL
+						AND iv.type IN ('single-tree-registration', 'multi-tree-registration')
+						AND pp.guid = ? 
+						AND iv.intervention_start_date BETWEEN ? AND ?`;
 
     const res = await db.query<TotalTreesPlanted[]>(query, [
       projectId,

--- a/pages/api/data-explorer/trees-planted.ts
+++ b/pages/api/data-explorer/trees-planted.ts
@@ -52,68 +52,93 @@ handler.post(async (req, response) => {
 
   switch (timeFrame) {
     case TIME_FRAME.DAYS:
-      query =
-        'SELECT  \
-          iv.intervention_start_date AS plantedDate, \
-          SUM(iv.trees_planted) AS treesPlanted \
-        FROM intervention iv \
-        JOIN project pp ON iv.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ? \
-        GROUP BY iv.intervention_start_date \
-        ORDER BY iv.intervention_start_date';
+      query = `
+				SELECT
+						iv.intervention_start_date AS plantedDate,
+						SUM(iv.trees_planted) AS treesPlanted
+					FROM intervention iv
+					JOIN project pp ON iv.plant_project_id = pp.id
+					WHERE
+							iv.deleted_at IS NULL AND
+							iv.type IN ('single-tree-registration', 'multi-tree-registration') AND
+							pp.guid = ? AND 
+							iv.intervention_start_date BETWEEN ? AND ?
+					GROUP BY iv.intervention_start_date
+					ORDER BY iv.intervention_start_date
+			`;
       break;
 
     case TIME_FRAME.WEEKS:
-      query =
-        'SELECT \
-          DATE_SUB(iv.intervention_start_date, INTERVAL WEEKDAY(iv.intervention_start_date) DAY) AS weekStartDate, \
-          DATE_ADD(DATE_SUB(iv.intervention_start_date, INTERVAL WEEKDAY(iv.intervention_start_date) DAY), INTERVAL 6 DAY) AS weekEndDate, \
-          WEEK(iv.intervention_start_date, 1) AS weekNum, \
-          LEFT(MONTHNAME(iv.intervention_start_date), 3) AS month, \
-          YEAR(iv.intervention_start_date) AS year, \
-          SUM(iv.trees_planted) AS treesPlanted \
-        FROM intervention iv \
-        JOIN project pp ON iv.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ? \
-        GROUP BY weekNum, weekStartDate, weekEndDate, month, year \
-        ORDER BY iv.intervention_start_date';
+      query = `
+				SELECT
+						DATE_SUB(iv.intervention_start_date, INTERVAL WEEKDAY(iv.intervention_start_date) DAY) AS weekStartDate,
+						DATE_ADD(DATE_SUB(iv.intervention_start_date, INTERVAL WEEKDAY(iv.intervention_start_date) DAY), INTERVAL 6 DAY) AS weekEndDate,
+						WEEK(iv.intervention_start_date, 1) AS weekNum,
+						LEFT(MONTHNAME(iv.intervention_start_date), 3) AS month,
+						YEAR(iv.intervention_start_date) AS year,
+						SUM(iv.trees_planted) AS treesPlanted
+					FROM intervention iv
+					JOIN project pp ON iv.plant_project_id = pp.id
+					WHERE
+							iv.deleted_at IS NULL AND
+							iv.type IN ('single-tree-registration', 'multi-tree-registration') AND 
+							pp.guid = ? AND 
+							iv.intervention_start_date BETWEEN ? AND ?
+					GROUP BY weekNum, weekStartDate, weekEndDate, month, year
+					ORDER BY iv.intervention_start_date
+				`;
       break;
 
     case TIME_FRAME.MONTHS:
-      query =
-        'SELECT \
-          LEFT(MONTHNAME(iv.intervention_start_date), 3) AS month, \
-          YEAR(iv.intervention_start_date) AS year, \
-          SUM(iv.trees_planted) AS treesPlanted \
-        FROM intervention iv \
-        JOIN project pp ON iv.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ? \
-        GROUP BY month, year \
-        ORDER BY iv.intervention_start_date;';
+      query = `
+				SELECT 
+						LEFT(MONTHNAME(iv.intervention_start_date), 3) AS month,
+						YEAR(iv.intervention_start_date) AS year,
+						SUM(iv.trees_planted) AS treesPlanted
+					FROM intervention iv
+					JOIN project pp ON iv.plant_project_id = pp.id 
+					WHERE
+							iv.deleted_at IS NULL AND
+							iv.type IN ('single-tree-registration', 'multi-tree-registration') AND 
+							pp.guid = ? AND 
+							iv.intervention_start_date BETWEEN ? AND ? 
+					GROUP BY month, year 
+					ORDER BY iv.intervention_start_date
+				`;
       break;
 
     case TIME_FRAME.YEARS:
-      query =
-        'SELECT \
-          YEAR(iv.intervention_start_date) AS year, \
-          SUM(iv.trees_planted) AS treesPlanted \
-        FROM intervention iv \
-        JOIN project pp ON iv.plant_project_id = pp.id \
-        WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ? \
-        GROUP BY year \
-        ORDER BY iv.intervention_start_date';
+      query = `
+				SELECT 
+						YEAR(iv.intervention_start_date) AS year, 
+						SUM(iv.trees_planted) AS treesPlanted 
+					FROM intervention iv 
+					JOIN project pp ON iv.plant_project_id = pp.id 
+					WHERE
+							iv.deleted_at IS NULL AND
+							iv.type IN ('single-tree-registration', 'multi-tree-registration') AND
+							pp.guid = ? AND 
+							iv.intervention_start_date BETWEEN ? AND ? 
+					GROUP BY year 
+					ORDER BY iv.intervention_start_date
+				`;
       break;
 
     default:
-      query =
-        'SELECT \
-            YEAR(iv.intervention_start_date) AS year, \
-            SUM(iv.trees_planted) AS treesPlanted \
-          FROM intervention iv \
-          JOIN project pp ON iv.plant_project_id = pp.id \
-          WHERE pp.guid = ? AND iv.intervention_start_date BETWEEN ? AND ? \
-          GROUP BY year \
-          ORDER BY iv.intervention_start_date';
+      query = `
+				SELECT
+            YEAR(iv.intervention_start_date) AS year,
+            SUM(iv.trees_planted) AS treesPlanted
+          FROM intervention iv
+          JOIN project pp ON iv.plant_project_id = pp.id
+          WHERE
+							iv.deleted_at IS NULL AND
+							iv.type IN ('single-tree-registration', 'multi-tree-registration') AND 
+							pp.guid = ? AND 
+							iv.intervention_start_date BETWEEN ? AND ?
+          GROUP BY year
+          ORDER BY iv.intervention_start_date
+				`;
   }
 
   try {

--- a/public/static/locales/en/treemapperAnalytics.json
+++ b/public/static/locales/en/treemapperAnalytics.json
@@ -69,6 +69,10 @@
     "sites": "Sites",
     "searchDateError": "Search date is not between the selected date range.",
     "noProjectsText": "No projects are available.",
-    "addProjectsButton": "Add A Project"
+    "addProjectsButton": "Add A Project",
+    "plantLocationType": {
+      "single-tree-registration": "Single Tree",
+      "multi-tree-registration": "Multiple Trees"
+    }
   }
 }

--- a/src/features/common/types/dataExplorer.d.ts
+++ b/src/features/common/types/dataExplorer.d.ts
@@ -124,36 +124,45 @@ export interface PlantLocationDetailsQueryRes {
   result: string;
 }
 
+export interface PlantLocationProperties {
+  hid: string;
+  type: 'single-tree-registration' | 'multi-tree-registration';
+}
+
 export interface PlantLocationDetails {
+  properties: PlantLocationProperties;
   plantedSpecies: PlantedSpecies[];
   totalPlantedTrees: number;
-  samplePlantLocations: SamplePlantLocation[];
-  totalSamplePlantLocations: number;
+  samplePlantLocations: null | SamplePlantLocation[];
+  totalSamplePlantLocations: null | number;
 }
 
 // --- types for plantLocationDetailsApi ------
 
 export interface PlantLocationDetailsApiResponse {
   res: {
+    properties: PlantLocationProperties;
     plantedSpecies: {
       treeCount: number;
       scientificName: string;
     }[];
     totalPlantedTrees: number;
-    samplePlantLocations: {
-      tag: string;
-      guid: string;
-      species: string;
-      geometry: {
-        type: string;
-        coordinates: number[];
-      };
-      measurements: {
-        width: string;
-        height: string;
-      };
-    }[];
-    totalSamplePlantLocations: number;
+    samplePlantLocations:
+      | null
+      | {
+          tag: string;
+          guid: string;
+          species: string;
+          geometry: {
+            type: string;
+            coordinates: number[];
+          };
+          measurements: {
+            width: string;
+            height: string;
+          };
+        }[];
+    totalSamplePlantLocations: null | number;
   };
 }
 

--- a/src/features/user/TreeMapper/Analytics/components/Map/components/PlantLocationDetails/index.module.scss
+++ b/src/features/user/TreeMapper/Analytics/components/Map/components/PlantLocationDetails/index.module.scss
@@ -70,6 +70,19 @@
       row-gap: 16px;
       width: 100%;
 
+      .header {
+        width: 100%;
+        padding: 0 5px;
+        font-size: 12px;
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: -8px;
+
+        .hid {
+          font-weight: 500;
+        }
+      }
+
       .topContainer {
         display: flex;
         justify-content: space-between;

--- a/src/features/user/TreeMapper/Analytics/components/Map/components/PlantLocationDetails/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Map/components/PlantLocationDetails/index.tsx
@@ -3,6 +3,7 @@ import styles from './index.module.scss';
 import {
   PlantLocationDetailsApiResponse,
   PlantLocation,
+  PlantLocationProperties,
 } from '../../../../../../../common/types/dataExplorer';
 import PlantLocationDetailsZeroState from '../PlantLocationDetailsZeroState';
 import TreeMapperIcon from '../TreeMapperIcon';
@@ -134,16 +135,30 @@ const SampleTreesInfo = ({
   );
 };
 
+const PlantLocationHeader = ({ type, hid }: PlantLocationProperties) => {
+  const t = useTranslations('TreemapperAnalytics');
+  const formattedHid = hid.substring(0, 3) + '-' + hid.substring(3);
+
+  return (
+    <header className={styles.header}>
+      <div>{t(`plantLocationType.${type}`)}</div>
+      <div className={styles.hid}>#{formattedHid}</div>
+    </header>
+  );
+};
+
 const PlantLocationDetails = ({
   plantLocationDetails,
   selectedLayer,
   loading,
 }: Props) => {
+  const plantLocationType = plantLocationDetails?.properties.type;
+
   const hasData =
     plantLocationDetails !== null &&
     Boolean(
-      selectedLayer.treeCount ||
-        selectedLayer?.density ||
+      (plantLocationType === 'multi-tree-registration' &&
+        (selectedLayer.treeCount || selectedLayer.density)) ||
         (plantLocationDetails?.plantedSpecies?.length || 0) > 0 ||
         (plantLocationDetails?.samplePlantLocations?.length || 0) > 0
     );
@@ -158,9 +173,18 @@ const PlantLocationDetails = ({
           </>
         ) : hasData ? (
           <div className={styles.contentTop}>
-            <PlantationUnitInfo selectedLayer={selectedLayer} />
+            <PlantLocationHeader
+              type={plantLocationDetails.properties.type}
+              hid={plantLocationDetails.properties.hid}
+            />
+            {plantLocationType === 'multi-tree-registration' && (
+              <PlantationUnitInfo selectedLayer={selectedLayer} />
+            )}
             <ListOfSpeciesPlanted plantLocationDetails={plantLocationDetails} />
-            <SampleTreesInfo plantLocationDetails={plantLocationDetails} />
+            {plantLocationType === 'multi-tree-registration' &&
+              plantLocationDetails.totalSamplePlantLocations !== null && (
+                <SampleTreesInfo plantLocationDetails={plantLocationDetails} />
+              )}
           </div>
         ) : (
           <>


### PR DESCRIPTION
- Fixes the data explorer queries to handle single tree registrations, and also makes tweaks to exclude deleted interventions, restrict data to single and multi tree registrations
- Updates the PlantLocationDetails component to handle single tree registrations, and also display a `hid` to identify the selected plant location