### PR TITLE
Donor circle member badge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@mui/x-date-pickers": "^5.0.15",
         "@netlify/plugin-nextjs": "^4.33.0",
         "@next/bundle-analyzer": "^10.2.3",
-        "@planet-sdk/common": "^0.1.43",
+        "@planet-sdk/common": "^0.1.46",
         "@prisma/client": "^4.13.0",
         "@sentry/browser": "^6.15.0",
         "@sentry/integrations": "^6.19.2",
@@ -5190,9 +5190,9 @@
       }
     },
     "node_modules/@planet-sdk/common": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/@planet-sdk/common/-/common-0.1.43.tgz",
-      "integrity": "sha512-TlamXIhBFwASi3pqGx/ZiqdLCasIW0HkY1T8JZkFPL8/DN4Y4+NcMeX5LMzKm2Z6My/BVrbjzYr+3x+W8bdStw==",
+      "version": "0.1.46",
+      "resolved": "https://registry.npmjs.org/@planet-sdk/common/-/common-0.1.46.tgz",
+      "integrity": "sha512-o26G7RhadrP1HXlflr4dSyZPfhxsMqe1GZiGWXXwhA7Z5fefNW+gDZhI9W8V24iR8GnGPTGX+KPC7nmP8n8LnQ==",
       "license": "ISC",
       "dependencies": {
         "@types/geojson": "^7946.0.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@mui/x-date-pickers": "^5.0.15",
         "@netlify/plugin-nextjs": "^4.33.0",
         "@next/bundle-analyzer": "^10.2.3",
-        "@planet-sdk/common": "^0.1.41",
+        "@planet-sdk/common": "^0.1.43",
         "@prisma/client": "^4.13.0",
         "@sentry/browser": "^6.15.0",
         "@sentry/integrations": "^6.19.2",
@@ -5190,9 +5190,10 @@
       }
     },
     "node_modules/@planet-sdk/common": {
-      "version": "0.1.41",
-      "resolved": "https://registry.npmjs.org/@planet-sdk/common/-/common-0.1.41.tgz",
-      "integrity": "sha512-GNl6UORtHI5t3UNisTHsONn9X/ZFJphnZvChmsWQtV0h9kCxberkdZxSyUSnWgzwHeupuiyl/RK0pYbxFgqH5g==",
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/@planet-sdk/common/-/common-0.1.43.tgz",
+      "integrity": "sha512-TlamXIhBFwASi3pqGx/ZiqdLCasIW0HkY1T8JZkFPL8/DN4Y4+NcMeX5LMzKm2Z6My/BVrbjzYr+3x+W8bdStw==",
+      "license": "ISC",
       "dependencies": {
         "@types/geojson": "^7946.0.10"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@mui/x-date-pickers": "^5.0.15",
     "@netlify/plugin-nextjs": "^4.33.0",
     "@next/bundle-analyzer": "^10.2.3",
-    "@planet-sdk/common": "^0.1.43",
+    "@planet-sdk/common": "^0.1.46",
     "@prisma/client": "^4.13.0",
     "@sentry/browser": "^6.15.0",
     "@sentry/integrations": "^6.19.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@mui/x-date-pickers": "^5.0.15",
     "@netlify/plugin-nextjs": "^4.33.0",
     "@next/bundle-analyzer": "^10.2.3",
-    "@planet-sdk/common": "^0.1.41",
+    "@planet-sdk/common": "^0.1.43",
     "@prisma/client": "^4.13.0",
     "@sentry/browser": "^6.15.0",
     "@sentry/integrations": "^6.19.2",

--- a/public/assets/images/icons/ProgressBarIcons.tsx
+++ b/public/assets/images/icons/ProgressBarIcons.tsx
@@ -1,4 +1,5 @@
-import { IconProps } from '../../../../src/features/common/types/common';
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 export const AreaRestoredIcon = ({ width }: IconProps) => {
   return (
     <svg

--- a/public/static/locales/en/profile.json
+++ b/public/static/locales/en/profile.json
@@ -2,7 +2,6 @@
   "Profile": {
     "myProfile": {
       "memberSince": "Member since {date}",
-      "userDescription": "{bio}",
       "donorCircleMember": "Donor Circle-Member"
     },
     "feature": {

--- a/public/static/locales/en/profile.json
+++ b/public/static/locales/en/profile.json
@@ -2,7 +2,8 @@
   "Profile": {
     "myProfile": {
       "memberSince": "Member since {date}",
-      "userDescription": "{bio}"
+      "userDescription": "{bio}",
+      "donorCircleMember": "Donor Circle-Member"
     },
     "feature": {
       "redeem": "Redeem",

--- a/src/features/user/Profile/ProfileCard/MicroComponents/DonorCircleMemberBadge.tsx
+++ b/src/features/user/Profile/ProfileCard/MicroComponents/DonorCircleMemberBadge.tsx
@@ -1,0 +1,15 @@
+import { useTranslations } from 'next-intl';
+import { TreesPlantedIcon } from '../../../../../../public/assets/images/icons/ProgressBarIcons';
+import styles from '../ProfileCard.module.scss';
+
+const DonorCircleMemberBadge = () => {
+  const t = useTranslations('Profile');
+  return (
+    <div className={styles.donorCircleMemberBadge}>
+      <TreesPlantedIcon width={15} />
+      <span role="status">{t('myProfile.donorCircleMember')}</span>
+    </div>
+  );
+};
+
+export default DonorCircleMemberBadge;

--- a/src/features/user/Profile/ProfileCard/ProfileCard.module.scss
+++ b/src/features/user/Profile/ProfileCard/ProfileCard.module.scss
@@ -14,9 +14,38 @@
   background-repeat: no-repeat;
   background-size: cover;
   min-height: 8rem;
-
+  position: relative;
   @include mdTabletView {
     flex: 1;
+  }
+}
+
+.donorCircleMemberBadge {
+  width: max-content;
+  display: flex;
+  gap: 9px;
+  position: absolute;
+  top: 60%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(211, 234, 221, 1);
+  border-radius: 16px;
+  padding: 8px 16px;
+  color: $primaryDarkColor;
+  font-size: $fontXSmall;
+  line-height: 16.34px;
+  font-weight: 700;
+  svg path {
+    fill: $primaryDarkColor;
+  }
+  @include xsPhoneView {
+    top: 35%;
+  }
+  @include smTabletView {
+    top: 35%;
+  }
+  @include lgLaptopView {
+    top: 60%;
   }
 }
 

--- a/src/features/user/Profile/ProfileCard/ProfileCard.module.scss
+++ b/src/features/user/Profile/ProfileCard/ProfileCard.module.scss
@@ -14,20 +14,20 @@
   background-repeat: no-repeat;
   background-size: cover;
   min-height: 8rem;
-  position: relative;
   @include mdTabletView {
     flex: 1;
   }
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
 }
 
 .donorCircleMemberBadge {
   width: max-content;
+  height: fit-content;
   display: flex;
   gap: 9px;
-  position: absolute;
-  top: 60%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  margin-bottom: 4.5rem;
   background: rgba(211, 234, 221, 1);
   border-radius: 16px;
   padding: 8px 16px;
@@ -37,15 +37,6 @@
   font-weight: 700;
   svg path {
     fill: $primaryDarkColor;
-  }
-  @include xsPhoneView {
-    top: 35%;
-  }
-  @include smTabletView {
-    top: 35%;
-  }
-  @include lgLaptopView {
-    top: 60%;
   }
 }
 

--- a/src/features/user/Profile/ProfileCard/index.tsx
+++ b/src/features/user/Profile/ProfileCard/index.tsx
@@ -1,3 +1,5 @@
+import type { ProfileV2Props } from '../../../common/types/profile';
+
 import React from 'react';
 import { Avatar } from '@mui/material';
 import getImageUrl from '../../../../utils/getImageURL';
@@ -8,8 +10,8 @@ import {
 } from '../../../../../public/assets/images/icons/ProfilePageV2Icons';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
-import { ProfileV2Props } from '../../../common/types/profile';
 import ProfileActions from './ProfileActions';
+import DonorCircleMemberBadge from './MicroComponents/DonorCircleMemberBadge';
 
 const ProfileCard = ({ userProfile, profilePageType }: ProfileV2Props) => {
   const t = useTranslations('Profile');
@@ -17,10 +19,12 @@ const ProfileCard = ({ userProfile, profilePageType }: ProfileV2Props) => {
   const userImageUrl = userProfile?.image
     ? getImageUrl('profile', 'thumb', userProfile.image)
     : '';
-
   return (
     <div className={styles.profileCardContainer}>
-      <div className={styles.profileBackground}></div>
+      <div className={styles.profileBackground}>
+        {/* planet-sdk need to be updated  to include isMember*/}
+        {isPrivateAccount && userProfile.isMember && <DonorCircleMemberBadge />}
+      </div>
       <div className={styles.profilePicture}>
         {/* if no user profile picture exists or image is fetched from CDN in development env, show default profile image */}
         {userImageUrl && !userImageUrl.includes('development') ? (

--- a/src/features/user/Profile/ProfileCard/index.tsx
+++ b/src/features/user/Profile/ProfileCard/index.tsx
@@ -8,13 +8,11 @@ import {
   DefaultUserProfileImage,
   SettingsIcon,
 } from '../../../../../public/assets/images/icons/ProfilePageV2Icons';
-import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import ProfileActions from './ProfileActions';
 import DonorCircleMemberBadge from './MicroComponents/DonorCircleMemberBadge';
 
 const ProfileCard = ({ userProfile, profilePageType }: ProfileV2Props) => {
-  const t = useTranslations('Profile');
   const isPrivateAccount = profilePageType === 'private';
   const userImageUrl = userProfile?.image
     ? getImageUrl('profile', 'thumb', userProfile.image)

--- a/src/features/user/Profile/ProfileCard/index.tsx
+++ b/src/features/user/Profile/ProfileCard/index.tsx
@@ -22,7 +22,6 @@ const ProfileCard = ({ userProfile, profilePageType }: ProfileV2Props) => {
   return (
     <div className={styles.profileCardContainer}>
       <div className={styles.profileBackground}>
-        {/* planet-sdk need to be updated  to include isMember*/}
         {isPrivateAccount && userProfile.isMember && <DonorCircleMemberBadge />}
       </div>
       <div className={styles.profilePicture}>
@@ -45,11 +44,7 @@ const ProfileCard = ({ userProfile, profilePageType }: ProfileV2Props) => {
         )}
         <div className={styles.profileNameAndDescriptionContainer}>
           <h2>{userProfile?.displayName}</h2>
-          <p>
-            {t('myProfile.userDescription', {
-              bio: userProfile?.bio,
-            })}
-          </p>
+          <p>{userProfile?.bio}</p>
         </div>
 
         {profilePageType === 'private' ? (


### PR DESCRIPTION
Handle rendering of donor circle member badge in profile card

- Display the donor circle member badge when `isMember` is `true` and the profile is set to private.
- Updated the profile card layout to accommodate the donor circle badge accordingly.