### PR TITLE
fix: handle site geometry null case

### DIFF
--- a/src/features/projectsV2/ProjectSnippet/index.tsx
+++ b/src/features/projectsV2/ProjectSnippet/index.tsx
@@ -54,7 +54,6 @@ export interface ImageSectionProps extends CommonProps {
   projectReviews: Review[] | undefined;
   classification: TreeProjectClassification;
   page?: 'project-list' | 'project-details';
-  setSelectedSite: SetState<number | null>;
   setPreventShallowPush: SetState<boolean> | undefined;
 }
 
@@ -73,7 +72,6 @@ const ProjectSnippetContent = ({
   page,
   setPreventShallowPush,
 }: ProjectSnippetContentProps) => {
-  const { setSelectedSite } = useProjects();
   const isTopProject = project.purpose === 'trees' && project.isTopProject;
   const isApproved = project.purpose === 'trees' && project.isApproved;
   const ecosystem =
@@ -111,7 +109,6 @@ const ProjectSnippetContent = ({
     projectReviews: project.reviews,
     classification: (project as TreeProjectConcise).classification,
     page,
-    setSelectedSite,
     setPreventShallowPush,
   };
   const projectInfoProps: ProjectInfoProps = {

--- a/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
@@ -26,7 +26,6 @@ const ImageSection = (props: ImageSectionProps) => {
     isTopProject,
     allowDonations,
     page,
-    setSelectedSite,
     setPreventShallowPush,
   } = props;
   const tManageProjects = useTranslations('ManageProjects');
@@ -38,7 +37,6 @@ const ImageSection = (props: ImageSectionProps) => {
 
   const handleBackButton = () => {
     if (setPreventShallowPush) setPreventShallowPush(true);
-    setSelectedSite(null);
     const previousPageRoute = sessionStorage.getItem('backNavigationUrl');
     const defaultRoute = `/${locale}/prd`;
     const queryParams = {
@@ -51,8 +49,11 @@ const ImageSection = (props: ImageSectionProps) => {
       ? previousPageRoute.split('?')[0]
       : defaultRoute;
 
-    const isAbsoluteUrl = previousPageRoute && (previousPageRoute.includes('http://') || previousPageRoute.includes('https://'));
-    const finalQueryParams = isAbsoluteUrl ? {}: queryParams
+    const isAbsoluteUrl =
+      previousPageRoute &&
+      (previousPageRoute.includes('http://') ||
+        previousPageRoute.includes('https://'));
+    const finalQueryParams = isAbsoluteUrl ? {} : queryParams;
     router
       .push({
         pathname: routerPath,

--- a/src/features/projectsV2/ProjectsContext.tsx
+++ b/src/features/projectsV2/ProjectsContext.tsx
@@ -269,13 +269,10 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
     projectSlug: string,
     siteIndex: number | null
   ) => {
-    if (!singleProject?.sites?.length) return;
-
+    if (!singleProject?.sites) return;
     setSelectedSite(siteIndex);
-
     const siteId =
       siteIndex !== null ? singleProject.sites[siteIndex]?.properties.id : null;
-
     updateUrlWithSiteId(locale, projectSlug, siteId);
   };
 

--- a/src/features/projectsV2/ProjectsContext.tsx
+++ b/src/features/projectsV2/ProjectsContext.tsx
@@ -269,13 +269,20 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
   const updateSiteAndUrl = (
     locale: string,
     projectSlug: string,
-    siteIndex: number | null
+    siteIndex?: number
   ) => {
-    if (!singleProject?.sites) return;
-    setSelectedSite(siteIndex);
-    const siteId =
-      siteIndex !== null ? singleProject.sites[siteIndex]?.properties.id : null;
-    updateUrlWithSiteId(locale, projectSlug, siteId);
+    if (
+      singleProject?.sites &&
+      singleProject.sites.length > 0 &&
+      siteIndex !== undefined
+    ) {
+      const siteId = singleProject.sites[siteIndex]?.properties.id;
+      setSelectedSite(siteIndex);
+      updateUrlWithSiteId(locale, projectSlug, siteId);
+    } else {
+      setSelectedSite(null);
+      updateUrlWithSiteId(locale, projectSlug, null);
+    }
   };
 
   useEffect(() => {
@@ -288,13 +295,13 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
       (requestedPlantLocation && requestedSite)
     )
       return;
-    
+
     if (requestedPlantLocation && selectedPlantLocation === null) {
       const hasNoSites = singleProject.sites?.length === 0;
 
       if (hasNoSites) {
         //Case when a direct link requests a specific plant location but no sites exist for a project(e.g projectSlug: mothersforest).
-        updateSiteAndUrl(locale, singleProject.slug, null);
+        updateSiteAndUrl(locale, singleProject.slug);
       } else {
         // Handle the case where a direct link requests a specific plant location (via URL query).
         // This will update the ploc param based on the requestedPlantLocation. If the requested hid is invalid,

--- a/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
+++ b/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
@@ -86,7 +86,7 @@ const SingleProjectView = ({ mapRef }: Props) => {
     // - false if there are no plant locations and no sites (i.e., a single project location only)
     // - true if there are no plant locations but there are multiple sites
     setIsSatelliteView(!isSingleProjectLocation && hasNoPlantLocations);
-  }, [plantLocations?.length, hasNoSites]);
+  }, [plantLocations, hasNoSites]);
 
   return (
     <>
@@ -97,9 +97,15 @@ const SingleProjectView = ({ mapRef }: Props) => {
           purpose={singleProject.purpose}
         />
       ) : (
-        <SitePolygon isSatelliteView={isSatelliteView} geoJson={sitesGeojson} />
+        <>
+          <SitePolygon
+            isSatelliteView={isSatelliteView}
+            geoJson={sitesGeojson}
+          />
+          {isSatelliteView && plantLocations !== null && <SatelliteLayer />}
+        </>
       )}
-      {isSatelliteView && <SatelliteLayer />}
+
       <PlantLocations />
     </>
   );

--- a/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
+++ b/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
@@ -18,21 +18,22 @@ interface Props {
 const SingleProjectView = ({ mapRef }: Props) => {
   const { singleProject, selectedSite, selectedPlantLocation, plantLocations } =
     useProjects();
-  if (!singleProject?.sites) return null;
-  const hasNoSites = singleProject.sites?.length === 0;
+  if (singleProject === null) return;
+
   const { isSatelliteView, setViewState, setIsSatelliteView } =
     useProjectsMap();
   const router = useRouter();
-  const { p: projectSlug } = router.query;
 
   const sitesGeojson = useMemo(() => {
     return {
       type: 'FeatureCollection' as const,
-      features: singleProject.sites ?? [],
+      features:
+        singleProject?.sites?.filter((site) => site.geometry !== null) ?? [],
     };
-  }, [projectSlug]);
-
+  }, [singleProject?.sites]);
+  const hasNoSites = sitesGeojson.features.length === 0;
   // Zoom to plant location
+
   useEffect(() => {
     if (!router.isReady || selectedPlantLocation === null) return;
     const { geometry } = selectedPlantLocation;
@@ -60,8 +61,7 @@ const SingleProjectView = ({ mapRef }: Props) => {
   // Zoom to project site
   useEffect(() => {
     if (!router.isReady || selectedPlantLocation !== null) return;
-
-    if (selectedSite !== null) {
+    if (sitesGeojson.features.length > 0 && selectedSite !== null) {
       zoomInToProjectSite(
         mapRef,
         sitesGeojson,
@@ -77,13 +77,16 @@ const SingleProjectView = ({ mapRef }: Props) => {
         zoomToLocation(setViewState, longitude, latitude, 10, 4000, mapRef);
       }
     }
-  }, [selectedSite, router.isReady, selectedPlantLocation]);
+  }, [selectedSite, sitesGeojson, router.isReady, selectedPlantLocation]);
 
   useEffect(() => {
-    const hasNoPlantLocations =
-      plantLocations?.length === 0 || plantLocations === null;
-    setIsSatelliteView(hasNoPlantLocations || hasNoSites);
-  }, [plantLocations, hasNoSites]);
+    const hasNoPlantLocations = !plantLocations?.length;
+    const isSingleProjectLocation = hasNoPlantLocations && hasNoSites;
+    // Satellite view will be:
+    // - false if there are no plant locations and no sites (i.e., a single project location only)
+    // - true if there are no plant locations but there are multiple sites
+    setIsSatelliteView(!isSingleProjectLocation && hasNoPlantLocations);
+  }, [plantLocations?.length, hasNoSites]);
 
   return (
     <>

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -25,7 +25,14 @@ const paramsToPreserve = [
   'project_list',
   'enable_intro',
 ];
-const paramsToDelete = ['locale', 'slug', 'p', 'ploc', 'backNavigationUrl'];
+const paramsToDelete = [
+  'locale',
+  'slug',
+  'p',
+  'ploc',
+  'backNavigationUrl',
+  'site',
+];
 
 /**
  * Updates and returns a query object for a URL based on the current path and specified parameters.


### PR DESCRIPTION
This PR addresses the case where a `project site geometry is null`, ensuring that the application handles this scenario gracefully without causing errors or unexpected behavior.