### PR TITLE
Project Details Navigation Improvements + Translation Issue Fix

### DIFF
--- a/src/features/projectsV2/ProjectSnippet/index.tsx
+++ b/src/features/projectsV2/ProjectSnippet/index.tsx
@@ -163,7 +163,11 @@ export default function ProjectSnippet({
   };
 
   const projectPath = useMemo(() => {
-    let path = `/${locale}${generateProjectLink(project.slug, router.asPath)}`;
+    let path = `/${locale}${generateProjectLink(
+      project.slug,
+      router.asPath,
+      locale
+    )}`;
     const params = new URLSearchParams();
 
     if (embed === 'true') {

--- a/src/features/projectsV2/ProjectsContext.tsx
+++ b/src/features/projectsV2/ProjectsContext.tsx
@@ -27,7 +27,7 @@ import getStoredCurrency from '../../utils/countryCurrency/getStoredCurrency';
 import { getRequest } from '../../utils/apiRequests/api';
 import { ErrorHandlingContext } from '../common/Layout/ErrorHandlingContext';
 import { useTenant } from '../common/Layout/TenantContext';
-import { updateUrlWithParams } from '../../utils/projectV2';
+import { buildProjectDetailsQuery } from '../../utils/projectV2';
 
 interface ProjectsState {
   projects: MapProject[] | null;
@@ -245,15 +245,37 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
       setPlantLocations(null);
   }, [page]);
 
-  const pushWithShallow = (
+  const updateProjectDetailsPath = (
     locale: string,
     projectSlug: string,
-    queryParams = {}
+    queryParams: Record<string, string> = {}
   ) => {
+    console.log('===== Pushing with shallow =====');
+    console.log('Locale:', locale);
+    console.log('Project Slug:', projectSlug);
+    console.log('Query Params:', queryParams);
+    console.log('Router Pathname:', router.pathname);
+    console.log('Router AsPath:', router.asPath);
+    console.log('Router Query:', router.query);
+    console.log('==============================');
     const pathname = `/${locale}/prd/${projectSlug}`;
-    router?.push({ pathname, query: queryParams }, undefined, {
-      shallow: true,
-    });
+
+    // Extract only the visible query params for the URL
+    const { locale: _, slug: __, p: ___, ...visibleParams } = queryParams;
+
+    router?.push(
+      {
+        pathname,
+        query: queryParams,
+      },
+      // Only show necessary params in the URL
+      `${pathname}${
+        Object.keys(visibleParams).length
+          ? '?' + new URLSearchParams(visibleParams).toString()
+          : ''
+      }`,
+      { shallow: true }
+    );
   };
 
   const updateUrlWithSiteId = (
@@ -261,12 +283,12 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
     projectSlug: string,
     siteId: string | null
   ) => {
-    const updatedQueryParams = updateUrlWithParams(
+    const updatedQueryParams = buildProjectDetailsQuery(
       router.asPath,
       router.query,
-      siteId
+      { siteId }
     );
-    pushWithShallow(locale, projectSlug, updatedQueryParams);
+    updateProjectDetailsPath(locale, projectSlug, updatedQueryParams);
   };
 
   const updateSiteAndUrl = (
@@ -325,8 +347,12 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
 
     // Handles updating the URL with the 'ploc' parameter when a user selects a different plant location.
     if (selectedPlantLocation) {
-      const updatedQueryParams = { ploc: selectedPlantLocation.hid };
-      pushWithShallow(locale, singleProject.slug, updatedQueryParams);
+      const updatedQueryParams = buildProjectDetailsQuery(
+        router.asPath,
+        router.query,
+        { plocId: selectedPlantLocation.hid }
+      );
+      updateProjectDetailsPath(locale, singleProject.slug, updatedQueryParams);
     }
   }, [
     page,

--- a/src/features/projectsV2/ProjectsContext.tsx
+++ b/src/features/projectsV2/ProjectsContext.tsx
@@ -250,14 +250,6 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
     projectSlug: string,
     queryParams: Record<string, string> = {}
   ) => {
-    console.log('===== Pushing with shallow =====');
-    console.log('Locale:', locale);
-    console.log('Project Slug:', projectSlug);
-    console.log('Query Params:', queryParams);
-    console.log('Router Pathname:', router.pathname);
-    console.log('Router AsPath:', router.asPath);
-    console.log('Router Query:', router.query);
-    console.log('==============================');
     const pathname = `/${locale}/prd/${projectSlug}`;
 
     // Extract only the visible query params for the URL

--- a/src/features/user/Account/components/AccountRecord.tsx
+++ b/src/features/user/Account/components/AccountRecord.tsx
@@ -171,7 +171,11 @@ export function DetailsComponent({ record }: DetailProps): ReactElement {
           {record.projectGuid ? (
             <a
               title={record.details.project}
-              href={generateProjectLink(record.projectGuid, router.asPath)}
+              href={generateProjectLink(
+                record.projectGuid,
+                router.asPath,
+                locale
+              )}
             >
               {record.details.project.length > 42
                 ? record.details.project.substring(0, 42)

--- a/src/features/user/ManageProjects/ProjectsContainer.tsx
+++ b/src/features/user/ManageProjects/ProjectsContainer.tsx
@@ -90,7 +90,7 @@ function SingleProject({ project }: { project: Properties }) {
         </div>
       </div>
       <div className={styles.projectLinksContainer}>
-        <Link href={generateProjectLink(project.id, router.asPath)}>
+        <Link href={generateProjectLink(project.id, router.asPath, locale)}>
           <button className={styles.secondaryLink}>{tCommon('view')}</button>
         </Link>
         <Link href={`/profile/projects/${project.id}?type=basic-details`}>

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -216,10 +216,15 @@ export const centerMapOnCoordinates = (
 
 export const generateProjectLink = (
   projectGuid: string,
-  routerAsPath: string
+  routerAsPath: string, //e.g. /en/yucatan, /en
+  locale: string //e.g. en
 ) => {
+  const nonLocalizedPath =
+    routerAsPath === `/${locale}`
+      ? '/'
+      : routerAsPath.replace(`/${locale}`, '');
   return `/prd/${projectGuid}?backNavigationUrl=${encodeURIComponent(
-    routerAsPath
+    nonLocalizedPath
   )}`;
 };
 

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -1,7 +1,7 @@
 import type { TreeProjectClassification } from '@planet-sdk/common';
 import type { PointLike } from 'react-map-gl-v7/maplibre';
-import type { ParsedUrlQuery } from 'querystring';
 import type { Position } from 'geojson';
+import type { ParsedUrlQuery } from 'querystring';
 import type {
   MapRef,
   MapProjectProperties,
@@ -18,22 +18,12 @@ import * as turf from '@turf/turf';
 
 export type MobileOs = 'android' | 'ios' | undefined;
 
-const paramsToPreserve = [
-  'embed',
-  'back_icon',
-  'callback',
-  'project_details',
-  'project_list',
-  'enable_intro',
-];
-const paramsToDelete = [
-  'locale',
-  'slug',
-  'p',
-  'ploc',
-  'backNavigationUrl',
-  'site',
-];
+const paramsToDelete = ['ploc', 'backNavigationUrl', 'site'];
+
+type RouteParams = {
+  siteId?: string | null;
+  plocId?: string | null;
+};
 
 /**
  * Updates and returns a query object for a URL based on the current path and specified parameters.
@@ -44,22 +34,40 @@ const paramsToDelete = [
  * @returns An updated query object with preserved, removed, and new parameter
  */
 
-export const updateUrlWithParams = (
+export const buildProjectDetailsQuery = (
   asPath: string,
   query: ParsedUrlQuery,
-  siteId: string | null
-) => {
-  const [, queryString] = asPath.split('?');
-  const currentUrlParams = new URLSearchParams(queryString || '');
-  const currentQuery = { ...query };
-  paramsToPreserve.forEach((param) => {
-    if (currentUrlParams.has(param)) {
-      currentQuery[param] = currentUrlParams.get(param) ?? '';
-    }
-  });
+  routeParams: RouteParams
+): Record<string, string> => {
+  console.log('updateUrlWithParams:');
+  console.log('  Path:', asPath);
+  console.log('  Query:', query);
+  console.log('  Route Params:', routeParams);
+  // Convert ParsedUrlQuery to Record<string, string> by filtering out non-string values
+  const currentQuery: Record<string, string> = Object.entries(query).reduce(
+    (stringQueryParams, [key, value]) => {
+      if (typeof value === 'string') {
+        stringQueryParams[key] = value;
+      }
+      return stringQueryParams;
+    },
+    {} as Record<string, string>
+  );
+
+  // Preserve and delete query parameters
   paramsToDelete.forEach((param) => delete currentQuery[param]);
-  //add project site param
-  if (siteId) currentQuery.site = siteId;
+
+  // Add routing params if provided
+  if (routeParams.siteId) {
+    currentQuery.site = routeParams.siteId;
+  }
+
+  if (routeParams.plocId) {
+    currentQuery.ploc = routeParams.plocId;
+  }
+
+  console.log('updateUrlWithParams: Updated Query Parameters:');
+  console.log('  Current Query:', JSON.stringify(currentQuery, null, 2));
   return currentQuery;
 };
 

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -25,6 +25,11 @@ type RouteParams = {
   plocId?: string | null;
 };
 
+/** Type predicate to check that the property contains a string value*/
+const isStringValue = (entry: [string, unknown]): entry is [string, string] => {
+  return typeof entry[1] === 'string';
+};
+
 /**
  * Updates and returns a query object for a URL based on the current path and specified parameters.
  * It preserves selected query parameters, removes unwanted ones, and adds or updates the site parameter.
@@ -39,19 +44,9 @@ export const buildProjectDetailsQuery = (
   query: ParsedUrlQuery,
   routeParams: RouteParams
 ): Record<string, string> => {
-  console.log('updateUrlWithParams:');
-  console.log('  Path:', asPath);
-  console.log('  Query:', query);
-  console.log('  Route Params:', routeParams);
   // Convert ParsedUrlQuery to Record<string, string> by filtering out non-string values
-  const currentQuery: Record<string, string> = Object.entries(query).reduce(
-    (stringQueryParams, [key, value]) => {
-      if (typeof value === 'string') {
-        stringQueryParams[key] = value;
-      }
-      return stringQueryParams;
-    },
-    {} as Record<string, string>
+  const currentQuery: Record<string, string> = Object.fromEntries(
+    Object.entries(query).filter(isStringValue)
   );
 
   // Preserve and delete query parameters
@@ -66,8 +61,6 @@ export const buildProjectDetailsQuery = (
     currentQuery.ploc = routeParams.plocId;
   }
 
-  console.log('updateUrlWithParams: Updated Query Parameters:');
-  console.log('  Current Query:', JSON.stringify(currentQuery, null, 2));
   return currentQuery;
 };
 

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -228,6 +228,41 @@ export const generateProjectLink = (
   )}`;
 };
 
+/**
+ * Takes a relative path and returns a localized version with the correct locale prefix.
+ * Query parameters are stripped from the input path.
+ * @param path - The relative path to localize
+ * @param locale - The current locale (e.g., 'en')
+ * @returns The localized path without query parameters
+ */
+export const getLocalizedPath = (path: string, locale: string): string => {
+  // Strip query parameters if present
+  const pathWithoutQuery = path.split('?')[0];
+
+  // Remove trailing slash if present
+  const cleanPath = pathWithoutQuery.endsWith('/')
+    ? pathWithoutQuery.slice(0, -1)
+    : pathWithoutQuery;
+
+  // Handle root path special case
+  if (cleanPath === '' || cleanPath === '/') {
+    return `/${locale}`;
+  }
+
+  // If path already starts with locale, return as is
+  if (cleanPath.startsWith(`/${locale}/`)) {
+    return cleanPath;
+  }
+
+  // Remove leading slash if present for consistent handling
+  const normalizedPath = cleanPath.startsWith('/')
+    ? cleanPath.slice(1)
+    : cleanPath;
+
+  // Add locale prefix
+  return `/${locale}/${normalizedPath}`;
+};
+
 export const getDeviceType = (): MobileOs => {
   const userAgent = navigator.userAgent;
   if (/android/i.test(userAgent)) return 'android';


### PR DESCRIPTION
## Changes
- **Fixed locale persistence during shallow routing in project details page**
- Improved query parameter management for site and plant location navigation
- Cleaned up URL appearance by hiding internal routing params (locale, slug, p)
- Added proper TypeScript types and removed type assertions
- Updates back navigation logic to preserve the locale
- Refactors back navigation logic to ensure path was localized and avoid an additional middleware run

## Technical Details
1. Introduced proper parameter management in `buildProjectDetailsQuery` (renamed from `updateUrlWithParams`):
  - Safely converts Next.js router query params to string-only values
  - Preserves necessary routing parameters while cleaning up internal ones
  - Returns strongly typed `Record<string, string>` for URL query params

2. Enhanced `updateProjectDetailsPath` (renamed from `pushWithShallow`):
  - Maintains internal routing state while showing clean URLs
  - Uses proper URL handling for both browser display and Next.js router
  - Keeps locale consistent during navigation

3. Unified handling of both site and plant location navigation:
  - Both now use the same query parameter management flow
  - Consistent approach to shallow routing throughout the project details page
  - Proper TypeScript types for navigation parameters

4. Enhanced `generateProjectLink` logic (supplementary change)
  - Updates logic for `backNavigationUrl` to strip locale from path
  - Preserves locale on going back to an "in-app page" even if locale was changed on the project details page

5. Refactored `handleBackButton` logic (supplementary change)
  - Handle locale prefixing in the client-side navigation logic instead of relying on middleware
  - Properly handle relative paths without locale prefix (e.g. '/prd' -> '/en/prd')
  - Handle root path localization correctly (e.g. '/' -> '/en')
  - Move path localization logic to a separate utility function
  - These changes reduce middleware runs and avoid potential caching issues by handling locale prefixing directly in the navigation code
   
## Understanding the Main Fix
The core issue stemmed from the interaction between shallow routing and our middleware:

1. Normal Navigation:
  - Middleware rewrites `/de/prd/yucatan` to `/sites/planet/de/prd/yucatan`
  - Next.js extracts dynamic parameters (`locale`, `slug`, `p`) from the rewritten path
  - These parameters are available in `router.query` but not in the URL query string

3. Shallow Routing:
  - Bypasses middleware (no server-side execution)
  - No URL rewrite occurs
  - We need to manually maintain these parameters in query state
  - Parameters need to be hidden from the URL to maintain consistent URL structure

The fix ensures that during shallow routing:
- Internal routing parameters (`locale`, `slug`, `p`) are preserved in `router.query`
- URL remains clean and consistent with middleware-processed URLs
- Locale context is maintained for next-intl