### PR TITLE
hotfix: avoid calling plantlocation api while switching between list …

### DIFF
--- a/src/features/projectsV2/ProjectDetails/index.tsx
+++ b/src/features/projectsV2/ProjectDetails/index.tsx
@@ -31,6 +31,7 @@ const ProjectDetails = ({
   const {
     singleProject,
     setSingleProject,
+    plantLocations,
     setPlantLocations,
     setIsLoading,
     setIsError,
@@ -108,9 +109,9 @@ const ProjectDetails = ({
         setIsLoading(false);
       }
     }
-    if (singleProject && singleProject?.purpose === 'trees')
+    if (singleProject && singleProject?.purpose === 'trees' && plantLocations === null) 
       loadPlantLocations();
-  }, [singleProject]);
+  }, [singleProject?.id]);
 
   const shouldShowPlantLocationInfo =
     (hoveredPlantLocation?.type === 'multi-tree-registration' ||

--- a/src/features/projectsV2/ProjectDetails/index.tsx
+++ b/src/features/projectsV2/ProjectDetails/index.tsx
@@ -109,9 +109,14 @@ const ProjectDetails = ({
         setIsLoading(false);
       }
     }
-    if (singleProject && singleProject?.purpose === 'trees' && plantLocations === null) 
+
+    if (
+      singleProject &&
+      singleProject?.purpose === 'trees' &&
+      plantLocations === null
+    )
       loadPlantLocations();
-  }, [singleProject?.id]);
+  }, [singleProject]);
 
   const shouldShowPlantLocationInfo =
     (hoveredPlantLocation?.type === 'multi-tree-registration' ||

--- a/src/features/projectsV2/ProjectsContext.tsx
+++ b/src/features/projectsV2/ProjectsContext.tsx
@@ -228,6 +228,15 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
   }, [currencyCode, setCurrencyCode]);
 
   useEffect(() => {
+    if (selectedMode === 'list' && singleProject !== null) {
+      setSelectedSamplePlantLocation(null);
+      setSelectedPlantLocation(null);
+      setHoveredPlantLocation(null);
+      updateSiteAndUrl(locale, singleProject.slug, 0);
+    }
+  }, [selectedMode, singleProject, locale]);
+
+  useEffect(() => {
     setDebouncedSearchValue('');
     if (page === 'project-details') {
       if (setSelectedMode) setSelectedMode('list');
@@ -239,7 +248,10 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
       setHoveredPlantLocation(null);
       setSelectedSite(0);
       setPreventShallowPush(false);
+      setPlantLocations(null);
     }
+    if (selectedMode === 'list' && page === 'project-list')
+      setPlantLocations(null);
   }, [page]);
 
   const pushWithShallow = (
@@ -288,7 +300,7 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
       (requestedPlantLocation && requestedSite)
     )
       return;
-    
+
     if (requestedPlantLocation && selectedPlantLocation === null) {
       const hasNoSites = singleProject.sites?.length === 0;
 
@@ -366,15 +378,6 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
     selectedPlantLocation,
     preventShallowPush,
   ]);
-
-  useEffect(() => {
-    if (selectedMode === 'list' && singleProject !== null) {
-      setSelectedSamplePlantLocation(null);
-      setSelectedPlantLocation(null);
-      setHoveredPlantLocation(null);
-      updateSiteAndUrl(locale, singleProject.slug, 0);
-    }
-  }, [selectedMode, singleProject, locale]);
 
   const value: ProjectsState | null = useMemo(
     () => ({


### PR DESCRIPTION
- [ ] I noticed that multiple calls are made to the plantLocations API in mobile devices (map mode) - This is getting called everytime map mode is exited