### PR TITLE
Hotfix/token api break

### DIFF
--- a/src/features/common/Layout/UserPropsContext.tsx
+++ b/src/features/common/Layout/UserPropsContext.tsx
@@ -77,7 +77,7 @@ export const UserPropsProvider: FC = ({ children }) => {
     if (!isLoading)
       if (isAuthenticated) loadToken();
       else setContextLoaded(true);
-  }, [isLoading, isAuthenticated, getAccessTokenSilently, loginWithRedirect]);
+  }, [isLoading, isAuthenticated]);
 
   const logoutUser = (
     returnUrl: string | undefined = `${window.location.origin}/`

--- a/src/features/common/Layout/UserPropsContext.tsx
+++ b/src/features/common/Layout/UserPropsContext.tsx
@@ -1,13 +1,13 @@
-import {
-  useAuth0,
-  User as Auth0User,
-  RedirectLoginOptions,
-} from '@auth0/auth0-react';
+import type { FC } from 'react';
+import type { RedirectLoginOptions } from '@auth0/auth0-react';
+import type { User } from '@planet-sdk/common/build/types/user';
+import type { SetState } from '../types/common';
+import type { User as Auth0User } from '@auth0/auth0-react';
+
+import { useAuth0 } from '@auth0/auth0-react';
 import { useRouter } from 'next/router';
-import React, { FC, useContext } from 'react';
+import React, { useContext } from 'react';
 import { getAccountInfo } from '../../../utils/apiRequests/api';
-import { User } from '@planet-sdk/common/build/types/user';
-import { SetState } from '../types/common';
 import { useTenant } from './TenantContext';
 
 interface UserPropsContextInterface {

--- a/src/features/common/Layout/UserPropsContext.tsx
+++ b/src/features/common/Layout/UserPropsContext.tsx
@@ -63,13 +63,21 @@ export const UserPropsProvider: FC = ({ children }) => {
 
   React.useEffect(() => {
     async function loadToken() {
-      const accessToken = await getAccessTokenSilently();
-      setToken(accessToken);
+      try {
+        const accessToken = await getAccessTokenSilently();
+        setToken(accessToken);
+      } catch (error) {
+        console.error('Error fetching access token:', error);
+        loginWithRedirect({
+          redirectUri: `${window.location.origin}/login`,
+          ui_locales: localStorage.getItem('language') || 'en',
+        });
+      }
     }
     if (!isLoading)
       if (isAuthenticated) loadToken();
       else setContextLoaded(true);
-  }, [isLoading, isAuthenticated]);
+  }, [isLoading, isAuthenticated, getAccessTokenSilently, loginWithRedirect]);
 
   const logoutUser = (
     returnUrl: string | undefined = `${window.location.origin}/`


### PR DESCRIPTION
Fixed the invalid_grant (403 Forbidden) error by implementing a` try-catch` block in the useEffect for token retrieval.
If an error occurs while fetching the access token, the user is redirected to the login page to resolve the invalid or expired `refresh token.`