### PR TITLE
fix: avoid returning to the map center after selecting a project from…

### DIFF
--- a/src/features/projectsV2/ProjectsMap/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/index.tsx
@@ -63,9 +63,10 @@ function ProjectsMap(props: ProjectsMapProps) {
         filteredProjects.length > 0 &&
         (filteredProjects.length < 30 ||
           filteredProjects.length === projects?.length) &&
-        map !== null;
-      if (!shouldCenterMap) return;
+        map !== null &&
+        props.page === 'project-list';
 
+      if (!shouldCenterMap) return;
       const validFeatures = getValidFeatures(filteredProjects);
       if (validFeatures.length === 0) return;
 


### PR DESCRIPTION
Bug -> When a user searches for a project, the map should center on that project. After selecting the searched project, the map should zoom in while staying centered on the selected project's location. However, instead of remaining centered on the selected project, the map shifts to its overall center.
