### PR TITLE
feat: add `locale` as a dependency for `getSearchProjects` useCallback

### DIFF
--- a/src/features/projectsV2/ProjectsContext.tsx
+++ b/src/features/projectsV2/ProjectsContext.tsx
@@ -171,7 +171,7 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
       });
       return filteredProjects;
     },
-    []
+    [locale]
   );
 
   const filteredProjects = useMemo(() => {


### PR DESCRIPTION
Issue :
There was an issue where the search functionality only returned results when searching for `Germany` in German, but not for `Deutschland`. This issue occurred when the language was switched, and the search did not account for the localized term for Germany in German.

Solution:
Added `locale` as a  dependency  for `getSearchProjects` useCallback.
