### PR TITLE
Ensure planting density is always passed to PlantingDetails component

### DIFF
--- a/src/features/projectsV2/ProjectDetails/components/MultiPlantLocationInfo.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/MultiPlantLocationInfo.tsx
@@ -90,7 +90,7 @@ const MultiPlantLocationInfo = ({
     </>,
     <PlantingDetails
       key="plantingDetails"
-      plantingDensity={hasSampleInterventions ? plantingDensity : null}
+      plantingDensity={plantingDensity}
       plantDate={plantLocationInfo?.interventionStartDate}
     />,
     isMultiTreeRegistration && plantLocationInfo.plantedSpecies.length > 0 && (


### PR DESCRIPTION
Always display plantingDensity, regardless of sample interventions.