### PR TITLE
feat: avoid rendering project tabs for Salesforce tenant

### DIFF
--- a/src/features/projectsV2/ProjectListControls/ProjectListControlForMobile.tsx
+++ b/src/features/projectsV2/ProjectListControls/ProjectListControlForMobile.tsx
@@ -33,7 +33,7 @@ interface ProjectListControlForMobileProps {
   filteredProjects: MapProject[] | undefined;
   mapOptions: MapOptions;
   updateMapOption: (option: keyof MapOptions, value: boolean) => void;
-  isSalesforceTenant: boolean;
+  shouldHideProjectTabs: boolean;
 }
 
 const ProjectListControlForMobile = ({
@@ -53,7 +53,7 @@ const ProjectListControlForMobile = ({
   setIsSearching,
   mapOptions,
   updateMapOption,
-  isSalesforceTenant,
+  shouldHideProjectTabs,
 }: ProjectListControlForMobileProps) => {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const tAllProjects = useTranslations('AllProjects');
@@ -61,7 +61,7 @@ const ProjectListControlForMobile = ({
   const hasFilterApplied = selectedClassification.length > 0;
   const shouldDisplayFilterResults = hasFilterApplied && selectedMode !== 'map';
   const shouldDisplayProjectListTab =
-    !hasFilterApplied && selectedMode !== 'map' && !isSalesforceTenant;
+    !hasFilterApplied && selectedMode !== 'map' && !shouldHideProjectTabs;
   const shouldDisplayMapFeatureExplorer = selectedMode === 'map';
   const projectListControlsMobileClasses = `${
     styles.projectListControlsMobile

--- a/src/features/projectsV2/ProjectListControls/ProjectListControlForMobile.tsx
+++ b/src/features/projectsV2/ProjectListControls/ProjectListControlForMobile.tsx
@@ -33,6 +33,7 @@ interface ProjectListControlForMobileProps {
   filteredProjects: MapProject[] | undefined;
   mapOptions: MapOptions;
   updateMapOption: (option: keyof MapOptions, value: boolean) => void;
+  isSalesforceTenant: boolean;
 }
 
 const ProjectListControlForMobile = ({
@@ -52,6 +53,7 @@ const ProjectListControlForMobile = ({
   setIsSearching,
   mapOptions,
   updateMapOption,
+  isSalesforceTenant,
 }: ProjectListControlForMobileProps) => {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const tAllProjects = useTranslations('AllProjects');
@@ -59,7 +61,7 @@ const ProjectListControlForMobile = ({
   const hasFilterApplied = selectedClassification.length > 0;
   const shouldDisplayFilterResults = hasFilterApplied && selectedMode !== 'map';
   const shouldDisplayProjectListTab =
-    !hasFilterApplied && selectedMode !== 'map';
+    !hasFilterApplied && selectedMode !== 'map' && !isSalesforceTenant;
   const shouldDisplayMapFeatureExplorer = selectedMode === 'map';
   const projectListControlsMobileClasses = `${
     styles.projectListControlsMobile

--- a/src/features/projectsV2/ProjectListControls/index.tsx
+++ b/src/features/projectsV2/ProjectListControls/index.tsx
@@ -41,7 +41,6 @@ const ProjectListControls = ({
   const tAllProjects = useTranslations('AllProjects');
   const tCommon = useTranslations('Common');
   const hasFilterApplied = selectedClassification.length > 0;
-  const shouldDisplayTabs = !shouldHideProjectTabs;
 
   const projectListTabProps = {
     setIsFilterOpen,
@@ -79,15 +78,16 @@ const ProjectListControls = ({
       );
     }
 
-    if (shouldDisplayTabs)
-      return <ProjectListTabLargeScreen {...projectListTabProps} />;
+    if (shouldHideProjectTabs) {
+      return (
+        <h2 className={styles.projectListHeaderText}>
+          {tCommon('stopTalkingStartPlanting')}
+        </h2>
+      );
+    }
 
-    return (
-      <h2 className={styles.projectListHeaderText}>
-        {tCommon('stopTalkingStartPlanting')}
-      </h2>
-    );
-  }, [hasFilterApplied, shouldDisplayTabs, filteredProjects]);
+    return <ProjectListTabLargeScreen {...projectListTabProps} />;
+  }, [hasFilterApplied, shouldHideProjectTabs, filteredProjects]);
 
   return (
     <>

--- a/src/features/projectsV2/ProjectListControls/index.tsx
+++ b/src/features/projectsV2/ProjectListControls/index.tsx
@@ -22,6 +22,7 @@ export interface ProjectListControlsProps {
   debouncedSearchValue: string;
   setDebouncedSearchValue: SetState<string>;
   filteredProjects: MapProject[] | undefined;
+  isSalesforceTenant: boolean;
 }
 const ProjectListControls = ({
   projectCount,
@@ -33,11 +34,12 @@ const ProjectListControls = ({
   debouncedSearchValue,
   setDebouncedSearchValue,
   filteredProjects,
+  isSalesforceTenant,
 }: ProjectListControlsProps) => {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
   const tAllProjects = useTranslations('AllProjects');
-
+  const tCommon = useTranslations('Common');
   const hasFilterApplied = selectedClassification.length > 0;
 
   const projectListTabProps = {
@@ -78,7 +80,15 @@ const ProjectListControls = ({
               })}
             </div>
           ) : (
-            <ProjectListTabLargeScreen {...projectListTabProps} />
+            <>
+              {isSalesforceTenant ? (
+                <h2 className={styles.salesforceHeaderText}>
+                  {tCommon('stopTalkingStartPlanting')}
+                </h2>
+              ) : (
+                <ProjectListTabLargeScreen {...projectListTabProps} />
+              )}
+            </>
           )}
           <SearchAndFilter {...searchAndFilterProps} />
         </div>

--- a/src/features/projectsV2/ProjectListControls/styles/ProjectListControls.module.scss
+++ b/src/features/projectsV2/ProjectListControls/styles/ProjectListControls.module.scss
@@ -26,7 +26,10 @@
     }
   }
 }
-
+.salesforceHeaderText {
+  font-weight: 600;
+  margin-left: 20px;
+}
 .tabsContainer,
 .projectListControlsMobile {
   display: flex;

--- a/src/features/projectsV2/ProjectListControls/styles/ProjectListControls.module.scss
+++ b/src/features/projectsV2/ProjectListControls/styles/ProjectListControls.module.scss
@@ -26,7 +26,7 @@
     }
   }
 }
-.salesforceHeaderText {
+.projectListHeaderText {
   font-weight: 600;
   margin-left: 20px;
 }

--- a/src/features/projectsV2/ProjectsSection.tsx
+++ b/src/features/projectsV2/ProjectsSection.tsx
@@ -33,7 +33,8 @@ const ProjectsSection = ({ isMobile }: ProjectsSectionProps) => {
   const { mapOptions, updateMapOption } = useProjectsMap();
   const [tabSelected, setTabSelected] = useState<ProjectTabs>('topProjects');
   const { tenantConfig } = useTenant();
-  const isSalesforceTenant = tenantConfig.config.slug === 'salesforce';
+  const shouldHideProjectTabs =
+    tenantConfig.topProjectsOnly !== undefined && tenantConfig.topProjectsOnly;
   if ((isLoading || isError) && filteredProjects?.length === 0) {
     return <Skeleton className={styles.projectSectionSkeleton} />;
   }
@@ -50,7 +51,7 @@ const ProjectsSection = ({ isMobile }: ProjectsSectionProps) => {
     debouncedSearchValue,
     setDebouncedSearchValue,
     filteredProjects,
-    isSalesforceTenant,
+    shouldHideProjectTabs,
   };
   const projectListControlMobileProps = {
     debouncedSearchValue,

--- a/src/features/projectsV2/ProjectsSection.tsx
+++ b/src/features/projectsV2/ProjectsSection.tsx
@@ -33,8 +33,7 @@ const ProjectsSection = ({ isMobile }: ProjectsSectionProps) => {
   const { mapOptions, updateMapOption } = useProjectsMap();
   const [tabSelected, setTabSelected] = useState<ProjectTabs>('topProjects');
   const { tenantConfig } = useTenant();
-  const shouldHideProjectTabs =
-    tenantConfig.topProjectsOnly !== undefined && tenantConfig.topProjectsOnly;
+  const shouldHideProjectTabs = tenantConfig.topProjectsOnly === true;
   if ((isLoading || isError) && filteredProjects?.length === 0) {
     return <Skeleton className={styles.projectSectionSkeleton} />;
   }

--- a/src/features/projectsV2/ProjectsSection.tsx
+++ b/src/features/projectsV2/ProjectsSection.tsx
@@ -8,6 +8,7 @@ import ProjectListControlForMobile from './ProjectListControls/ProjectListContro
 import ProjectList from './ProjectList';
 import { useProjectsMap } from './ProjectsMapContext';
 import ProjectsListMeta from '../../utils/getMetaTags/ProjectsListMeta';
+import { useTenant } from '../common/Layout/TenantContext';
 
 interface ProjectsSectionProps {
   isMobile: boolean;
@@ -31,6 +32,8 @@ const ProjectsSection = ({ isMobile }: ProjectsSectionProps) => {
   } = useProjects();
   const { mapOptions, updateMapOption } = useProjectsMap();
   const [tabSelected, setTabSelected] = useState<ProjectTabs>('topProjects');
+  const { tenantConfig } = useTenant();
+  const isSalesforceTenant = tenantConfig.config.slug === 'salesforce';
   if ((isLoading || isError) && filteredProjects?.length === 0) {
     return <Skeleton className={styles.projectSectionSkeleton} />;
   }
@@ -47,6 +50,7 @@ const ProjectsSection = ({ isMobile }: ProjectsSectionProps) => {
     debouncedSearchValue,
     setDebouncedSearchValue,
     filteredProjects,
+    isSalesforceTenant,
   };
   const projectListControlMobileProps = {
     debouncedSearchValue,


### PR DESCRIPTION
This update modifies the behavior of the project tabs for Salesforce tenants:

On desktop, project tabs are replaced with a header text.
On mobile, neither the text nor the project tabs are rendered.