### PR TITLE
fix: adjust degradation year and year abandoned condition to exclude …

### DIFF
--- a/src/features/common/Layout/ProjectsLayout/ProjectsLayout.module.scss
+++ b/src/features/common/Layout/ProjectsLayout/ProjectsLayout.module.scss
@@ -49,7 +49,7 @@ $layoutPaddingBottom: 30px;
 
 .mapFeatureExplorerOverlay {
   position: absolute;
-  top: calc($layoutPaddingTop + 8px);
+  top: calc($layoutPaddingTop + 10px);
   right: calc($layoutPaddingSide + 10px);
   z-index: 1;
 }

--- a/src/features/projectsV2/ProjectDetails/components/KeyInfo.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/KeyInfo.tsx
@@ -117,13 +117,13 @@ const KeyInfo = ({
         )}
       </div>
 
-      <div className={styles.keyInfoSubContainer}>
-        {degradationYear && (
+      {degradationYear && (
+        <div className={styles.keyInfoSubContainer}>
           <SingleProjectInfoItem title={tProjectDetails('degradationYear')}>
             <p>{degradationYear}</p>
           </SingleProjectInfoItem>
-        )}
-      </div>
+        </div>
+      )}
 
       {activitySeasons && activitySeasons.length > 0 && (
         <SingleProjectInfoItem title={tProjectDetails('protectionSeasons')}>

--- a/src/features/projectsV2/ProjectDetails/components/ProjectInfo.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/ProjectInfo.tsx
@@ -155,7 +155,11 @@ const ProjectInfo = ({
       {isMobile && <MapPreview handleMap={handleMap} />}
       {shouldRenderKeyInfo && (
         <KeyInfo
-          abandonment={isTreeProject ? metadata.yearAbandoned : null}
+          abandonment={
+            isTreeProject && metadata.yearAbandoned !== 0
+              ? metadata.yearAbandoned
+              : null
+          }
           firstTreePlanted={isTreeProject ? metadata.firstTreePlanted : null}
           startingProtectionYear={
             isConservationProject ? metadata.startingProtectionYear : null
@@ -169,7 +173,11 @@ const ProjectInfo = ({
             isTreeProject ? metadata.maxPlantingDensity : null
           }
           employees={metadata.employeesCount}
-          degradationYear={isTreeProject ? metadata.degradationYear : null}
+          degradationYear={
+            isTreeProject && metadata.degradationYear !== 0
+              ? metadata.degradationYear
+              : null
+          }
         />
       )}
       {shouldRenderAdditionalInfo && (


### PR DESCRIPTION
- Updated the condition for `metadata.degradationYear`  and  `metadata.yearAbandoned` to ensure that projects with a degradation year and yearAbandoned year of `0` are excluded. 
- Minor position adjustment of the explore button