### PR TITLE
refactor: apply 'import type' for type-only imports via ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,7 +53,12 @@ module.exports = {
     'import/extensions': 'off',
     'import/no-unresolved': 'off',
     'react/jsx-no-literals': 'off',
-    '@typescript-eslint/consistent-type-imports': 'warn',
+    '@typescript-eslint/consistent-type-imports': [
+      'warn',
+      {
+        prefer: 'type-imports',
+      },
+    ],
     '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/no-empty-function': 'off',

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+import { NextResponse } from 'next/server';
 import { getTenantConciseInfo } from './src/utils/multiTenancy/helpers';
 import { match as matchLocale } from '@formatjs/intl-localematcher';
 import Negotiator from 'negotiator';

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,12 +1,13 @@
-import Custom404Image from '../public/assets/images/Custom404Image';
-import { useRouter } from 'next/router';
-import Footer from '../src/features/common/Layout/Footer';
-import {
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
-import { AbstractIntlMessages } from 'next-intl';
+import type { AbstractIntlMessages } from 'next-intl';
+
+import Custom404Image from '../public/assets/images/Custom404Image';
+import { useRouter } from 'next/router';
+import Footer from '../src/features/common/Layout/Footer';
 import getMessagesForPage from '../src/utils/language/getMessagesForPage';
 
 interface Props {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,12 +1,20 @@
+import type { EmotionCache } from '@emotion/react';
+import type { ReactElement, ReactNode } from 'react';
+import type { AppContext, AppInitialProps, AppProps } from 'next/app';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type { AbstractIntlMessages } from 'next-intl';
+import type { NextPage } from 'next';
+import type { SetState } from '../src/features/common/types/common';
+
 import CssBaseline from '@mui/material/CssBaseline';
-import { CacheProvider, EmotionCache } from '@emotion/react';
+import { CacheProvider } from '@emotion/react';
 import createEmotionCache from '../src/createEmotionCache';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import 'mapbox-gl-compare/dist/mapbox-gl-compare.css';
-import React, { ReactElement, ReactNode, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import TagManager from 'react-gtm-module';
 import Router from 'next/router';
-import App, { AppContext, AppInitialProps, AppProps } from 'next/app';
+import App from 'next/app';
 import { Auth0Provider } from '@auth0/auth0-react';
 // NOTE - needs to be removed when old projects code is removed
 import '../src/features/projects/styles/MapPopup.scss';
@@ -43,10 +51,7 @@ import {
   getTenantConfig,
   getTenantSlug,
 } from '../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
-import { AbstractIntlMessages, NextIntlClientProvider } from 'next-intl';
-import { NextPage } from 'next';
-import { SetState } from '../src/features/common/types/common';
+import { NextIntlClientProvider } from 'next-intl';
 
 const VideoContainer = dynamic(
   () => import('../src/features/common/LandingVideo'),

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,17 +1,11 @@
-import Document, {
-  DocumentContext,
-  DocumentInitialProps,
-  Head,
-  Html,
-  Main,
-  NextScript,
-} from 'next/document';
+import type { EmotionCache } from '@emotion/react';
+import type { AppType } from 'next/app';
+import type { DocumentContext, DocumentInitialProps } from 'next/document';
+
+import Document, { Head, Html, Main, NextScript } from 'next/document';
 import createEmotionServer from '@emotion/server/create-instance';
 import createEmotionCache from '../src/createEmotionCache';
-import { EmotionCache } from '@emotion/react';
-
 import React from 'react';
-import { AppType } from 'next/app';
 
 class MyDocument extends Document {
   static async getInitialProps(

--- a/pages/api/data-explorer/export.ts
+++ b/pages/api/data-explorer/export.ts
@@ -1,11 +1,12 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { IExportData } from '../../../src/features/common/types/dataExplorer';
+
 import db from '../../../src/utils/connectDB';
 import nc from 'next-connect';
 import {
   rateLimiter,
   speedLimiter,
 } from '../../../src/middlewares/rate-limiter';
-import { IExportData } from '../../../src/features/common/types/dataExplorer';
 
 const handler = nc<NextApiRequest, NextApiResponse>();
 

--- a/pages/api/data-explorer/map/distinct-species/[projectId].ts
+++ b/pages/api/data-explorer/map/distinct-species/[projectId].ts
@@ -1,14 +1,15 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type {
+  DistinctSpecies,
+  UncleanDistinctSpecies,
+} from '../../../../../src/features/common/types/dataExplorer';
+
 import db from '../../../../../src/utils/connectDB';
 import nc from 'next-connect';
 import {
   rateLimiter,
   speedLimiter,
 } from '../../../../../src/middlewares/rate-limiter';
-import {
-  DistinctSpecies,
-  UncleanDistinctSpecies,
-} from '../../../../../src/features/common/types/dataExplorer';
 import redisClient from '../../../../../src/redis-client';
 import { cacheKeyPrefix } from '../../../../../src/utils/constants/cacheKeyPrefix';
 

--- a/pages/api/data-explorer/map/plant-location/[plantLocationId].ts
+++ b/pages/api/data-explorer/map/plant-location/[plantLocationId].ts
@@ -1,10 +1,11 @@
-import { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
-import db from '../../../../../src/utils/connectDB';
-import {
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type {
   PlantLocationDetails,
   PlantLocationDetailsQueryRes,
 } from '../../../../../src/features/common/types/dataExplorer';
+
+import nc from 'next-connect';
+import db from '../../../../../src/utils/connectDB';
 
 const handler = nc<NextApiRequest, NextApiResponse>();
 

--- a/pages/api/data-explorer/map/plant-location/index.ts
+++ b/pages/api/data-explorer/map/plant-location/index.ts
@@ -1,8 +1,9 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { Geometry } from '@turf/turf';
+import type { SinglePlantLocationApiResponse } from '../../../../../src/features/common/types/dataExplorer';
+
 import nc from 'next-connect';
 import db from '../../../../../src/utils/connectDB';
-import { Geometry } from '@turf/turf';
-import { SinglePlantLocationApiResponse } from '../../../../../src/features/common/types/dataExplorer';
 import { QueryType } from '../../../../../src/features/user/TreeMapper/Analytics/constants';
 
 const handler = nc<NextApiRequest, NextApiResponse>();

--- a/pages/api/data-explorer/map/sites/[projectId].ts
+++ b/pages/api/data-explorer/map/sites/[projectId].ts
@@ -1,14 +1,15 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type {
+  FeatureCollection,
+  UncleanSite,
+} from '../../../../../src/features/common/types/dataExplorer';
+
 import db from '../../../../../src/utils/connectDB';
 import nc from 'next-connect';
 import {
   rateLimiter,
   speedLimiter,
 } from '../../../../../src/middlewares/rate-limiter';
-import {
-  FeatureCollection,
-  UncleanSite,
-} from '../../../../../src/features/common/types/dataExplorer';
 import redisClient from '../../../../../src/redis-client';
 import { cacheKeyPrefix } from '../../../../../src/utils/constants/cacheKeyPrefix';
 

--- a/pages/api/data-explorer/species-planted.ts
+++ b/pages/api/data-explorer/species-planted.ts
@@ -1,4 +1,6 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { ISpeciesPlanted } from '../../../src/features/common/types/dataExplorer';
+
 import db from '../../../src/utils/connectDB';
 import nc from 'next-connect';
 import {
@@ -6,7 +8,6 @@ import {
   speedLimiter,
 } from '../../../src/middlewares/rate-limiter';
 import { getCachedKey } from '../../../src/utils/getCachedKey';
-import { ISpeciesPlanted } from '../../../src/features/common/types/dataExplorer';
 import redisClient from '../../../src/redis-client';
 import { cacheKeyPrefix } from '../../../src/utils/constants/cacheKeyPrefix';
 

--- a/pages/api/data-explorer/total-species-planted.ts
+++ b/pages/api/data-explorer/total-species-planted.ts
@@ -1,4 +1,6 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { TotalSpeciesPlanted } from '../../../src/features/common/types/dataExplorer';
+
 import db from '../../../src/utils/connectDB';
 import nc from 'next-connect';
 import {
@@ -6,7 +8,6 @@ import {
   speedLimiter,
 } from '../../../src/middlewares/rate-limiter';
 import { getCachedKey } from '../../../src/utils/getCachedKey';
-import { TotalSpeciesPlanted } from '../../../src/features/common/types/dataExplorer';
 import redisClient from '../../../src/redis-client';
 import { cacheKeyPrefix } from '../../../src/utils/constants/cacheKeyPrefix';
 

--- a/pages/api/data-explorer/total-trees-planted.ts
+++ b/pages/api/data-explorer/total-trees-planted.ts
@@ -1,4 +1,6 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { TotalTreesPlanted } from '../../../src/features/common/types/dataExplorer';
+
 import db from '../../../src/utils/connectDB';
 import nc from 'next-connect';
 import {
@@ -6,7 +8,6 @@ import {
   speedLimiter,
 } from '../../../src/middlewares/rate-limiter';
 import { getCachedKey } from '../../../src/utils/getCachedKey';
-import { TotalTreesPlanted } from '../../../src/features/common/types/dataExplorer';
 import redisClient from '../../../src/redis-client';
 import { cacheKeyPrefix } from '../../../src/utils/constants/cacheKeyPrefix';
 

--- a/pages/api/data-explorer/trees-planted.ts
+++ b/pages/api/data-explorer/trees-planted.ts
@@ -1,4 +1,11 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type {
+  IDailyFrame,
+  IMonthlyFrame,
+  IWeeklyFrame,
+  IYearlyFrame,
+} from '../../../src/features/common/types/dataExplorer';
+
 import db from '../../../src/utils/connectDB';
 import { TIME_FRAME } from '../../../src/features/user/TreeMapper/Analytics/components/TreePlanted/TimeFrameSelector';
 import nc from 'next-connect';
@@ -7,12 +14,6 @@ import {
   speedLimiter,
 } from '../../../src/middlewares/rate-limiter';
 import { getCachedKey } from '../../../src/utils/getCachedKey';
-import {
-  IDailyFrame,
-  IMonthlyFrame,
-  IWeeklyFrame,
-  IYearlyFrame,
-} from '../../../src/features/common/types/dataExplorer';
 import redisClient from '../../../src/redis-client';
 import { cacheKeyPrefix } from '../../../src/utils/constants/cacheKeyPrefix';
 

--- a/pages/sites/[slug]/[locale]/all.tsx
+++ b/pages/sites/[slug]/[locale]/all.tsx
@@ -1,28 +1,30 @@
+import type { APIError } from '@planet-sdk/common';
+import type {
+  LeaderBoardList,
+  TenantScore,
+  TreesDonated,
+} from '../../../../src/features/common/types/leaderboard';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { AbstractIntlMessages } from 'next-intl';
+
 import React from 'react';
 import LeaderBoard from '../../../../src/tenants/planet/LeaderBoard';
 import { getRequest } from '../../../../src/utils/apiRequests/api';
 import GetLeaderboardMeta from '../../../../src/utils/getMetaTags/GetLeaderboardMeta';
 import { ErrorHandlingContext } from '../../../../src/features/common/Layout/ErrorHandlingContext';
-import { handleError, APIError } from '@planet-sdk/common';
-import {
-  LeaderBoardList,
-  TenantScore,
-  TreesDonated,
-} from '../../../../src/features/common/types/leaderboard';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../../../src/features/common/Layout/TenantContext';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useRouter } from 'next/router';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../src/utils/multiTenancy/helpers';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
 import { defaultTenant } from '../../../../tenant.config';
-import { AbstractIntlMessages } from 'next-intl';
 import getMessagesForPage from '../../../../src/utils/language/getMessagesForPage';
 
 interface Props {
@@ -78,7 +80,6 @@ export default function Home({ pageProps }: Props) {
     loadTenantScore();
   }, []);
 
-
   const [treesDonated, setTreesDonated] = React.useState<TreesDonated | null>(
     null
   );
@@ -103,12 +104,20 @@ export default function Home({ pageProps }: Props) {
     switch (pageProps.tenantConfig.config.slug) {
       case 'planet':
         AllPage = (
-          <LeaderBoard leaderboard={leaderboard} tenantScore={tenantScore} treesDonated={treesDonated} />
+          <LeaderBoard
+            leaderboard={leaderboard}
+            tenantScore={tenantScore}
+            treesDonated={treesDonated}
+          />
         );
         return AllPage;
       case 'ttc':
         AllPage = (
-          <LeaderBoard leaderboard={leaderboard} tenantScore={tenantScore} treesDonated={treesDonated}/>
+          <LeaderBoard
+            leaderboard={leaderboard}
+            tenantScore={tenantScore}
+            treesDonated={treesDonated}
+          />
         );
         return AllPage;
       default:

--- a/pages/sites/[slug]/[locale]/complete-signup.tsx
+++ b/pages/sites/[slug]/[locale]/complete-signup.tsx
@@ -1,3 +1,11 @@
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { AbstractIntlMessages } from 'next-intl';
+
 import React from 'react';
 import CompleteSignup from '../../../../src/features/user/CompleteSignup';
 import Head from 'next/head';
@@ -5,16 +13,9 @@ import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../src/features/common/Layout/TenantContext';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
 import { defaultTenant } from '../../../../tenant.config';
-import { AbstractIntlMessages } from 'next-intl';
 import getMessagesForPage from '../../../../src/utils/language/getMessagesForPage';
 
 interface Props {

--- a/pages/sites/[slug]/[locale]/home.tsx
+++ b/pages/sites/[slug]/[locale]/home.tsx
@@ -1,3 +1,16 @@
+import type { APIError } from '@planet-sdk/common';
+import type {
+  LeaderBoardList,
+  TenantScore,
+} from '../../../../src/features/common/types/leaderboard';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { AbstractIntlMessages } from 'next-intl';
+
 import { useRouter } from 'next/router';
 import React from 'react';
 import SalesforceHome from '../../../../src/tenants/salesforce/Home';
@@ -6,24 +19,13 @@ import BasicHome from '../../../../src/tenants/common/Home';
 import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
 import { getRequest } from '../../../../src/utils/apiRequests/api';
 import { ErrorHandlingContext } from '../../../../src/features/common/Layout/ErrorHandlingContext';
-import { handleError, APIError } from '@planet-sdk/common';
-import {
-  LeaderBoardList,
-  TenantScore,
-} from '../../../../src/features/common/types/leaderboard';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../../../src/features/common/Layout/TenantContext';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../src/utils/multiTenancy/helpers';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
 import { defaultTenant } from '../../../../tenant.config';
-import { AbstractIntlMessages } from 'next-intl';
 import getMessagesForPage from '../../../../src/utils/language/getMessagesForPage';
 
 interface Props {

--- a/pages/sites/[slug]/[locale]/login.tsx
+++ b/pages/sites/[slug]/[locale]/login.tsx
@@ -1,4 +1,13 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { AbstractIntlMessages } from 'next-intl';
+
+import React from 'react';
 import { UserProfileLoader } from '../../../../src/features/common/ContentLoaders/UserProfile/UserProfile';
 import { useRouter } from 'next/router';
 import { useUserProps } from '../../../../src/features/common/Layout/UserPropsContext';
@@ -6,15 +15,8 @@ import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useTenant } from '../../../../src/features/common/Layout/TenantContext';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
 import { defaultTenant } from '../../../../tenant.config';
-import { AbstractIntlMessages } from 'next-intl';
 import getMessagesForPage from '../../../../src/utils/language/getMessagesForPage';
 
 interface Props {

--- a/pages/sites/[slug]/[locale]/mangrove-challenge.tsx
+++ b/pages/sites/[slug]/[locale]/mangrove-challenge.tsx
@@ -1,17 +1,18 @@
-import React, { useEffect, useState } from 'react';
-import SalesforceCampaign from '../../../../src/tenants/salesforce/OceanforceCampaign';
-import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
-import {
+import type {
   LeaderBoard,
   TenantScore,
 } from '../../../../src/features/common/types/campaign';
-import { AbstractIntlMessages } from 'next-intl';
-import { Tenant } from '@planet-sdk/common';
-import {
+import type { AbstractIntlMessages } from 'next-intl';
+import type { Tenant } from '@planet-sdk/common';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
+
+import React, { useEffect, useState } from 'react';
+import SalesforceCampaign from '../../../../src/tenants/salesforce/OceanforceCampaign';
+import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
 import { getTenantConfig } from '../../../../src/utils/multiTenancy/helpers';
 import { defaultTenant } from '../../../../tenant.config';
 import getMessagesForPage from '../../../../src/utils/language/getMessagesForPage';

--- a/pages/sites/[slug]/[locale]/mangroves.tsx
+++ b/pages/sites/[slug]/[locale]/mangroves.tsx
@@ -1,13 +1,14 @@
-import React, { useEffect } from 'react';
-import Mangroves from '../../../../src/tenants/salesforce/Mangroves';
-import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
-import { AbstractIntlMessages } from 'next-intl';
-import { Tenant } from '@planet-sdk/common';
-import {
+import type { AbstractIntlMessages } from 'next-intl';
+import type { Tenant } from '@planet-sdk/common';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
+
+import React, { useEffect } from 'react';
+import Mangroves from '../../../../src/tenants/salesforce/Mangroves';
+import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
 import { getTenantConfig } from '../../../../src/utils/multiTenancy/helpers';
 import { defaultTenant } from '../../../../tenant.config';
 import getMessagesForPage from '../../../../src/utils/language/getMessagesForPage';

--- a/pages/sites/[slug]/[locale]/profile/api-key.tsx
+++ b/pages/sites/[slug]/[locale]/profile/api-key.tsx
@@ -1,19 +1,22 @@
-import Head from 'next/head';
-import React, { ReactElement } from 'react';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import ApiKey from '../../../../../src/features/user/Settings/ApiKey';
-import {
+import type { ReactElement } from 'react';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type { AbstractIntlMessages } from 'next-intl';
+
+import Head from 'next/head';
+import React from 'react';
+import { useTranslations } from 'next-intl';
+import ApiKey from '../../../../../src/features/user/Settings/ApiKey';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../src/utils/multiTenancy/helpers';
 import { defaultTenant } from '../../../../../tenant.config';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../src/features/common/Layout/TenantContext';
 import getMessagesForPage from '../../../../../src/utils/language/getMessagesForPage';

--- a/pages/sites/[slug]/[locale]/profile/bulk-codes/[method]/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/bulk-codes/[method]/index.tsx
@@ -1,4 +1,13 @@
-import React, { ReactElement, useEffect } from 'react';
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import React, { useEffect } from 'react';
 import UserLayout from '../../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import BulkCodes, {
   BulkCodeSteps,
@@ -7,18 +16,12 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useBulkCode } from '../../../../../../../src/features/common/Layout/BulkCodeContext';
 import { BulkCodeMethods } from '../../../../../../../src/utils/constants/bulkCodeConstants';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
+import { useTranslations } from 'next-intl';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../../src/utils/multiTenancy/helpers';
 import { v4 } from 'uuid';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useTenant } from '../../../../../../../src/features/common/Layout/TenantContext';
 import { defaultTenant } from '../../../../../../../tenant.config';
 import getMessagesForPage from '../../../../../../../src/utils/language/getMessagesForPage';

--- a/pages/sites/[slug]/[locale]/profile/bulk-codes/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/bulk-codes/index.tsx
@@ -1,16 +1,19 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import React from 'react';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import BulkCodes, {
   BulkCodeSteps,
 } from '../../../../../../src/features/user/BulkCodes';
 import Head from 'next/head';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
+import { useTranslations } from 'next-intl';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,

--- a/pages/sites/[slug]/[locale]/profile/delete-account.tsx
+++ b/pages/sites/[slug]/[locale]/profile/delete-account.tsx
@@ -1,14 +1,17 @@
-import Head from 'next/head';
-import React, { ReactElement } from 'react';
-import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import DeleteProfile from '../../../../../src/features/user/Settings/DeleteProfile';
-import {
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import Head from 'next/head';
+import React from 'react';
+import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
+import { useTranslations } from 'next-intl';
+import DeleteProfile from '../../../../../src/features/user/Settings/DeleteProfile';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,

--- a/pages/sites/[slug]/[locale]/profile/donation-link.tsx
+++ b/pages/sites/[slug]/[locale]/profile/donation-link.tsx
@@ -1,18 +1,21 @@
-import React, { ReactElement } from 'react';
-import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
-import DonationLink from '../../../../../src/features/user/Widget/DonationLink';
-import Head from 'next/head';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import {
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import React from 'react';
+import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
+import DonationLink from '../../../../../src/features/user/Widget/DonationLink';
+import Head from 'next/head';
+import { useTranslations } from 'next-intl';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { defaultTenant } from '../../../../../tenant.config';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../src/features/common/Layout/TenantContext';

--- a/pages/sites/[slug]/[locale]/profile/edit.tsx
+++ b/pages/sites/[slug]/[locale]/profile/edit.tsx
@@ -1,18 +1,21 @@
-import Head from 'next/head';
-import React, { ReactElement } from 'react';
-import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import EditProfile from '../../../../../src/features/user/Settings/EditProfile';
-import {
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type { AbstractIntlMessages } from 'next-intl';
+import type { ReactElement } from 'react';
+
+import Head from 'next/head';
+import React from 'react';
+import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
+import { useTranslations } from 'next-intl';
+import EditProfile from '../../../../../src/features/user/Settings/EditProfile';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { defaultTenant } from '../../../../../tenant.config';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../src/features/common/Layout/TenantContext';

--- a/pages/sites/[slug]/[locale]/profile/edit.tsx
+++ b/pages/sites/[slug]/[locale]/profile/edit.tsx
@@ -7,7 +7,7 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React from 'react';
+import { useEffect } from 'react';
 import Head from 'next/head';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import { useTranslations } from 'next-intl';
@@ -30,7 +30,7 @@ function EditProfilePage({ pageProps: { tenantConfig } }: Props): ReactElement {
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/giftfund/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/giftfund/index.tsx
@@ -1,19 +1,22 @@
-import React, { ReactElement } from 'react';
-import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
-import Head from 'next/head';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import GiftFunds from '../../../../../../src/features/user/GiftFunds';
-import {
+import type { ReactElement } from 'react';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
+import type { AbstractIntlMessages } from 'next-intl';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import React from 'react';
+import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
+import Head from 'next/head';
+import { useTranslations } from 'next-intl';
+import GiftFunds from '../../../../../../src/features/user/GiftFunds';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../src/utils/multiTenancy/helpers';
 import { defaultTenant } from '../../../../../../tenant.config';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../../src/features/common/Layout/TenantContext';
 import getMessagesForPage from '../../../../../../src/utils/language/getMessagesForPage';

--- a/pages/sites/[slug]/[locale]/profile/impersonate-user.tsx
+++ b/pages/sites/[slug]/[locale]/profile/impersonate-user.tsx
@@ -1,21 +1,24 @@
-import Head from 'next/head';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
-import ImpersonateUser from '../../../../../src/features/user/Settings/ImpersonateUser';
-import { useUserProps } from '../../../../../src/features/common/Layout/UserPropsContext';
-import { ReactElement, useEffect } from 'react';
-import AccessDeniedLoader from '../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
-import {
+import type { AbstractIntlMessages } from 'next-intl';
+import type { ReactElement } from 'react';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
+
+import Head from 'next/head';
+import { useTranslations } from 'next-intl';
+import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
+import ImpersonateUser from '../../../../../src/features/user/Settings/ImpersonateUser';
+import { useUserProps } from '../../../../../src/features/common/Layout/UserPropsContext';
+import { useEffect } from 'react';
+import AccessDeniedLoader from '../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../src/utils/multiTenancy/helpers';
 import { defaultTenant } from '../../../../../tenant.config';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../src/features/common/Layout/TenantContext';
 import getMessagesForPage from '../../../../../src/utils/language/getMessagesForPage';

--- a/pages/sites/[slug]/[locale]/profile/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/index.tsx
@@ -1,11 +1,13 @@
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
-import { MyForestProvider } from '../../../../../src/features/common/Layout/MyForestContext';
-import {
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
+import type { AbstractIntlMessages } from 'next-intl';
+
+import { MyForestProvider } from '../../../../../src/features/common/Layout/MyForestContext';
+import { useTranslations } from 'next-intl';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,

--- a/pages/sites/[slug]/[locale]/profile/payouts/add-bank-details.tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/add-bank-details.tsx
@@ -1,22 +1,25 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import React from 'react';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import ManagePayouts, {
   ManagePayoutTabs,
 } from '../../../../../../src/features/user/ManagePayouts';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
 import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { defaultTenant } from '../../../../../../tenant.config';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../../src/features/common/Layout/TenantContext';

--- a/pages/sites/[slug]/[locale]/profile/payouts/edit-bank-details/[id].tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/edit-bank-details/[id].tsx
@@ -1,21 +1,24 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import { useTranslations } from 'next-intl';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import React from 'react';
 import UserLayout from '../../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import ManagePayouts, {
   ManagePayoutTabs,
 } from '../../../../../../../src/features/user/ManagePayouts';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../../src/utils/multiTenancy/helpers';
 import { v4 } from 'uuid';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { defaultTenant } from '../../../../../../../tenant.config';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../../../src/features/common/Layout/TenantContext';

--- a/pages/sites/[slug]/[locale]/profile/payouts/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/index.tsx
@@ -1,23 +1,26 @@
-import React, { ReactElement, useState } from 'react';
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import React, { useState } from 'react';
 import TopProgressBar from '../../../../../../src/features/common/ContentLoaders/TopProgressBar';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import ManagePayouts, {
   ManagePayoutTabs,
 } from '../../../../../../src/features/user/ManagePayouts';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
 import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { defaultTenant } from '../../../../../../tenant.config';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../../src/features/common/Layout/TenantContext';

--- a/pages/sites/[slug]/[locale]/profile/payouts/schedule.tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/schedule.tsx
@@ -1,23 +1,26 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import React from 'react';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import ManagePayouts, {
   ManagePayoutTabs,
 } from '../../../../../../src/features/user/ManagePayouts';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
 import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../src/utils/multiTenancy/helpers';
 import { defaultTenant } from '../../../../../../tenant.config';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../../src/features/common/Layout/TenantContext';
 import getMessagesForPage from '../../../../../../src/utils/language/getMessagesForPage';

--- a/pages/sites/[slug]/[locale]/profile/planetcash/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/planetcash/index.tsx
@@ -1,21 +1,24 @@
-import React, { ReactElement, useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import React, { useState, useEffect } from 'react';
 import TopProgressBar from '../../../../../../src/features/common/ContentLoaders/TopProgressBar';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import PlanetCash, {
   PlanetCashTabs,
 } from '../../../../../../src/features/user/PlanetCash';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
+import { useTranslations } from 'next-intl';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { defaultTenant } from '../../../../../../tenant.config';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../../src/features/common/Layout/TenantContext';

--- a/pages/sites/[slug]/[locale]/profile/planetcash/new.tsx
+++ b/pages/sites/[slug]/[locale]/profile/planetcash/new.tsx
@@ -1,21 +1,24 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import React, { useEffect, useState } from 'react';
 import TopProgressBar from '../../../../../../src/features/common/ContentLoaders/TopProgressBar';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import PlanetCash, {
   PlanetCashTabs,
 } from '../../../../../../src/features/user/PlanetCash';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
+import { useTranslations } from 'next-intl';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { defaultTenant } from '../../../../../../tenant.config';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../../src/features/common/Layout/TenantContext';

--- a/pages/sites/[slug]/[locale]/profile/planetcash/transactions.tsx
+++ b/pages/sites/[slug]/[locale]/profile/planetcash/transactions.tsx
@@ -1,21 +1,24 @@
-import React, { ReactElement, useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import React, { useState, useEffect } from 'react';
 import TopProgressBar from '../../../../../../src/features/common/ContentLoaders/TopProgressBar';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import PlanetCash, {
   PlanetCashTabs,
 } from '../../../../../../src/features/user/PlanetCash';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
+import { useTranslations } from 'next-intl';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { defaultTenant } from '../../../../../../tenant.config';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../../src/features/common/Layout/TenantContext';

--- a/pages/sites/[slug]/[locale]/profile/projects/[id].tsx
+++ b/pages/sites/[slug]/[locale]/profile/projects/[id].tsx
@@ -1,4 +1,18 @@
-import React, { ReactElement, useEffect } from 'react';
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type { APIError } from '@planet-sdk/common';
+import type {
+  ProfileProjectConservation,
+  ProfileProjectTrees,
+} from '../../../../../../src/features/common/types/project';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+
+import React, { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import ManageProjects from '../../../../../../src/features/user/ManageProjects';
 import { getAuthenticatedRequest } from '../../../../../../src/utils/apiRequests/api';
@@ -8,24 +22,14 @@ import Footer from '../../../../../../src/features/common/Layout/Footer';
 import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import { ErrorHandlingContext } from '../../../../../../src/features/common/Layout/ErrorHandlingContext';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
-import { handleError, APIError } from '@planet-sdk/common';
-import {
-  ProfileProjectConservation,
-  ProfileProjectTrees,
-} from '../../../../../../src/features/common/types/project';
+import { handleError } from '@planet-sdk/common';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../src/utils/multiTenancy/helpers';
 import { v4 } from 'uuid';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { defaultTenant } from '../../../../../../tenant.config';
 import { useTenant } from '../../../../../../src/features/common/Layout/TenantContext';
 import getMessagesForPage from '../../../../../../src/utils/language/getMessagesForPage';

--- a/pages/sites/[slug]/[locale]/profile/projects/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/projects/index.tsx
@@ -1,21 +1,24 @@
-import React, { ReactElement } from 'react';
-import ProjectsContainer from '../../../../../../src/features/user/ManageProjects/ProjectsContainer';
-import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
-import Head from 'next/head';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
-import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
-import {
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import React from 'react';
+import ProjectsContainer from '../../../../../../src/features/user/ManageProjects/ProjectsContainer';
+import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
+import Head from 'next/head';
+import { useTranslations } from 'next-intl';
+import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
+import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../src/utils/multiTenancy/helpers';
 import { defaultTenant } from '../../../../../../tenant.config';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../../src/features/common/Layout/TenantContext';
 import getMessagesForPage from '../../../../../../src/utils/language/getMessagesForPage';

--- a/pages/sites/[slug]/[locale]/profile/projects/new-project.tsx
+++ b/pages/sites/[slug]/[locale]/profile/projects/new-project.tsx
@@ -1,5 +1,14 @@
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import React, { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type { ReactElement } from 'react';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import { useTranslations } from 'next-intl';
+import React from 'react';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import ManageProjects from '../../../../../../src/features/user/ManageProjects';
 import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
@@ -7,15 +16,9 @@ import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoa
 import Footer from '../../../../../../src/features/common/Layout/Footer';
 import Head from 'next/head';
 import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
-import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { defaultTenant } from '../../../../../../tenant.config';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../../src/features/common/Layout/TenantContext';

--- a/pages/sites/[slug]/[locale]/profile/recurrency.tsx
+++ b/pages/sites/[slug]/[locale]/profile/recurrency.tsx
@@ -1,24 +1,28 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type { APIError } from '@planet-sdk/common';
+import type { Subscription } from '../../../../../src/features/common/types/payments';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import React from 'react';
 import { getAuthenticatedRequest } from '../../../../../src/utils/apiRequests/api';
 import TopProgressBar from '../../../../../src/features/common/ContentLoaders/TopProgressBar';
 import { useUserProps } from '../../../../../src/features/common/Layout/UserPropsContext';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import { ErrorHandlingContext } from '../../../../../src/features/common/Layout/ErrorHandlingContext';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import { handleError, APIError } from '@planet-sdk/common';
-import { Subscription } from '../../../../../src/features/common/types/payments';
+import { useTranslations } from 'next-intl';
+import { handleError } from '@planet-sdk/common';
 import RecurrentPayments from '../../../../../src/features/user/Account/RecurrentPayments';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { defaultTenant } from '../../../../../tenant.config';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../src/features/common/Layout/TenantContext';

--- a/pages/sites/[slug]/[locale]/profile/register-trees.tsx
+++ b/pages/sites/[slug]/[locale]/profile/register-trees.tsx
@@ -1,14 +1,17 @@
-import React, { ReactElement } from 'react';
-import dynamic from 'next/dynamic';
-import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
-import Head from 'next/head';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import {
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import React from 'react';
+import dynamic from 'next/dynamic';
+import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
+import Head from 'next/head';
+import { useTranslations } from 'next-intl';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,

--- a/pages/sites/[slug]/[locale]/profile/treemapper/data-explorer.tsx
+++ b/pages/sites/[slug]/[locale]/profile/treemapper/data-explorer.tsx
@@ -1,20 +1,23 @@
-import Head from 'next/head';
-import React, { ReactElement, useEffect } from 'react';
-import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
-import Analytics from '../../../../../../src/features/user/TreeMapper/Analytics';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import { useRouter } from 'next/router';
-import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
-import {
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import Head from 'next/head';
+import React, { useEffect } from 'react';
+import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
+import Analytics from '../../../../../../src/features/user/TreeMapper/Analytics';
+import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/router';
+import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { defaultTenant } from '../../../../../../tenant.config';
 import { useTenant } from '../../../../../../src/features/common/Layout/TenantContext';
 import getMessagesForPage from '../../../../../../src/utils/language/getMessagesForPage';

--- a/pages/sites/[slug]/[locale]/profile/treemapper/import.tsx
+++ b/pages/sites/[slug]/[locale]/profile/treemapper/import.tsx
@@ -1,20 +1,23 @@
-import Head from 'next/head';
-import React, { ReactElement } from 'react';
-import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import ImportData from '../../../../../../src/features/user/TreeMapper/Import';
-import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
-import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
-import {
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import Head from 'next/head';
+import React from 'react';
+import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
+import { useTranslations } from 'next-intl';
+import ImportData from '../../../../../../src/features/user/TreeMapper/Import';
+import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
+import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { defaultTenant } from '../../../../../../tenant.config';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../../src/features/common/Layout/TenantContext';

--- a/pages/sites/[slug]/[locale]/profile/treemapper/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/treemapper/index.tsx
@@ -1,19 +1,22 @@
-import Head from 'next/head';
-import React, { ReactElement } from 'react';
-import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
-import TreeMapper from '../../../../../../src/features/user/TreeMapper';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import {
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import Head from 'next/head';
+import React from 'react';
+import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
+import TreeMapper from '../../../../../../src/features/user/TreeMapper';
+import { useTranslations } from 'next-intl';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../src/utils/multiTenancy/helpers';
 import { defaultTenant } from '../../../../../../tenant.config';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../../src/features/common/Layout/TenantContext';
 import getMessagesForPage from '../../../../../../src/utils/language/getMessagesForPage';

--- a/pages/sites/[slug]/[locale]/profile/treemapper/my-species.tsx
+++ b/pages/sites/[slug]/[locale]/profile/treemapper/my-species.tsx
@@ -1,20 +1,23 @@
-import Head from 'next/head';
-import React, { ReactElement } from 'react';
-import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
-import MySpecies from '../../../../../../src/features/user/TreeMapper/MySpecies';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
-import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
-import {
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import Head from 'next/head';
+import React from 'react';
+import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
+import MySpecies from '../../../../../../src/features/user/TreeMapper/MySpecies';
+import { useTranslations } from 'next-intl';
+import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
+import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { defaultTenant } from '../../../../../../tenant.config';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../../src/features/common/Layout/TenantContext';

--- a/pages/sites/[slug]/[locale]/profile/widgets.tsx
+++ b/pages/sites/[slug]/[locale]/profile/widgets.tsx
@@ -1,21 +1,24 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { AbstractIntlMessages } from 'next-intl';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import React from 'react';
 import { useUserProps } from '../../../../../src/features/common/Layout/UserPropsContext';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import EmbedModal from '../../../../../src/features/user/Widget/EmbedModal';
 import styles from '../../../../../src/features/common/Layout/UserLayout/UserLayout.module.scss';
 import Head from 'next/head';
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
+import { useTranslations } from 'next-intl';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../src/utils/multiTenancy/helpers';
 import { defaultTenant } from '../../../../../tenant.config';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../../src/features/common/Layout/TenantContext';
 import getMessagesForPage from '../../../../../src/utils/language/getMessagesForPage';

--- a/pages/sites/[slug]/[locale]/projects-archive/[p].tsx
+++ b/pages/sites/[slug]/[locale]/projects-archive/[p].tsx
@@ -1,3 +1,19 @@
+import type { AbstractIntlMessages } from 'next-intl';
+import type { SetState } from '../../../../../src/features/common/types/common';
+import type { PlantLocation } from '../../../../../src/features/common/types/plantLocation';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type {
+  APIError,
+  TreeProjectExtended,
+  ConservationProjectExtended,
+  ProjectExtended,
+} from '@planet-sdk/common';
+
 import { useRouter } from 'next/router';
 import React from 'react';
 import { ErrorHandlingContext } from '../../../../../src/features/common/Layout/ErrorHandlingContext';
@@ -8,29 +24,14 @@ import { getRequest } from '../../../../../src/utils/apiRequests/api';
 import getStoredCurrency from '../../../../../src/utils/countryCurrency/getStoredCurrency';
 import ProjectDetailsMeta from '../../../../../src/utils/getMetaTags/ProjectDetailsMeta';
 import { getAllPlantLocations } from '../../../../../src/utils/maps/plantLocations';
-import { AbstractIntlMessages, useLocale } from 'next-intl';
-import {
-  handleError,
-  APIError,
-  TreeProjectExtended,
-  ConservationProjectExtended,
-  ProjectExtended,
-  ClientError,
-} from '@planet-sdk/common';
-import { SetState } from '../../../../../src/features/common/types/common';
-import { PlantLocation } from '../../../../../src/features/common/types/plantLocation';
+import { useLocale } from 'next-intl';
+import { handleError, ClientError } from '@planet-sdk/common';
 import { useTenant } from '../../../../../src/features/common/Layout/TenantContext';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { v4 } from 'uuid';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
 import { defaultTenant } from '../../../../../tenant.config';
 import getMessagesForPage from '../../../../../src/utils/language/getMessagesForPage';
 

--- a/pages/sites/[slug]/[locale]/projects-archive/index.tsx
+++ b/pages/sites/[slug]/[locale]/projects-archive/index.tsx
@@ -8,26 +8,28 @@ import { useProjectProps } from '../../../../../src/features/common/Layout/Proje
 import Credits from '../../../../../src/features/projectsV2/ProjectsMap/Credits';
 import Filters from '../../../../../src/features/projects/components/projects/Filters';
 import { ErrorHandlingContext } from '../../../../../src/features/common/Layout/ErrorHandlingContext';
-import DirectGift, {
+import type {
   DirectGiftI,
 } from '../../../../../src/features/donations/components/DirectGift';
+import DirectGift from '../../../../../src/features/donations/components/DirectGift';
 import { useLocale } from 'next-intl';
-import { handleError, APIError } from '@planet-sdk/common';
-import { SetState } from '../../../../../src/features/common/types/common';
-import { MapProject } from '../../../../../src/features/common/types/ProjectPropsContextInterface';
+import type { APIError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
+import type { SetState } from '../../../../../src/features/common/types/common';
+import type { MapProject } from '../../../../../src/features/common/types/ProjectPropsContextInterface';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../src/utils/multiTenancy/helpers';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useTenant } from '../../../../../src/features/common/Layout/TenantContext';
-import {
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
 import { defaultTenant } from '../../../../../tenant.config';
-import { AbstractIntlMessages } from 'next-intl';
+import type { AbstractIntlMessages } from 'next-intl';
 import getMessagesForPage from '../../../../../src/utils/language/getMessagesForPage';
 
 interface Props {

--- a/pages/sites/[slug]/[locale]/projects-archive/index.tsx
+++ b/pages/sites/[slug]/[locale]/projects-archive/index.tsx
@@ -1,3 +1,10 @@
+import type { AbstractIntlMessages } from 'next-intl';
+import type { APIError } from '@planet-sdk/common';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type { DirectGiftI } from '../../../../../src/features/donations/components/DirectGift';
+import type { SetState } from '../../../../../src/features/common/types/common';
+import type { MapProject } from '../../../../../src/features/common/types/ProjectPropsContextInterface';
+
 import { useRouter } from 'next/router';
 import React from 'react';
 import ProjectsList from '../../../../../src/features/projects/screens/Projects';
@@ -8,20 +15,13 @@ import { useProjectProps } from '../../../../../src/features/common/Layout/Proje
 import Credits from '../../../../../src/features/projectsV2/ProjectsMap/Credits';
 import Filters from '../../../../../src/features/projects/components/projects/Filters';
 import { ErrorHandlingContext } from '../../../../../src/features/common/Layout/ErrorHandlingContext';
-import type {
-  DirectGiftI,
-} from '../../../../../src/features/donations/components/DirectGift';
 import DirectGift from '../../../../../src/features/donations/components/DirectGift';
 import { useLocale } from 'next-intl';
-import type { APIError } from '@planet-sdk/common';
 import { handleError } from '@planet-sdk/common';
-import type { SetState } from '../../../../../src/features/common/types/common';
-import type { MapProject } from '../../../../../src/features/common/types/ProjectPropsContextInterface';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../src/utils/multiTenancy/helpers';
-import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useTenant } from '../../../../../src/features/common/Layout/TenantContext';
 import type {
   GetStaticProps,
@@ -29,7 +29,6 @@ import type {
   GetStaticPropsResult,
 } from 'next';
 import { defaultTenant } from '../../../../../tenant.config';
-import type { AbstractIntlMessages } from 'next-intl';
 import getMessagesForPage from '../../../../../src/utils/language/getMessagesForPage';
 
 interface Props {

--- a/pages/sites/[slug]/[locale]/s/[id].tsx
+++ b/pages/sites/[slug]/[locale]/s/[id].tsx
@@ -1,22 +1,25 @@
-import React, { ReactElement } from 'react';
-import { useRouter } from 'next/router';
-import { getRequest } from '../../../../../src/utils/apiRequests/api';
-import { ErrorHandlingContext } from '../../../../../src/features/common/Layout/ErrorHandlingContext';
-import {
+import type { ReactElement } from 'react';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
-import { handleError, APIError, UserPublicProfile } from '@planet-sdk/common';
+import type { APIError, UserPublicProfile } from '@planet-sdk/common';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type { AbstractIntlMessages } from 'next-intl';
+
+import React from 'react';
+import { useRouter } from 'next/router';
+import { getRequest } from '../../../../../src/utils/apiRequests/api';
+import { ErrorHandlingContext } from '../../../../../src/features/common/Layout/ErrorHandlingContext';
+import { handleError } from '@planet-sdk/common';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
 } from '../../../../../src/utils/multiTenancy/helpers';
 import { v4 } from 'uuid';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { defaultTenant } from '../../../../../tenant.config';
 import { useTenant } from '../../../../../src/features/common/Layout/TenantContext';
-import { AbstractIntlMessages } from 'next-intl';
 import getMessagesForPage from '../../../../../src/utils/language/getMessagesForPage';
 
 interface Props {

--- a/pages/sites/[slug]/[locale]/t/[profile].tsx
+++ b/pages/sites/[slug]/[locale]/t/[profile].tsx
@@ -1,11 +1,13 @@
 // This page will be moved to a different place in the future, as it is not a part of the user dashboard
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
-import {
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
-import { AbstractIntlMessages } from 'next-intl';
+import type { AbstractIntlMessages } from 'next-intl';
+import type { APIError, UserPublicProfile } from '@planet-sdk/common';
+
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
@@ -20,7 +22,7 @@ import { useRouter } from 'next/router';
 import { MyForestProvider } from '../../../../../src/features/common/Layout/MyForestContext';
 import { useContext, useEffect, useState } from 'react';
 import { ErrorHandlingContext } from '../../../../../src/features/common/Layout/ErrorHandlingContext';
-import { APIError, handleError, UserPublicProfile } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { getRequest } from '../../../../../src/utils/apiRequests/api';
 import GetPublicUserProfileMeta from '../../../../../src/utils/getMetaTags/GetPublicUserProfileMeta';
 import { ProjectsProvider } from '../../../../../src/features/projectsV2/ProjectsContext';

--- a/pages/sites/[slug]/[locale]/verify-email.tsx
+++ b/pages/sites/[slug]/[locale]/verify-email.tsx
@@ -1,4 +1,13 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { AbstractIntlMessages } from 'next-intl';
+
+import React from 'react';
 import Footer from '../../../../src/features/common/Layout/Footer';
 import LandingSection from '../../../../src/features/common/Layout/LandingSection';
 import VerifyEmailComponent from '../../../../src/features/common/VerifyEmail/VerifyEmail';
@@ -8,14 +17,7 @@ import {
 } from '../../../../src/utils/multiTenancy/helpers';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../src/features/common/Layout/TenantContext';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
-import {
-  GetStaticProps,
-  GetStaticPropsContext,
-  GetStaticPropsResult,
-} from 'next';
 import { defaultTenant } from '../../../../tenant.config';
-import { AbstractIntlMessages } from 'next-intl';
 import getMessagesForPage from '../../../../src/utils/language/getMessagesForPage';
 
 interface Props {

--- a/pages/sites/[slug]/[locale]/vto-fitness-challenge-2023.tsx
+++ b/pages/sites/[slug]/[locale]/vto-fitness-challenge-2023.tsx
@@ -1,17 +1,18 @@
-import React, { useEffect, useState } from 'react';
-import SalesforceCampaign from '../../../../src/tenants/salesforce/VTOCampaign2023';
-import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
-import {
+import type {
   LeaderBoard,
   TenantScore,
 } from '../../../../src/features/common/types/campaign';
-import { AbstractIntlMessages } from 'next-intl';
-import { Tenant } from '@planet-sdk/common';
-import {
+import type { AbstractIntlMessages } from 'next-intl';
+import type { Tenant } from '@planet-sdk/common';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
+
+import React, { useEffect, useState } from 'react';
+import SalesforceCampaign from '../../../../src/tenants/salesforce/VTOCampaign2023';
+import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
 import { defaultTenant } from '../../../../tenant.config';
 import { getTenantConfig } from '../../../../src/utils/multiTenancy/helpers';
 import getMessagesForPage from '../../../../src/utils/language/getMessagesForPage';

--- a/pages/sites/[slug]/[locale]/vto-fitness-challenge.tsx
+++ b/pages/sites/[slug]/[locale]/vto-fitness-challenge.tsx
@@ -1,17 +1,18 @@
-import React, { useEffect, useState } from 'react';
-import SalesforceCampaign from '../../../../src/tenants/salesforce/VTOCampaign';
-import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
-import {
+import type {
   LeaderBoard,
   TenantScore,
 } from '../../../../src/features/common/types/campaign';
-import { AbstractIntlMessages } from 'next-intl';
-import { Tenant } from '@planet-sdk/common';
-import {
+import type { AbstractIntlMessages } from 'next-intl';
+import type { Tenant } from '@planet-sdk/common';
+import type {
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
+
+import React, { useEffect, useState } from 'react';
+import SalesforceCampaign from '../../../../src/tenants/salesforce/VTOCampaign';
+import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
 import { getTenantConfig } from '../../../../src/utils/multiTenancy/helpers';
 import { defaultTenant } from '../../../../tenant.config';
 import getMessagesForPage from '../../../../src/utils/language/getMessagesForPage';

--- a/public/assets/images/NotFound.tsx
+++ b/public/assets/images/NotFound.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../src/features/common/types/common';
 
 function NotFound({ className }: IconProps) {
   return (

--- a/public/assets/images/PlanetLogo.tsx
+++ b/public/assets/images/PlanetLogo.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement } from 'react';
-import { IconProps } from '../../../src/features/common/types/common';
+import type { ReactElement } from 'react';
+import type { IconProps } from '../../../src/features/common/types/common';
+
+import React from 'react';
 
 export default function PlanetLogo({
   width = '40px',

--- a/public/assets/images/ProfilePageIcons/index.tsx
+++ b/public/assets/images/ProfilePageIcons/index.tsx
@@ -1,4 +1,4 @@
-import { IconProps } from '../../../../src/features/common/types/common';
+import type { IconProps } from '../../../../src/features/common/types/common';
 
 export const RegisteredTreeSvg = ({ color }: IconProps) => {
   return (

--- a/public/assets/images/icons/AcceptIcon.tsx
+++ b/public/assets/images/icons/AcceptIcon.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement } from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
+import type { ReactElement } from 'react';
+import type { IconProps } from '../../../../src/features/common/types/common';
+
+import React from 'react';
 
 export default function AcceptIcon({
   color = '#333',

--- a/public/assets/images/icons/AccountListLoader.tsx
+++ b/public/assets/images/icons/AccountListLoader.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 
 function AccountListLoader(): ReactElement {
   return (

--- a/public/assets/images/icons/AddIcon.tsx
+++ b/public/assets/images/icons/AddIcon.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement } from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
+import type { ReactElement } from 'react';
+import type { IconProps } from '../../../../src/features/common/types/common';
+
+import React from 'react';
 
 export default function AddIcon({
   color = '#333',

--- a/public/assets/images/icons/BankAccountLoader.tsx
+++ b/public/assets/images/icons/BankAccountLoader.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 
 function BankAccountListLoader(): ReactElement {
   return (

--- a/public/assets/images/icons/CancelIcon.tsx
+++ b/public/assets/images/icons/CancelIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function CancelIcon({ width }: IconProps) {
   return (

--- a/public/assets/images/icons/CheckCircle.tsx
+++ b/public/assets/images/icons/CheckCircle.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function CheckCircle({ width, color }: IconProps) {
   return (

--- a/public/assets/images/icons/CloseIcon.tsx
+++ b/public/assets/images/icons/CloseIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function CloseIcon({ color = 'black' }: IconProps) {
   return (

--- a/public/assets/images/icons/CopyIcon.tsx
+++ b/public/assets/images/icons/CopyIcon.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 
 export default function CopyIcon(): ReactElement {
   return (

--- a/public/assets/images/icons/DeleteIcon.tsx
+++ b/public/assets/images/icons/DeleteIcon.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement } from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
+import type { ReactElement } from 'react';
+import type { IconProps } from '../../../../src/features/common/types/common';
+
+import React from 'react';
 
 export default function DeleteIcon({
   color = '#333',

--- a/public/assets/images/icons/DownArrow.tsx
+++ b/public/assets/images/icons/DownArrow.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function Icon({ color = '#87b738' }: IconProps) {
   return (

--- a/public/assets/images/icons/EditIcon.tsx
+++ b/public/assets/images/icons/EditIcon.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement } from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
+import type { ReactElement } from 'react';
+import type { IconProps } from '../../../../src/features/common/types/common';
+
+import React from 'react';
 
 export default function EditIcon({
   color = '#333',

--- a/public/assets/images/icons/ExpandIcon.tsx
+++ b/public/assets/images/icons/ExpandIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function ExpandIcon({ color = '#2f3336' }: IconProps) {
   return (

--- a/public/assets/images/icons/ExploreIcon.tsx
+++ b/public/assets/images/icons/ExploreIcon.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
+
+import type { IconProps } from '../../../../src/features/common/types/common';
 
 function ExploreIcon({ color = '#2f3336' }: IconProps) {
   return (

--- a/public/assets/images/icons/EyeDisabled.tsx
+++ b/public/assets/images/icons/EyeDisabled.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function EyeDisabled({ color = '#2f3336' }: IconProps) {
   return (

--- a/public/assets/images/icons/EyeIcon.tsx
+++ b/public/assets/images/icons/EyeIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function EyeIcon({ color = '#2f3336' }: IconProps) {
   return (

--- a/public/assets/images/icons/FileAttachedIcon.tsx
+++ b/public/assets/images/icons/FileAttachedIcon.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement } from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
+import type { ReactElement } from 'react';
+import type { IconProps } from '../../../../src/features/common/types/common';
+
+import React from 'react';
 
 function FileAttachedIcon({ color = '#2f3336' }: IconProps): ReactElement {
   return (

--- a/public/assets/images/icons/FileProcessingIcon.tsx
+++ b/public/assets/images/icons/FileProcessingIcon.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement } from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
+import type { ReactElement } from 'react';
+import type { IconProps } from '../../../../src/features/common/types/common';
+
+import React from 'react';
 
 function FileProcessingIcon({ color = '#2f3336' }: IconProps): ReactElement {
   return (

--- a/public/assets/images/icons/FileUploadIcon.tsx
+++ b/public/assets/images/icons/FileUploadIcon.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement } from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
+import type { ReactElement } from 'react';
+import type { IconProps } from '../../../../src/features/common/types/common';
+
+import React from 'react';
 
 function FileUploadIcon({ color = '#2f3336' }: IconProps): ReactElement {
   return (

--- a/public/assets/images/icons/FilterIcon.tsx
+++ b/public/assets/images/icons/FilterIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function FilterIcon({ color = '#2f3336' }: IconProps) {
   return (

--- a/public/assets/images/icons/FilterInlineLoader.tsx
+++ b/public/assets/images/icons/FilterInlineLoader.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 
 function FilterInlineLoader(): ReactElement {
   return (

--- a/public/assets/images/icons/FilterLoader.tsx
+++ b/public/assets/images/icons/FilterLoader.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 
 function FilterLoader(): ReactElement {
   return (

--- a/public/assets/images/icons/ImportIcon.tsx
+++ b/public/assets/images/icons/ImportIcon.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 
 export default function ImportIcon(): ReactElement {
   return (

--- a/public/assets/images/icons/InfoIcon.tsx
+++ b/public/assets/images/icons/InfoIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function InfoIcon({ color = 'black' }: IconProps) {
   return (

--- a/public/assets/images/icons/LeftIcon.tsx
+++ b/public/assets/images/icons/LeftIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function CancelIcon({ color = 'black' }: IconProps) {
   return (

--- a/public/assets/images/icons/LocationIcon.tsx
+++ b/public/assets/images/icons/LocationIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function LocationIcon({ color }: IconProps) {
   return (

--- a/public/assets/images/icons/MinusIcon.tsx
+++ b/public/assets/images/icons/MinusIcon.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 
 export default function MinusIcon(): ReactElement {
   return (

--- a/public/assets/images/icons/PlayIcon.tsx
+++ b/public/assets/images/icons/PlayIcon.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 
 export default function PlayIcon(): ReactElement {
   return (

--- a/public/assets/images/icons/PlusIcon.tsx
+++ b/public/assets/images/icons/PlusIcon.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement } from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
+import type { ReactElement } from 'react';
+import type { IconProps } from '../../../../src/features/common/types/common';
+
+import React from 'react';
 
 export default function PlusIcon({
   color = '#333',

--- a/public/assets/images/icons/PolygonIcon.tsx
+++ b/public/assets/images/icons/PolygonIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function PolygonIcon({ color = '#2F3336' }: IconProps) {
   return (

--- a/public/assets/images/icons/ProfilePageV2Icons.tsx
+++ b/public/assets/images/icons/ProfilePageV2Icons.tsx
@@ -1,4 +1,4 @@
-import { IconProps } from '../../../../src/features/common/types/common';
+import type { IconProps } from '../../../../src/features/common/types/common';
 
 export const AllDonations = () => {
   return (

--- a/public/assets/images/icons/RejectIcon.tsx
+++ b/public/assets/images/icons/RejectIcon.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement } from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
+import type { ReactElement } from 'react';
+import type { IconProps } from '../../../../src/features/common/types/common';
+
+import React from 'react';
 
 export default function RejectIcon({
   color = '#333',

--- a/public/assets/images/icons/ResearchIcon.tsx
+++ b/public/assets/images/icons/ResearchIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function ResearchIcon({ color }: IconProps) {
   return (

--- a/public/assets/images/icons/RightIcon.tsx
+++ b/public/assets/images/icons/RightIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function CancelIcon({ color }: IconProps) {
   return (

--- a/public/assets/images/icons/SatelliteIcon.tsx
+++ b/public/assets/images/icons/SatelliteIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function SatelliteIcon({ color }: IconProps) {
   return (

--- a/public/assets/images/icons/Sidebar/DonateIcon.tsx
+++ b/public/assets/images/icons/Sidebar/DonateIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function DonateIcon({ color = '#000' }: IconProps) {
   return (

--- a/public/assets/images/icons/Sidebar/GiftIcon.tsx
+++ b/public/assets/images/icons/Sidebar/GiftIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function GiftIcon({ color = '#000' }: IconProps) {
   return (

--- a/public/assets/images/icons/Sidebar/Globe.tsx
+++ b/public/assets/images/icons/Sidebar/Globe.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function GlobeIcon({ color = '#000' }: IconProps) {
   return (

--- a/public/assets/images/icons/Sidebar/LogoutIcon.tsx
+++ b/public/assets/images/icons/Sidebar/LogoutIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function LogoutIcon({ color = '#000' }: IconProps) {
   return (

--- a/public/assets/images/icons/Sidebar/MapIcon.tsx
+++ b/public/assets/images/icons/Sidebar/MapIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function MapIcon({ color = '#000' }: IconProps) {
   return (

--- a/public/assets/images/icons/Sidebar/NotionLinkIcon.tsx
+++ b/public/assets/images/icons/Sidebar/NotionLinkIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 const NotionLinkIcon = ({ color = '#5f6368' }: IconProps) => {
   return (

--- a/public/assets/images/icons/Sidebar/PlanetCashIcon.tsx
+++ b/public/assets/images/icons/Sidebar/PlanetCashIcon.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement } from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
+import type { ReactElement } from 'react';
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
+import React from 'react';
 
 function PlanetCashIcon({ color = '#000' }: IconProps): ReactElement {
   return (

--- a/public/assets/images/icons/Sidebar/UserIcon.tsx
+++ b/public/assets/images/icons/Sidebar/UserIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function UserIcon({ color = '#000' }: IconProps) {
   return (

--- a/public/assets/images/icons/Sidebar/Widget.tsx
+++ b/public/assets/images/icons/Sidebar/Widget.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function WidgetIcon({ color = '#000' }: IconProps) {
   return (

--- a/public/assets/images/icons/SourceIcon.tsx
+++ b/public/assets/images/icons/SourceIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function SourceIcon({ color = '#2F3336' }: IconProps) {
   return (

--- a/public/assets/images/icons/ThreeDotIcon.tsx
+++ b/public/assets/images/icons/ThreeDotIcon.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 
 export default function ThreeDotIcon(): ReactElement {
   return (

--- a/public/assets/images/icons/TransactionIcon.tsx
+++ b/public/assets/images/icons/TransactionIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function CancelIcon({ width, color = '#2f3336' }: IconProps) {
   return (

--- a/public/assets/images/icons/TransactionListLoader.tsx
+++ b/public/assets/images/icons/TransactionListLoader.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 
 function TransactionListLoader(): ReactElement {
   return (

--- a/public/assets/images/icons/TreeIcon.tsx
+++ b/public/assets/images/icons/TreeIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function TreeIcon({ color = '#68B030', width, height }: IconProps) {
   return (

--- a/public/assets/images/icons/TreesIcon.tsx
+++ b/public/assets/images/icons/TreesIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../src/features/common/types/common';
 
 function TreesIcon({ color = '#68B030', width, height }: IconProps) {
   return (

--- a/public/assets/images/icons/UnderMaintenance.tsx
+++ b/public/assets/images/icons/UnderMaintenance.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 
 export default function UnderMaintenanceImage(): ReactElement {
   return (

--- a/public/assets/images/icons/headerIcons/Close.tsx
+++ b/public/assets/images/icons/headerIcons/Close.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function Close({ color = '#1e2225' }: IconProps) {
   return (

--- a/public/assets/images/icons/manageProjects/AccessDenied.tsx
+++ b/public/assets/images/icons/manageProjects/AccessDenied.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function AccessDenied({
   width = '1145.572px',

--- a/public/assets/images/icons/manageProjects/Delete.tsx
+++ b/public/assets/images/icons/manageProjects/Delete.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function Delete({ color = '#2f3336' }: IconProps) {
   return (

--- a/public/assets/images/icons/manageProjects/Expand.tsx
+++ b/public/assets/images/icons/manageProjects/Expand.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function Expand({ color = '#2f3336' }: IconProps) {
   return (

--- a/public/assets/images/icons/manageProjects/PDFIcon.tsx
+++ b/public/assets/images/icons/manageProjects/PDFIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function PDFIcon({ color = 'currentColor' }: IconProps) {
   return (

--- a/public/assets/images/icons/manageProjects/Pencil.tsx
+++ b/public/assets/images/icons/manageProjects/Pencil.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function EditIcon({ color = '#848484' }: IconProps) {
   return (

--- a/public/assets/images/icons/manageProjects/Polygon.tsx
+++ b/public/assets/images/icons/manageProjects/Polygon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function PolygonIcon({ color = 'currentColor' }: IconProps) {
   return (

--- a/public/assets/images/icons/manageProjects/Star.tsx
+++ b/public/assets/images/icons/manageProjects/Star.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function Icon({ color = '#2f3336', className }: IconProps) {
   return (

--- a/public/assets/images/icons/myForestMapIcons/PointMarkerIcons.tsx
+++ b/public/assets/images/icons/myForestMapIcons/PointMarkerIcons.tsx
@@ -1,5 +1,5 @@
 // Todo - move to a common location
-import { IconProps } from '../../../../../src/features/common/types/common';
+import type { IconProps } from '../../../../../src/features/common/types/common';
 
 export const Agroforestry = ({ color }: IconProps) => {
   return (

--- a/public/assets/images/icons/myForestMapIcons/index.tsx
+++ b/public/assets/images/icons/myForestMapIcons/index.tsx
@@ -1,4 +1,4 @@
-import { IconProps } from '../../../../../src/features/common/types/common';
+import type { IconProps } from '../../../../../src/features/common/types/common';
 
 export const ProjectStatIcon = () => {
   return (

--- a/public/assets/images/icons/project/BlackTree.tsx
+++ b/public/assets/images/icons/project/BlackTree.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
+import type { IconProps } from '../../../../../src/features/common/types/common';
 
 function BlackTree({ color = '#4d5153' }: IconProps) {
   return (

--- a/public/assets/images/icons/project/Email.tsx
+++ b/public/assets/images/icons/project/Email.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
+import type { IconProps } from '../../../../../src/features/common/types/common';
 
 function Email({ color = '#4d5153' }: IconProps) {
   return (

--- a/public/assets/images/icons/project/Location.tsx
+++ b/public/assets/images/icons/project/Location.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function Location({ color = '#4d5153' }: IconProps) {
   return (

--- a/public/assets/images/icons/project/TopProjectIcon.tsx
+++ b/public/assets/images/icons/project/TopProjectIcon.tsx
@@ -1,6 +1,7 @@
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import themeProperties from '../../../../../src/theme/themeProperties';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 const TopProjectIcon = ({
   color = themeProperties.primaryColor,

--- a/public/assets/images/icons/project/WorldWeb.tsx
+++ b/public/assets/images/icons/project/WorldWeb.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function WorldWeb({ color = '#4d5153' }: IconProps) {
   return (

--- a/public/assets/images/icons/share/Download.tsx
+++ b/public/assets/images/icons/share/Download.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function Icon({ color = 'black' }: IconProps) {
   return (

--- a/public/assets/images/icons/share/DownloadSolid.tsx
+++ b/public/assets/images/icons/share/DownloadSolid.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function Icon({ color = 'black' }: IconProps) {
   return (

--- a/public/assets/images/icons/share/Email.tsx
+++ b/public/assets/images/icons/share/Email.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function Icon({ color = 'black' }: IconProps) {
   return (

--- a/public/assets/images/icons/share/EmailSolid.tsx
+++ b/public/assets/images/icons/share/EmailSolid.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function Icon({ color = 'black' }: IconProps) {
   return (

--- a/public/assets/images/icons/share/Instagram.tsx
+++ b/public/assets/images/icons/share/Instagram.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function Icon({ color = 'black' }: IconProps) {
   return (

--- a/public/assets/images/icons/userProfileIcons/Redeem.tsx
+++ b/public/assets/images/icons/userProfileIcons/Redeem.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function Icon({ color = 'black' }: IconProps) {
   return (

--- a/public/assets/images/icons/userProfileIcons/ScrollDown.tsx
+++ b/public/assets/images/icons/userProfileIcons/ScrollDown.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function Icon({ color = '#87b738' }: IconProps) {
   return (

--- a/public/assets/images/icons/userProfileIcons/Settings.tsx
+++ b/public/assets/images/icons/userProfileIcons/Settings.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function Icon({ color = 'black' }: IconProps) {
   return (

--- a/public/assets/images/icons/userProfileIcons/Share.tsx
+++ b/public/assets/images/icons/userProfileIcons/Share.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../../../../src/features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../../../../src/features/common/types/common';
 
 function Share({ width, height, color, solid }: IconProps) {
   return (

--- a/src/features/common/CarouselSlider/index.tsx
+++ b/src/features/common/CarouselSlider/index.tsx
@@ -1,5 +1,8 @@
-import React, { ReactElement, useEffect, useRef, useState } from 'react';
-import Slider, { InnerSlider, Settings } from 'react-slick';
+import type { ReactElement } from 'react';
+import type { InnerSlider, Settings } from 'react-slick';
+
+import React, { useEffect, useRef, useState } from 'react';
+import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import {

--- a/src/features/common/ContentLoaders/Projects/AccessDeniedLoader.tsx
+++ b/src/features/common/ContentLoaders/Projects/AccessDeniedLoader.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import AccessDenied from '../../../../../public/assets/images/icons/manageProjects/AccessDenied';
 
 function AccessDeniedLoader(): ReactElement {

--- a/src/features/common/ContentLoaders/Projects/GlobeLoader.tsx
+++ b/src/features/common/ContentLoaders/Projects/GlobeLoader.tsx
@@ -1,5 +1,7 @@
+import type { ReactElement } from 'react';
+
 import { motion } from 'framer-motion';
-import React, { ReactElement } from 'react';
+import React from 'react';
 import GlobeLoader from '../../../../../public/assets/images/icons/Globe';
 
 function GlobeContentLoader(): ReactElement {

--- a/src/features/common/ContentLoaders/Projects/ProjectLoader.tsx
+++ b/src/features/common/ContentLoaders/Projects/ProjectLoader.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import ContentLoader from 'react-content-loader';
 
 function ProjectLoader(): ReactElement {

--- a/src/features/common/ContentLoaders/Projects/ProjectLoaderDetails.tsx
+++ b/src/features/common/ContentLoaders/Projects/ProjectLoaderDetails.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import ContentLoader from 'react-content-loader';
 
 function ProjectLoaderDetails(): ReactElement {

--- a/src/features/common/CopyToClipboard/index.tsx
+++ b/src/features/common/CopyToClipboard/index.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement, SyntheticEvent, useState } from 'react';
+import type { ReactElement, SyntheticEvent } from 'react';
+
+import React, { useState } from 'react';
 import CopyIcon from '../../../../public/assets/images/icons/CopyIcon';
 import styles from './styles.module.scss';
 import Snackbar from '@mui/material/Snackbar';

--- a/src/features/common/CustomSnackbar/index.tsx
+++ b/src/features/common/CustomSnackbar/index.tsx
@@ -1,6 +1,7 @@
+import type { ReactElement } from 'react';
+
 import Snackbar from '@mui/material/Snackbar';
 import MuiAlert from '@mui/material/Alert';
-import { ReactElement } from 'react';
 import { styled } from '@mui/material/styles';
 
 interface SnackbarProps {

--- a/src/features/common/InputTypes/AutoCompleteCountry.tsx
+++ b/src/features/common/InputTypes/AutoCompleteCountry.tsx
@@ -1,12 +1,14 @@
 /* eslint-disable no-use-before-define */
-import { useState, ReactElement, useEffect, ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
+import type { CountryType, ExtendedCountryCode } from '../types/country';
+import type { SetState } from '../types/common';
+
+import { useState, useEffect } from 'react';
 import { TextField } from '@mui/material';
 import React from 'react';
 import { useTranslations } from 'next-intl';
 import { MuiAutoComplete, StyledAutoCompleteOption } from './MuiAutoComplete';
-import { CountryType, ExtendedCountryCode } from '../types/country';
 import { allCountries } from '../../../utils/constants/countries';
-import { SetState } from '../types/common';
 
 // ISO 3166-1 alpha-2
 // ⚠️ No support for IE 11

--- a/src/features/common/InputTypes/BootstrapInput.tsx
+++ b/src/features/common/InputTypes/BootstrapInput.tsx
@@ -1,6 +1,8 @@
-import { InputBase, InputBaseProps, styled } from '@mui/material';
+import type { InputBaseProps } from '@mui/material';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import { InputBase, styled } from '@mui/material';
 import { useTenant } from '../Layout/TenantContext';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 
 interface StyledInputBaseType {
   config: Tenant;

--- a/src/features/common/InputTypes/GreenRadio.tsx
+++ b/src/features/common/InputTypes/GreenRadio.tsx
@@ -1,6 +1,8 @@
-import Radio, { RadioProps } from '@mui/material/Radio';
+import type { RadioProps } from '@mui/material/Radio';
+import type { ReactElement } from 'react';
+
+import Radio from '@mui/material/Radio';
 import { styled } from '@mui/material';
-import { ReactElement } from 'react';
 
 const StyledRadio = styled(Radio)({
   color: '#000000',

--- a/src/features/common/InputTypes/MaterialButton.tsx
+++ b/src/features/common/InputTypes/MaterialButton.tsx
@@ -1,4 +1,6 @@
-import React, { ReactNode, MouseEventHandler } from 'react';
+import type { ReactNode, MouseEventHandler } from 'react';
+
+import React from 'react';
 
 type Props = {
   children: ReactNode;

--- a/src/features/common/InputTypes/MaterialTextField.tsx
+++ b/src/features/common/InputTypes/MaterialTextField.tsx
@@ -1,5 +1,7 @@
-import { TextField, TextFieldProps, styled } from '@mui/material';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type { TextFieldProps } from '@mui/material';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
+import { TextField, styled } from '@mui/material';
 import { useTenant } from '../Layout/TenantContext';
 
 interface StyledTextFieldType {

--- a/src/features/common/InputTypes/MuiButton.tsx
+++ b/src/features/common/InputTypes/MuiButton.tsx
@@ -1,4 +1,6 @@
-import { Button, styled, ButtonProps } from '@mui/material';
+import type { ButtonProps } from '@mui/material';
+
+import { Button, styled } from '@mui/material';
 
 const StyledButton = styled(Button)(({ theme }) => {
   return {

--- a/src/features/common/InputTypes/NewToggleSwitch.tsx
+++ b/src/features/common/InputTypes/NewToggleSwitch.tsx
@@ -1,6 +1,7 @@
+import type { ChangeEvent, InputHTMLAttributes } from 'react';
+
 import { Switch } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import { ChangeEvent, InputHTMLAttributes } from 'react';
 import theme from '../../../theme/themeProperties';
 
 interface ToggleSwitchProps {

--- a/src/features/common/InputTypes/ReactHookFormSelect.tsx
+++ b/src/features/common/InputTypes/ReactHookFormSelect.tsx
@@ -1,10 +1,11 @@
-import { ReactElement, ReactNode } from 'react';
-import {
-  Controller,
+import type { ReactElement, ReactNode } from 'react';
+import type {
   FieldValues,
   Control,
   RegisterOptions,
-  FieldPath,
+  FieldPath} from 'react-hook-form';
+import {
+  Controller
 } from 'react-hook-form';
 import { TextField } from '@mui/material';
 

--- a/src/features/common/InputTypes/ToggleSwitch.tsx
+++ b/src/features/common/InputTypes/ToggleSwitch.tsx
@@ -1,7 +1,8 @@
+import type { ChangeEvent, InputHTMLAttributes } from 'react';
+
 import { Switch } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import theme from '../../../theme/themeProperties';
-import { ChangeEvent, InputHTMLAttributes } from 'react';
 
 interface ToggleSwitchProps {
   checked: boolean;

--- a/src/features/common/LandingVideo/PlayButton.tsx
+++ b/src/features/common/LandingVideo/PlayButton.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement, useContext } from 'react';
+import type { ReactElement } from 'react';
+
+import React, { useContext } from 'react';
 import { useRouter } from 'next/router';
 import PlayIcon from '../../../../public/assets/images/icons/PlayIcon';
 import styles from './styles.module.scss';

--- a/src/features/common/LandingVideo/index.tsx
+++ b/src/features/common/LandingVideo/index.tsx
@@ -1,10 +1,6 @@
-import React, {
-  ReactElement,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import type { ReactElement } from 'react';
+
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import styles from './styles.module.scss';
 import { useTranslations } from 'next-intl';
 import ReactPlayer from 'react-player/lazy';

--- a/src/features/common/Layout/AnalyticsContext.tsx
+++ b/src/features/common/Layout/AnalyticsContext.tsx
@@ -1,7 +1,8 @@
-import { useContext, createContext, useMemo, useState, FC } from 'react';
-import { subYears } from 'date-fns';
+import type { FC } from 'react';
+import type { SetState } from '../types/common';
 
-import { SetState } from '../types/common';
+import { useContext, createContext, useMemo, useState } from 'react';
+import { subYears } from 'date-fns';
 
 export interface Project {
   id: string;

--- a/src/features/common/Layout/CurrencyContext.tsx
+++ b/src/features/common/Layout/CurrencyContext.tsx
@@ -1,5 +1,8 @@
-import { APIError, CurrencyCode, handleError } from '@planet-sdk/common';
-import { createContext, FC, useState, useContext, useEffect } from 'react';
+import type { APIError, CurrencyCode } from '@planet-sdk/common';
+import type { FC } from 'react';
+
+import { handleError } from '@planet-sdk/common';
+import { createContext, useState, useContext, useEffect } from 'react';
 import { getRequest } from '../../../utils/apiRequests/api';
 import { ErrorHandlingContext } from './ErrorHandlingContext';
 

--- a/src/features/common/Layout/CustomTooltip/index.tsx
+++ b/src/features/common/Layout/CustomTooltip/index.tsx
@@ -1,4 +1,5 @@
-import { ReactElement, ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
+
 import { bindHover, bindPopover } from 'material-ui-popup-state';
 import HoverPopover from 'material-ui-popup-state/HoverPopover';
 import { usePopupState } from 'material-ui-popup-state/hooks';

--- a/src/features/common/Layout/DashboardView/index.tsx
+++ b/src/features/common/Layout/DashboardView/index.tsx
@@ -1,4 +1,5 @@
-import { ReactElement, ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
+
 import { Box, Grid, ThemeProvider, styled } from '@mui/material';
 import materialTheme from '../../../../theme/themeStyles';
 

--- a/src/features/common/Layout/ErrorHandlingContext.tsx
+++ b/src/features/common/Layout/ErrorHandlingContext.tsx
@@ -1,12 +1,8 @@
+import type { SetStateAction, Dispatch, FC } from 'react';
+import type { SerializedError } from '@planet-sdk/common';
+
 import { useRouter } from 'next/router';
-import React, {
-  createContext,
-  SetStateAction,
-  useState,
-  Dispatch,
-  FC,
-} from 'react';
-import { SerializedError } from '@planet-sdk/common';
+import React, { createContext, useState } from 'react';
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
 

--- a/src/features/common/Layout/ErrorPopup/index.tsx
+++ b/src/features/common/Layout/ErrorPopup/index.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement, useContext, useEffect } from 'react';
+import type { ReactElement } from 'react';
+
+import React, { useContext, useEffect } from 'react';
 import CloseIcon from '../../../../../public/assets/images/icons/CloseIcon';
 import styles from './ErrorPopup.module.scss';
 import { useTranslations } from 'next-intl';

--- a/src/features/common/Layout/Footer/SelectLanguageAndCountry.tsx
+++ b/src/features/common/Layout/Footer/SelectLanguageAndCountry.tsx
@@ -1,3 +1,6 @@
+import type { ChangeEvent } from 'react';
+import type { CountryCode } from '@planet-sdk/common';
+
 import {
   Modal,
   Fade,
@@ -5,13 +8,7 @@ import {
   FormControlLabel,
   RadioGroup,
 } from '@mui/material';
-import React, {
-  ChangeEvent,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import {
   getCountryDataBy,
   sortCountriesByTranslation,
@@ -24,7 +21,6 @@ import styles from './SelectLanguageAndCountry.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
 import { useTenant } from '../TenantContext';
 import { useRouter } from 'next/router';
-import { CountryCode } from '@planet-sdk/common';
 import { useCurrency } from '../CurrencyContext';
 
 interface MapCountryProps {

--- a/src/features/common/Layout/Footer/index.tsx
+++ b/src/features/common/Layout/Footer/index.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
+
+import React, { useEffect, useState } from 'react';
 import UNEPLogo from '../../../../../public/assets/images/footer/UNEPLogo';
 import World from '../../../../../public/assets/images/footer/World';
 import getLanguageName from '../../../../utils/language/getLanguageName';

--- a/src/features/common/Layout/Forms/InlineFormDisplayGroup.tsx
+++ b/src/features/common/Layout/Forms/InlineFormDisplayGroup.tsx
@@ -1,5 +1,6 @@
+import type { ReactElement, ReactNode } from 'react';
+
 import { styled } from '@mui/material';
-import { ReactElement, ReactNode } from 'react';
 
 const InlineFormGroup = styled('div')({
   display: 'flex',

--- a/src/features/common/Layout/MyForestContext.tsx
+++ b/src/features/common/Layout/MyForestContext.tsx
@@ -1,14 +1,5 @@
-import {
-  FC,
-  createContext,
-  useContext,
-  useMemo,
-  useState,
-  useEffect,
-} from 'react';
-import { trpc } from '../../../utils/trpc';
-import { ErrorHandlingContext } from './ErrorHandlingContext';
-import {
+import type { FC } from 'react';
+import type {
   ProjectListResponse,
   MyForestProject,
   ContributionsResponse,
@@ -20,9 +11,13 @@ import {
   DonationProperties,
   ContributionStats,
 } from '../types/myForest';
+import type { SetState } from '../types/common';
+import type { PointFeature } from 'supercluster';
+
+import { createContext, useContext, useMemo, useState, useEffect } from 'react';
+import { trpc } from '../../../utils/trpc';
+import { ErrorHandlingContext } from './ErrorHandlingContext';
 import { updateStateWithTrpcData } from '../../../utils/trpcHelpers';
-import { SetState } from '../types/common';
-import { PointFeature } from 'supercluster';
 
 interface UserInfo {
   profileId: string;

--- a/src/features/common/Layout/Navbar/getSubMenu.tsx
+++ b/src/features/common/Layout/Navbar/getSubMenu.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import ChildrenYouthIcon from '../../../../../public/assets/images/icons/megaMenuIcons/childrenAndYouth';
 import OverviewIcon from '../../../../../public/assets/images/icons/megaMenuIcons/overview';
 import PartnerIcon from '../../../../../public/assets/images/icons/megaMenuIcons/partners';

--- a/src/features/common/Layout/Navbar/microComponents/NavigationItem.tsx
+++ b/src/features/common/Layout/Navbar/microComponents/NavigationItem.tsx
@@ -1,10 +1,11 @@
+import type { SetState } from '../../../types/common';
+import { type HeaderItem } from '@planet-sdk/common';
+
 import { useRouter } from 'next/router';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import SubMenu from './SubMenu';
-import { SetState } from '../../../types/common';
 import { useTenant } from '../../TenantContext';
-import { type HeaderItem } from '@planet-sdk/common';
 import { useMemo } from 'react';
 
 interface NavigationItemProps {

--- a/src/features/common/Layout/Navbar/microComponents/NavigationMenu.tsx
+++ b/src/features/common/Layout/Navbar/microComponents/NavigationMenu.tsx
@@ -1,9 +1,10 @@
+import type { HeaderItem } from '@planet-sdk/common';
+
 import { useTenant } from '../../TenantContext';
 import UserProfileButton from './UserProfileButton';
 import { useState, useEffect } from 'react';
 import { useMobileDetection } from '../../../../../utils/navbarUtils';
 import NavigationItem from './NavigationItem';
-import { HeaderItem } from '@planet-sdk/common';
 
 const NavigationMenu = () => {
   const { tenantConfig } = useTenant();

--- a/src/features/common/Layout/Navbar/microComponents/SubMenu.tsx
+++ b/src/features/common/Layout/Navbar/microComponents/SubMenu.tsx
@@ -1,7 +1,8 @@
+import type { SubmenuItem } from '@planet-sdk/common';
+
 import { lang_path } from '../../../../../utils/constants/wpLanguages';
 import GetSubMenuIcons from '../getSubMenu';
 import { useTranslations, useLocale } from 'next-intl';
-import { SubmenuItem } from '@planet-sdk/common';
 import Link from 'next/link';
 
 export interface SubMenuProps {

--- a/src/features/common/Layout/PayoutsContext.tsx
+++ b/src/features/common/Layout/PayoutsContext.tsx
@@ -1,5 +1,7 @@
-import { createContext, FC, useState, useContext } from 'react';
-import { BankAccount, PayoutMinAmounts } from '../types/payouts';
+import type { FC } from 'react';
+import type { BankAccount, PayoutMinAmounts } from '../types/payouts';
+
+import { createContext, useState, useContext } from 'react';
 
 interface PayoutsContextInterface {
   accounts: BankAccount[] | null;

--- a/src/features/common/Layout/PlanetCashContext.tsx
+++ b/src/features/common/Layout/PlanetCashContext.tsx
@@ -1,5 +1,7 @@
-import { createContext, FC, useState, useContext } from 'react';
-import { PlanetCashAccount } from '../types/planetcash';
+import type { FC } from 'react';
+import type { PlanetCashAccount } from '../types/planetcash';
+
+import { createContext, useState, useContext } from 'react';
 
 interface PlanetCashContextInterface {
   accounts: PlanetCashAccount[] | null;

--- a/src/features/common/Layout/ProjectPropsContext.tsx
+++ b/src/features/common/Layout/ProjectPropsContext.tsx
@@ -1,18 +1,10 @@
-import React, {
-  useState,
-  createContext,
-  useRef,
-  useContext,
-  useEffect,
-  FC,
-} from 'react';
-import { ParamsContext } from './QueryParamsContext';
-import {
+import type { FC } from 'react';
+import type {
   TreeProjectExtended,
   ConservationProjectExtended,
 } from '@planet-sdk/common/build/types/project/extended';
-import { ProjectPurposeTypes } from '@planet-sdk/common/build/types/project/common';
-import ProjectPropsContextInterface, {
+import type { ProjectPurposeTypes } from '@planet-sdk/common/build/types/project/common';
+import type {
   ExploreOption,
   LayerSettings,
   MapMode,
@@ -23,8 +15,21 @@ import ProjectPropsContextInterface, {
   SitesGeoJSON,
   ViewPort,
 } from '../types/ProjectPropsContextInterface';
-import { MapRef } from 'react-map-gl/src/components/static-map';
-import { PlantLocation, SamplePlantLocation } from '../types/plantLocation';
+import type ProjectPropsContextInterface from '../types/ProjectPropsContextInterface';
+import type { MapRef } from 'react-map-gl/src/components/static-map';
+import type {
+  PlantLocation,
+  SamplePlantLocation,
+} from '../types/plantLocation';
+
+import React, {
+  useState,
+  createContext,
+  useRef,
+  useContext,
+  useEffect,
+} from 'react';
+import { ParamsContext } from './QueryParamsContext';
 
 const ProjectPropsContext = createContext<ProjectPropsContextInterface | null>(
   null

--- a/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
+++ b/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
@@ -1,7 +1,9 @@
-import { FC, useState } from 'react';
+import type { FC } from 'react';
+import type { SetState } from '../../types/common';
+
+import { useState } from 'react';
 import styles from './ProjectsLayout.module.scss';
 import ProjectsMap from '../../../projectsV2/ProjectsMap';
-import { SetState } from '../../types/common';
 import { ProjectsProvider } from '../../../projectsV2/ProjectsContext';
 import { ProjectsMapProvider } from '../../../projectsV2/ProjectsMapContext';
 import Credits from '../../../projectsV2/ProjectsMap/Credits';

--- a/src/features/common/Layout/ProjectsLayout/index.tsx
+++ b/src/features/common/Layout/ProjectsLayout/index.tsx
@@ -1,7 +1,9 @@
-import { FC, useMemo } from 'react';
+import type { FC } from 'react';
+import type { SetState } from '../../types/common';
+
+import { useMemo } from 'react';
 import styles from './ProjectsLayout.module.scss';
 import Credits from '../../../projectsV2/ProjectsMap/Credits';
-import { SetState } from '../../types/common';
 import ProjectsMap from '../../../projectsV2/ProjectsMap';
 import { ProjectsProvider } from '../../../projectsV2/ProjectsContext';
 import {

--- a/src/features/common/Layout/QueryParamsContext.tsx
+++ b/src/features/common/Layout/QueryParamsContext.tsx
@@ -1,4 +1,6 @@
-import React, { createContext, FC, useEffect, useState } from 'react';
+import type { FC } from 'react';
+
+import React, { createContext, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useLocale } from 'next-intl';
 

--- a/src/features/common/Layout/SingleColumnView/index.tsx
+++ b/src/features/common/Layout/SingleColumnView/index.tsx
@@ -1,4 +1,5 @@
-import { ReactElement, ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
+
 import { Grid } from '@mui/material';
 interface SingleColumnViewProps {
   children: ReactNode;

--- a/src/features/common/Layout/TabbedView/TabSteps.tsx
+++ b/src/features/common/Layout/TabbedView/TabSteps.tsx
@@ -1,8 +1,10 @@
-import React, { ReactElement, SyntheticEvent } from 'react';
+import type { ReactElement, SyntheticEvent } from 'react';
+import type { TabItem } from './TabbedViewTypes';
+
+import React from 'react';
 import { useRouter } from 'next/router';
 import { Tab, Tabs } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import { TabItem } from './TabbedViewTypes';
 
 interface TabStepsProps {
   step: number | string | false;

--- a/src/features/common/Layout/TabbedView/index.tsx
+++ b/src/features/common/Layout/TabbedView/index.tsx
@@ -1,7 +1,9 @@
-import { ReactElement, ReactNode, useEffect, useState } from 'react';
+import type { ReactElement, ReactNode } from 'react';
+import type { TabItem } from './TabbedViewTypes';
+
+import { useEffect, useState } from 'react';
 import { Grid, styled } from '@mui/material';
 import TabSteps from './TabSteps';
-import { TabItem } from './TabbedViewTypes';
 
 const TabContainer = styled('div')(() => ({
   backgroundColor: 'inherit',

--- a/src/features/common/Layout/TenantContext.tsx
+++ b/src/features/common/Layout/TenantContext.tsx
@@ -1,7 +1,8 @@
-import { useContext, createContext, useMemo, useState, FC } from 'react';
+import type { FC } from 'react';
+import type { SetState } from '../types/common';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import { SetState } from '../types/common';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
+import { useContext, createContext, useMemo, useState } from 'react';
 import { defaultTenant } from '../../../../tenant.config';
 
 interface TenantContextInterface {

--- a/src/features/common/Layout/UnderMaintenance/index.tsx
+++ b/src/features/common/Layout/UnderMaintenance/index.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import { useTranslations } from 'next-intl';
 import UnderMaintenanceImage from '../../../../../public/assets/images/icons/UnderMaintenance';
 import styles from './UnderMaintenance.module.scss';

--- a/src/features/common/Layout/UserLayout/UserLayout.tsx
+++ b/src/features/common/Layout/UserLayout/UserLayout.tsx
@@ -1,12 +1,8 @@
+import type { User } from '@planet-sdk/common/build/types/user';
+import type { Dispatch, FC, ReactNode, SetStateAction } from 'react';
+
 import router, { useRouter } from 'next/router';
-import React, {
-  Dispatch,
-  FC,
-  ReactNode,
-  SetStateAction,
-  useEffect,
-  useState,
-} from 'react';
+import React, { useEffect, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import MenuIcon from '../../../../../public/assets/images/icons/Sidebar/MenuIcon';
 import DownArrow from '../../../../../public/assets/images/icons/DownArrow';
@@ -28,7 +24,6 @@ import RegisterTreeIcon from '../../../../../public/assets/images/icons/Sidebar/
 import NotionLinkIcon from '../../../../../public/assets/images/icons/Sidebar/NotionLinkIcon';
 import SupportPin from '../../../user/Settings/ImpersonateUser/SupportPin';
 import FiberPinIcon from '@mui/icons-material/FiberPin';
-import { User } from '@planet-sdk/common/build/types/user';
 
 interface SubMenuItemType {
   title: string;

--- a/src/features/common/Layout/UserPropsContext.tsx
+++ b/src/features/common/Layout/UserPropsContext.tsx
@@ -1,13 +1,15 @@
-import {
-  useAuth0,
+import type {
   User as Auth0User,
   RedirectLoginOptions,
 } from '@auth0/auth0-react';
+import type { FC } from 'react';
+import type { User } from '@planet-sdk/common/build/types/user';
+import type { SetState } from '../types/common';
+
+import { useAuth0 } from '@auth0/auth0-react';
 import { useRouter } from 'next/router';
-import React, { FC, useContext } from 'react';
+import React, { useContext } from 'react';
 import { getAccountInfo } from '../../../utils/apiRequests/api';
-import { User } from '@planet-sdk/common/build/types/user';
-import { SetState } from '../types/common';
 import { useTenant } from './TenantContext';
 
 interface UserPropsContextInterface {

--- a/src/features/common/Layout/index.tsx
+++ b/src/features/common/Layout/index.tsx
@@ -1,4 +1,6 @@
-import React, { FC, useContext } from 'react';
+import type { FC } from 'react';
+
+import React, { useContext } from 'react';
 import theme from '../../../theme/theme';
 import { useTheme } from '../../../theme/themeContext';
 import CookiePolicy from './CookiePolicy';

--- a/src/features/common/TreeCounter/TreeCounter.tsx
+++ b/src/features/common/TreeCounter/TreeCounter.tsx
@@ -1,6 +1,6 @@
-import MuiCircularProgress, {
-  CircularProgressProps,
-} from '@mui/material/CircularProgress';
+import type { CircularProgressProps } from '@mui/material/CircularProgress';
+
+import MuiCircularProgress from '@mui/material/CircularProgress';
 import React, { useEffect, useState } from 'react';
 import treeCounterStyles from './TreeCounter.module.scss';
 import { useLocale, useTranslations } from 'next-intl';

--- a/src/features/common/VerifyEmail/VerifyEmail.tsx
+++ b/src/features/common/VerifyEmail/VerifyEmail.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement, useContext } from 'react';
+import type { ReactElement } from 'react';
+
+import React, { useContext } from 'react';
 import styles from './VerifyEmail.module.scss';
 import { useTranslations } from 'next-intl';
 import VerifyEmailIcon from '../../../../public/assets/images/icons/VerifyEmail';

--- a/src/features/common/WebappButton/index.tsx
+++ b/src/features/common/WebappButton/index.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import styles from './WebappButton.module.scss';
 import Link from 'next/link';
 

--- a/src/features/common/types/ProjectPropsContextInterface.ts
+++ b/src/features/common/types/ProjectPropsContextInterface.ts
@@ -1,22 +1,22 @@
-import {
+import type {
   ProjectMapInfo,
   TreeProjectConcise,
   ConservationProjectConcise,
 } from '@planet-sdk/common/build/types/project/map';
-import {
+import type {
   TreeProjectExtended,
   ConservationProjectExtended,
 } from '@planet-sdk/common/build/types/project/extended';
-import {
+import type {
   ProjectPurposeTypes,
   ProjectSite,
 } from '@planet-sdk/common/build/types/project/common';
-import { FeatureCollection, Polygon, MultiPolygon } from 'geojson';
-import { SetState } from './common';
-import { RefObject } from 'react';
-import { MapRef } from 'react-map-gl/src/components/static-map';
-import { FlyToInterpolator } from 'react-map-gl';
-import { PlantLocation, SamplePlantLocation } from './plantLocation';
+import type { FeatureCollection, Polygon, MultiPolygon } from 'geojson';
+import type { SetState } from './common';
+import type { RefObject } from 'react';
+import type { MapRef } from 'react-map-gl/src/components/static-map';
+import type { FlyToInterpolator } from 'react-map-gl';
+import type { PlantLocation, SamplePlantLocation } from './plantLocation';
 
 export type ExploreOption =
   | 'Deforestation'

--- a/src/features/common/types/common.d.ts
+++ b/src/features/common/types/common.d.ts
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 
 export type SetState<T> = Dispatch<SetStateAction<T>>;
 

--- a/src/features/common/types/country.d.ts
+++ b/src/features/common/types/country.d.ts
@@ -1,4 +1,4 @@
-import { CountryCode, CurrencyCode } from '@planet-sdk/common';
+import type { CountryCode, CurrencyCode } from '@planet-sdk/common';
 
 type ExtendedCountryCode = CountryCode | 'auto';
 

--- a/src/features/common/types/dataExplorer.d.ts
+++ b/src/features/common/types/dataExplorer.d.ts
@@ -1,4 +1,4 @@
-import { Geometry } from '@turf/turf';
+import type { Geometry } from '@turf/turf';
 
 export interface IDailyFrame {
   plantedDate: string;

--- a/src/features/common/types/map.d.ts
+++ b/src/features/common/types/map.d.ts
@@ -1,8 +1,8 @@
-import Supercluster from 'supercluster';
-import { User, UserInfo } from '@planet-sdk/common';
-import { MutableRefObject } from 'react';
-import { UserPublicProfile } from '@planet-sdk/common';
-import {
+import type Supercluster from 'supercluster';
+import type { User } from '@planet-sdk/common';
+import type { MutableRefObject } from 'react';
+import type { UserPublicProfile } from '@planet-sdk/common';
+import type {
   TreeProjectClassification,
   CountryCode,
   CurrencyCode,
@@ -11,10 +11,9 @@ import {
   Tpo,
   UnitTypes,
 } from '@planet-sdk/common';
-import { Nullable } from '@planet-sdk/common/build/types/util';
-import { ContributionProps } from '../../user/RegisterTrees/RegisterTrees/SingleContribution';
-import { FlyToInterpolator } from 'react-map-gl';
-import { SetState } from './common';
+import type { Nullable } from '@planet-sdk/common/build/types/util';
+import type { ContributionProps } from '../../user/RegisterTrees/RegisterTrees/SingleContribution';
+import type { FlyToInterpolator } from 'react-map-gl';
 
 export interface ClusterMarker {
   geometry: {

--- a/src/features/common/types/myForest.d.ts
+++ b/src/features/common/types/myForest.d.ts
@@ -1,11 +1,11 @@
-import { Point, Polygon } from 'geojson';
-import { DateString } from './common';
-import {
+import type { Point, Polygon } from 'geojson';
+import type { DateString } from './common';
+import type {
   CountryCode,
   EcosystemTypes,
   TreeProjectClassification,
 } from '@planet-sdk/common';
-import { ClusterProperties } from 'supercluster';
+import type { ClusterProperties } from 'supercluster';
 
 export type ContributionStats = {
   giftsReceivedCount: number;

--- a/src/features/common/types/payments.d.ts
+++ b/src/features/common/types/payments.d.ts
@@ -1,4 +1,4 @@
-import { ProjectPurpose, UnitTypes } from '@planet-sdk/common';
+import type { ProjectPurpose, UnitTypes } from '@planet-sdk/common';
 
 export interface Fees {
   disputeFee: number;

--- a/src/features/common/types/plantLocation.d.ts
+++ b/src/features/common/types/plantLocation.d.ts
@@ -1,6 +1,6 @@
-import { DateString } from './common';
-import { Links } from './payments';
-import { Polygon, Point } from 'geojson';
+import type { DateString } from './common';
+import type { Links } from './payments';
+import type { Polygon, Point } from 'geojson';
 
 export interface PlantLocationBase {
   hid: string;

--- a/src/features/common/types/profile.d.ts
+++ b/src/features/common/types/profile.d.ts
@@ -1,6 +1,6 @@
-import { User, UserPublicProfile } from '@planet-sdk/common';
-import { SetState } from './common';
-import { PublicUser } from './user';
+import type { User, UserPublicProfile } from '@planet-sdk/common';
+import type { SetState } from './common';
+import type { PublicUser } from './user';
 
 export interface UserFeaturesProps {
   handleShare: () => void;

--- a/src/features/common/types/user.d.ts
+++ b/src/features/common/types/user.d.ts
@@ -1,5 +1,5 @@
-import { Image } from '@planet-sdk/common';
-import { Geometry } from '@turf/turf';
+import type { Image } from '@planet-sdk/common';
+import type { Geometry } from '@turf/turf';
 
 export interface ContributionType {
   type: string;

--- a/src/features/donations/components/DirectGift.tsx
+++ b/src/features/donations/components/DirectGift.tsx
@@ -1,8 +1,9 @@
+import type { SetState } from '../../common/types/common';
+
 import React from 'react';
 import styles from '../styles/DirectGift.module.scss';
 import CancelIcon from '../../../../public/assets/images/icons/CancelIcon';
 import { useTranslations } from 'next-intl';
-import { SetState } from '../../common/types/common';
 import Link from 'next/link';
 
 export interface DirectGiftI {

--- a/src/features/projects/components/PlantLocation/ImageSlider.tsx
+++ b/src/features/projects/components/PlantLocation/ImageSlider.tsx
@@ -1,8 +1,9 @@
+import type { Story } from 'react-insta-stories/dist/interfaces';
+
 import { useState, useEffect } from 'react';
 import Stories from 'react-insta-stories';
 import getImageUrl from '../../../../utils/getImageURL';
 import styles from './../../styles/PlantLocation.module.scss';
-import { Story } from 'react-insta-stories/dist/interfaces';
 
 export type SliderImage = {
   image?: string;

--- a/src/features/projects/components/PlantLocation/PlantLocationDetails.tsx
+++ b/src/features/projects/components/PlantLocation/PlantLocationDetails.tsx
@@ -1,4 +1,11 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type {
+  PlantLocation,
+  SamplePlantLocation,
+} from '../../../common/types/plantLocation';
+import type { SliderImage } from '../../components/PlantLocation/ImageSlider';
+
+import React from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import styles from '../../styles/PlantLocation.module.scss';
 import { localizedAbbreviatedNumber } from '../../../../utils/getFormattedNumber';
@@ -7,11 +14,6 @@ import formatDate from '../../../../utils/countryCurrency/getFormattedDate';
 import dynamic from 'next/dynamic';
 import { useProjectProps } from '../../../common/Layout/ProjectPropsContext';
 import InfoIcon from '../../../../../public/assets/images/icons/InfoIcon';
-import {
-  PlantLocation,
-  SamplePlantLocation,
-} from '../../../common/types/plantLocation';
-import { SliderImage } from '../../components/PlantLocation/ImageSlider';
 
 const ImageSlider = dynamic(
   () => import('../../components/PlantLocation/ImageSlider'),

--- a/src/features/projects/components/PopupProject.tsx
+++ b/src/features/projects/components/PopupProject.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, RefObject } from 'react';
+import type { ReactElement, RefObject } from 'react';
+import type {
+  ConservationProjectConcise,
+  TreeProjectConcise,
+} from '@planet-sdk/common/build/types/project/map';
+import React from 'react';
+
 import getImageUrl from '../../../utils/getImageURL';
 import { useLocale, useTranslations } from 'next-intl';
 import getFormatedCurrency from '../../../utils/countryCurrency/getFormattedCurrency';
@@ -10,10 +16,6 @@ import { ParamsContext } from '../../common/Layout/QueryParamsContext';
 import VerifiedBadge from './VerifiedBadge';
 import TopProjectBadge from './TopProjectBadge';
 import ProjectTypeIcon from '../../common/ProjectTypeIcon';
-import {
-  ConservationProjectConcise,
-  TreeProjectConcise,
-} from '@planet-sdk/common/build/types/project/map';
 import ProjectInfo from '../../../../public/assets/images/icons/project/ProjectInfo';
 import {
   bindHover,

--- a/src/features/projects/components/ProjectSnippet.tsx
+++ b/src/features/projects/components/ProjectSnippet.tsx
@@ -1,4 +1,12 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type {
+  ConservationProjectConcise,
+  ConservationProjectExtended,
+  TreeProjectConcise,
+  TreeProjectExtended,
+} from '@planet-sdk/common';
+
+import React from 'react';
 import getImageUrl from '../../../utils/getImageURL';
 import { useRouter } from 'next/router';
 import { useLocale, useTranslations } from 'next-intl';
@@ -14,12 +22,6 @@ import { ParamsContext } from '../../common/Layout/QueryParamsContext';
 import VerifiedBadge from './VerifiedBadge';
 import TopProjectBadge from './TopProjectBadge';
 import ProjectTypeIcon from '../../common/ProjectTypeIcon';
-import {
-  ConservationProjectConcise,
-  ConservationProjectExtended,
-  TreeProjectConcise,
-  TreeProjectExtended,
-} from '@planet-sdk/common';
 import ProjectInfo from '../../../../public/assets/images/icons/project/ProjectInfo';
 import {
   bindHover,

--- a/src/features/projects/components/ProjectsMap.tsx
+++ b/src/features/projects/components/ProjectsMap.tsx
@@ -1,5 +1,10 @@
-import React, { ReactElement, useEffect, useState } from 'react';
-import MapGL, { MapEvent, NavigationControl, Popup } from 'react-map-gl';
+import type { MapEvent } from 'react-map-gl';
+import type { PopupData } from './maps/Markers';
+import type { PlantLocation } from '../../common/types/plantLocation';
+import type { ReactElement } from 'react';
+
+import React, { useEffect, useState } from 'react';
+import MapGL, { NavigationControl, Popup } from 'react-map-gl';
 import getMapStyle from '../../../utils/maps/getMapStyle';
 import styles from '../styles/ProjectsMap.module.scss';
 import Project from '../components/maps/Project';
@@ -11,8 +16,6 @@ import LayerIcon from '../../../../public/assets/images/icons/LayerIcon';
 import LayerDisabled from '../../../../public/assets/images/icons/LayerDisabled';
 import { useTranslations } from 'next-intl';
 import { ParamsContext } from '../../common/Layout/QueryParamsContext';
-import { PopupData } from './maps/Markers';
-import { PlantLocation } from '../../common/types/plantLocation';
 
 interface ShowDetailsProps {
   coordinates: [number, number] | null;

--- a/src/features/projects/components/TopProjectBadge.tsx
+++ b/src/features/projects/components/TopProjectBadge.tsx
@@ -1,4 +1,5 @@
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
 import {
   bindPopover,
   usePopupState,

--- a/src/features/projects/components/VerifiedBadge.tsx
+++ b/src/features/projects/components/VerifiedBadge.tsx
@@ -1,4 +1,6 @@
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { Review } from '@planet-sdk/common';
+
 import VerifiedIcon from '@mui/icons-material/Verified';
 import {
   bindPopover,
@@ -7,7 +9,6 @@ import {
 } from 'material-ui-popup-state/hooks';
 import TopProjectReports from './projectDetails/TopProjectReports';
 import HoverPopover from 'material-ui-popup-state/HoverPopover';
-import { Review } from '@planet-sdk/common';
 import styles from '../styles/ProjectSnippet.module.scss';
 
 interface Props {

--- a/src/features/projects/components/maps/Explore.tsx
+++ b/src/features/projects/components/maps/Explore.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import styles from '../../styles/ProjectsMap.module.scss';
 import CancelIcon from '../../../../../public/assets/images/icons/CancelIcon';
 import ExploreIcon from '../../../../../public/assets/images/icons/ExploreIcon';

--- a/src/features/projects/components/maps/ExploreInfoModal.tsx
+++ b/src/features/projects/components/maps/ExploreInfoModal.tsx
@@ -1,10 +1,12 @@
-import React, { ReactElement, RefObject } from 'react';
+import type { ReactElement, RefObject } from 'react';
+import type { ExploreOption } from '../../../common/types/ProjectPropsContextInterface';
+import type { SetState } from '../../../common/types/common';
+
+import React from 'react';
 import styles from '../../styles/ProjectsMap.module.scss';
 import { useTranslations } from 'next-intl';
 import OpenLink from '../../../../../public/assets/images/icons/OpenLink';
 import CancelIcon from '../../../../../public/assets/images/icons/CancelIcon';
-import { ExploreOption } from '../../../common/types/ProjectPropsContextInterface';
-import { SetState } from '../../../common/types/common';
 
 interface Props {
   infoRef: RefObject<HTMLDivElement>;

--- a/src/features/projects/components/maps/ExploreLayers.tsx
+++ b/src/features/projects/components/maps/ExploreLayers.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import { Layer, Source } from 'react-map-gl';
 import { useProjectProps } from '../../../common/Layout/ProjectPropsContext';
 import { LayerManager, Layer as LayerM } from 'layer-manager/dist/components';

--- a/src/features/projects/components/maps/Home.tsx
+++ b/src/features/projects/components/maps/Home.tsx
@@ -1,12 +1,15 @@
-import React, { ReactElement } from 'react';
-import { FlyToInterpolator } from 'react-map-gl';
-import Markers, { PopupData } from './Markers';
-import * as d3 from 'd3-ease';
-import {
+import type { ReactElement } from 'react';
+import type { PopupData } from './Markers';
+import type {
   MapProject,
   ViewPort,
 } from '../../../common/types/ProjectPropsContextInterface';
-import { SetState } from '../../../common/types/common';
+import type { SetState } from '../../../common/types/common';
+
+import { FlyToInterpolator } from 'react-map-gl';
+import React from 'react';
+import Markers from './Markers';
+import * as d3 from 'd3-ease';
 
 interface Props {
   searchedProject: MapProject[];

--- a/src/features/projects/components/maps/ImageDropdown.tsx
+++ b/src/features/projects/components/maps/ImageDropdown.tsx
@@ -1,15 +1,17 @@
+import type { ReactElement } from 'react';
+import type {
+  Imagery,
+  RasterData,
+} from '../../../common/types/ProjectPropsContextInterface';
+import type { SetState } from '../../../common/types/common';
+
 import { FormControl, NativeSelect } from '@mui/material';
-import React, { ReactElement } from 'react';
+import React from 'react';
 import BootstrapInput from '../../../common/InputTypes/BootstrapInput';
 import styles from '../../styles/VegetationChange.module.scss';
 import sources from '../../../../../public/data/maps/sources.json';
 import SourceIcon from '../../../../../public/assets/images/icons/SourceIcon';
 import { ParamsContext } from '../../../common/Layout/QueryParamsContext';
-import {
-  Imagery,
-  RasterData,
-} from '../../../common/types/ProjectPropsContextInterface';
-import { SetState } from '../../../common/types/common';
 
 interface Props {
   selectedYear1: string;

--- a/src/features/projects/components/maps/Location.tsx
+++ b/src/features/projects/components/maps/Location.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
-import { Marker } from 'react-map-gl';
-import styles from '../../styles/ProjectsMap.module.scss';
 import ProjectPolygon from './ProjectPolygon';
-import { FeatureCollection } from 'geojson';
-import {
+import type { FeatureCollection } from 'geojson';
+import type {
   ConservationProjectExtended,
   TreeProjectExtended,
 } from '@planet-sdk/common/build/types/project/extended';
+
+import React from 'react';
+import { Marker } from 'react-map-gl';
+import styles from '../../styles/ProjectsMap.module.scss';
 
 interface Props {
   siteExists: boolean;

--- a/src/features/projects/components/maps/MapHolder.tsx
+++ b/src/features/projects/components/maps/MapHolder.tsx
@@ -1,7 +1,8 @@
+import type { SetState } from '../../../common/types/common';
+
 import { useTenant } from '../../../common/Layout/TenantContext';
 import PlayButton from '../../../common/LandingVideo/PlayButton';
 import { useProjectProps } from '../../../common/Layout/ProjectPropsContext';
-import { SetState } from '../../../common/types/common';
 import MapLayout from '../ProjectsMap';
 import { useRouter } from 'next/router';
 

--- a/src/features/projects/components/maps/Markers.tsx
+++ b/src/features/projects/components/maps/Markers.tsx
@@ -1,12 +1,14 @@
+import type { ReactElement } from 'react';
+import type { SetState } from '../../../common/types/common';
+import type { MapProject } from '../../../common/types/ProjectPropsContextInterface';
+
 import { useRouter } from 'next/router';
-import React, { ReactElement } from 'react';
+import React from 'react';
 import { Marker, Popup } from 'react-map-gl';
 import PopupProject from '../PopupProject';
 import styles from '../../styles/ProjectsMap.module.scss';
 import { ParamsContext } from '../../../common/Layout/QueryParamsContext';
 import ProjectTypeIcon from '../../../common/ProjectTypeIcon';
-import { SetState } from '../../../common/types/common';
-import { MapProject } from '../../../common/types/ProjectPropsContextInterface';
 import { useLocale } from 'next-intl';
 
 type PopupClosedData = {

--- a/src/features/projects/components/maps/PlantLocations.tsx
+++ b/src/features/projects/components/maps/PlantLocations.tsx
@@ -1,4 +1,13 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type {
+  PlantLocation,
+  PlantLocationMulti,
+  PlantLocationSingle,
+  SamplePlantLocation,
+} from '../../../common/types/plantLocation';
+import type { Feature, Point, Polygon } from 'geojson';
+
+import React from 'react';
 import { Layer, Marker } from 'react-map-gl';
 import { Source } from 'react-map-gl';
 import { useProjectProps } from '../../../common/Layout/ProjectPropsContext';
@@ -6,13 +15,6 @@ import styles from '../../styles/PlantLocation.module.scss';
 import * as turf from '@turf/turf';
 import { localizedAbbreviatedNumber } from '../../../../utils/getFormattedNumber';
 import { useLocale, useTranslations } from 'next-intl';
-import {
-  PlantLocation,
-  PlantLocationMulti,
-  PlantLocationSingle,
-  SamplePlantLocation,
-} from '../../../common/types/plantLocation';
-import { Feature, Point, Polygon } from 'geojson';
 
 export default function PlantLocations(): ReactElement {
   const {

--- a/src/features/projects/components/maps/Project.tsx
+++ b/src/features/projects/components/maps/Project.tsx
@@ -1,4 +1,17 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type {
+  TreeProjectExtended,
+  ConservationProjectExtended,
+} from '@planet-sdk/common';
+import type {
+  Imagery,
+  RasterData,
+  ViewPort,
+} from '../../../common/types/ProjectPropsContextInterface';
+import type { SetState } from '../../../common/types/common';
+import type { Position } from 'geojson';
+
+import React from 'react';
 import { getRasterData } from '../../../../utils/apiRequests/api';
 import zoomToLocation from '../../../../utils/maps/zoomToLocation';
 import zoomToProjectSite from '../../../../utils/maps/zoomToProjectSite';
@@ -7,17 +20,6 @@ import Location from './Location';
 import Sites from './Sites';
 import { useRouter } from 'next/router';
 import { zoomToPolygonPlantLocation } from '../../../../../src/utils/maps/plantLocations';
-import {
-  TreeProjectExtended,
-  ConservationProjectExtended,
-} from '@planet-sdk/common';
-import {
-  Imagery,
-  RasterData,
-  ViewPort,
-} from '../../../common/types/ProjectPropsContextInterface';
-import { SetState } from '../../../common/types/common';
-import { Position } from 'geojson';
 
 interface Props {
   project: TreeProjectExtended | ConservationProjectExtended;

--- a/src/features/projects/components/maps/ProjectPolygon.tsx
+++ b/src/features/projects/components/maps/ProjectPolygon.tsx
@@ -1,7 +1,9 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { FeatureCollection } from 'geojson';
+
+import React from 'react';
 import { Layer, Source } from 'react-map-gl';
 import { useProjectProps } from '../../../common/Layout/ProjectPropsContext';
-import { FeatureCollection } from 'geojson';
 
 interface Props {
   id?: string | undefined;

--- a/src/features/projects/components/maps/ProjectTabs.tsx
+++ b/src/features/projects/components/maps/ProjectTabs.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import { useRouter } from 'next/router';
 import { useTranslations } from 'next-intl';
 import LocationIcon from '../../../../../public/assets/images/icons/LocationIcon';

--- a/src/features/projects/components/maps/SatelliteLayer.tsx
+++ b/src/features/projects/components/maps/SatelliteLayer.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import { Layer, Source } from 'react-map-gl';
 
 interface Props {

--- a/src/features/projects/components/maps/Sites.tsx
+++ b/src/features/projects/components/maps/Sites.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import zoomToProjectSite from '../../../../utils/maps/zoomToProjectSite';
 import { useProjectProps } from '../../../common/Layout/ProjectPropsContext';
 import SatelliteLayer from './SatelliteLayer';

--- a/src/features/projects/components/maps/SitesDropdown.tsx
+++ b/src/features/projects/components/maps/SitesDropdown.tsx
@@ -1,16 +1,17 @@
+import type { ReactElement } from 'react';
+import type {
+  ConservationProjectExtended,
+  TreeProjectExtended,
+} from '@planet-sdk/common/build/types/project/extended';
+import type { SitesGeoJSON } from '../../../common/types/ProjectPropsContextInterface';
+import React from 'react';
 import { FormControl, NativeSelect } from '@mui/material';
-import React, { ReactElement } from 'react';
 import { useRouter } from 'next/router';
 import PolygonIcon from '../../../../../public/assets/images/icons/PolygonIcon';
 import styles from '../../styles/ProjectsMap.module.scss';
 import BootstrapInput from '../../../common/InputTypes/BootstrapInput';
 import { useProjectProps } from '../../../common/Layout/ProjectPropsContext';
 import { ParamsContext } from '../../../common/Layout/QueryParamsContext';
-import {
-  ConservationProjectExtended,
-  TreeProjectExtended,
-} from '@planet-sdk/common/build/types/project/extended';
-import { SitesGeoJSON } from '../../../common/types/ProjectPropsContextInterface';
 
 export default function SitesDropdown(): ReactElement {
   const {

--- a/src/features/projects/components/maps/TimeTravel.tsx
+++ b/src/features/projects/components/maps/TimeTravel.tsx
@@ -1,10 +1,13 @@
-import React, { ReactElement } from 'react';
-import mapboxgl, { Map } from 'mapbox-gl';
+import type { ReactElement } from 'react';
+import type { Map } from 'mapbox-gl';
+import type { Imagery } from '../../../common/types/ProjectPropsContextInterface';
+
+import React from 'react';
+import mapboxgl from 'mapbox-gl';
 import MapboxCompare from 'mapbox-gl-compare';
 import ImageDropdown from './ImageDropdown';
 import { useProjectProps } from '../../../common/Layout/ProjectPropsContext';
 import ZoomButtons from './ZoomButtons';
-import { Imagery } from '../../../common/types/ProjectPropsContextInterface';
 
 export default function TimeTravel(): ReactElement {
   const { mapRef, geoJson, rasterData, isMobile, siteViewPort, selectedMode } =

--- a/src/features/projects/components/maps/VegetationChange.tsx
+++ b/src/features/projects/components/maps/VegetationChange.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import { Layer, Source } from 'react-map-gl';
 
 interface Props {

--- a/src/features/projects/components/maps/ZoomButtons.tsx
+++ b/src/features/projects/components/maps/ZoomButtons.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import MinusIcon from '../../../../../public/assets/images/icons/MinusIcon';
 import PlusIcon from '../../../../../public/assets/images/icons/PlusIcon';
 import styles from '../../styles/ZoomButtons.module.scss';

--- a/src/features/projects/components/projectDetails/ImageSlider.tsx
+++ b/src/features/projects/components/projectDetails/ImageSlider.tsx
@@ -1,8 +1,9 @@
+import type { Story } from 'react-insta-stories/dist/interfaces';
+
 import { useState, useEffect } from 'react';
 import Stories from 'react-insta-stories';
 import getImageUrl from '../../../../utils/getImageURL';
 import styles from './../../styles/ProjectDetails.module.scss';
-import { Story } from 'react-insta-stories/dist/interfaces';
 
 export type SliderImage = {
   image?: string;

--- a/src/features/projects/components/projectDetails/ProjectContactDetails.tsx
+++ b/src/features/projects/components/projectDetails/ProjectContactDetails.tsx
@@ -1,16 +1,18 @@
+import type { ReactElement } from 'react';
+import type {
+  ConservationProjectExtended,
+  TreeProjectExtended,
+} from '@planet-sdk/common';
+
 import Link from 'next/link';
-import React, { ReactElement } from 'react';
+import { ParamsContext } from '../../../common/Layout/QueryParamsContext';
+import React from 'react';
 import styles from './../../styles/ProjectDetails.module.scss';
 import { useTranslations } from 'next-intl';
 import BlackTree from '../../../../../public/assets/images/icons/project/BlackTree';
 import Email from '../../../../../public/assets/images/icons/project/Email';
 import Location from '../../../../../public/assets/images/icons/project/Location';
 import WorldWeb from '../../../../../public/assets/images/icons/project/WorldWeb';
-import { ParamsContext } from '../../../common/Layout/QueryParamsContext';
-import {
-  ConservationProjectExtended,
-  TreeProjectExtended,
-} from '@planet-sdk/common';
 
 interface Props {
   project: TreeProjectExtended | ConservationProjectExtended;

--- a/src/features/projects/components/projectDetails/ProjectInfo.tsx
+++ b/src/features/projects/components/projectDetails/ProjectInfo.tsx
@@ -1,14 +1,16 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type {
+  ConservationProjectExtended,
+  TreeProjectExtended,
+} from '@planet-sdk/common/build/types/project/extended';
+
+import React from 'react';
 import styles from './../../styles/ProjectDetails.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
 import { getPDFFile } from '../../../../utils/getImageURL';
 import getFormatedCurrency from '../../../../utils/countryCurrency/getFormattedCurrency';
 import formatDate from '../../../../utils/countryCurrency/getFormattedDate';
 import InfoIcon from '../../../../../public/assets/images/icons/manageProjects/Info';
-import {
-  ConservationProjectExtended,
-  TreeProjectExtended,
-} from '@planet-sdk/common/build/types/project/extended';
 
 interface Props {
   project: TreeProjectExtended | ConservationProjectExtended;

--- a/src/features/projects/components/projectDetails/TopProjectReports.tsx
+++ b/src/features/projects/components/projectDetails/TopProjectReports.tsx
@@ -1,3 +1,5 @@
+import type { Review } from '@planet-sdk/common/build/types/project/common';
+
 import React from 'react';
 import styles from './../../styles/ProjectDetails.module.scss';
 import VerifiedIcon from '@mui/icons-material/Verified';
@@ -6,7 +8,6 @@ import parse from 'date-fns/parse';
 import format from 'date-fns/format';
 import { localeMapForDate } from '../../../../utils/language/getLanguageName';
 import { useTranslations } from 'next-intl';
-import { Review } from '@planet-sdk/common/build/types/project/common';
 
 interface Props {
   projectReviews: Review[] | undefined;

--- a/src/features/projects/components/projects/Filters.tsx
+++ b/src/features/projects/components/projects/Filters.tsx
@@ -1,10 +1,12 @@
-import React, { ReactElement, useEffect } from 'react';
+import type { ReactElement } from 'react';
+import type { TreeProjectClassification } from '@planet-sdk/common/build/types/project/common';
+
+import React, { useEffect } from 'react';
 import styles from '../../styles/Filters.module.scss';
 import { useTranslations } from 'next-intl';
 import { FormControlLabel, FormGroup } from '@mui/material';
 import Switch from '../../../common/InputTypes/ToggleSwitch';
 import { useProjectProps } from '../../../common/Layout/ProjectPropsContext';
-import { TreeProjectClassification } from '@planet-sdk/common/build/types/project/common';
 import { useTenant } from '../../../common/Layout/TenantContext';
 import { useRouter } from 'next/router';
 

--- a/src/features/projects/components/projects/Header.tsx
+++ b/src/features/projects/components/projects/Header.tsx
@@ -1,8 +1,10 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { SetState } from '../../../common/types/common';
+import type { MapProject } from '../../../common/types/ProjectPropsContextInterface';
+
+import React from 'react';
 import SearchIcon from '../../../../../public/assets/images/icons/SearchIcon';
 import { useTranslations } from 'next-intl';
-import { SetState } from '../../../common/types/common';
-import { MapProject } from '../../../common/types/ProjectPropsContextInterface';
 
 interface Props {
   showTopProjectsList: boolean;

--- a/src/features/projects/components/projects/SearchBar.tsx
+++ b/src/features/projects/components/projects/SearchBar.tsx
@@ -1,4 +1,6 @@
-import React, { RefObject } from 'react';
+import type { RefObject } from 'react';
+
+import React from 'react';
 import { useTranslations } from 'next-intl';
 import CancelIcon from '../../../../../public/assets/images/icons/CancelIcon';
 import SearchIcon from '../../../../../public/assets/images/icons/SearchIcon';

--- a/src/features/projects/screens/Projects.tsx
+++ b/src/features/projects/screens/Projects.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { SetState } from '../../common/types/common';
+import type { MapProject } from '../../common/types/ProjectPropsContextInterface';
+import type { APIError } from '@planet-sdk/common';
+import type { Tenant } from '@planet-sdk/common';
+
+import React from 'react';
 import dynamic from 'next/dynamic';
 import MuiButton from '../../common/InputTypes/MuiButton';
 import ProjectLoader from '../../common/ContentLoaders/Projects/ProjectLoader';
@@ -11,12 +17,9 @@ import { useDebouncedEffect } from '../../../utils/useDebouncedEffect';
 import Explore from '../components/maps/Explore';
 import { ParamsContext } from '../../common/Layout/QueryParamsContext';
 import { useUserProps } from '../../../../src/features/common/Layout/UserPropsContext';
-import { SetState } from '../../common/types/common';
-import { MapProject } from '../../common/types/ProjectPropsContextInterface';
 import { getRequest } from '../../../utils/apiRequests/api';
 import { ErrorHandlingContext } from '../../common/Layout/ErrorHandlingContext';
-import { handleError, APIError } from '@planet-sdk/common';
-import { Tenant } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../common/Layout/TenantContext';
 
 interface Props {

--- a/src/features/projects/screens/SingleProjectDetails.tsx
+++ b/src/features/projects/screens/SingleProjectDetails.tsx
@@ -1,8 +1,10 @@
+import type { ReactElement } from 'react';
+
 import Modal from '@mui/material/Modal';
 import MuiButton from '../../common/InputTypes/MuiButton';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
-import React, { ReactElement, useState, useContext } from 'react';
+import React, { useState, useContext } from 'react';
 import ReactPlayer from 'react-player/lazy';
 import ReadMoreReact from 'read-more-react';
 import BackButton from '../../../../public/assets/images/icons/BackButton';

--- a/src/features/projectsV2/ProjectSnippet/microComponents/TopProjectReports.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/TopProjectReports.tsx
@@ -1,3 +1,5 @@
+import type { Review } from '@planet-sdk/common/build/types/project/common';
+
 import React from 'react';
 import styles from '../styles/ProjectSnippet.module.scss';
 import VerifiedIcon from '@mui/icons-material/Verified';
@@ -6,7 +8,6 @@ import parse from 'date-fns/parse';
 import format from 'date-fns/format';
 import { localeMapForDate } from '../../../../utils/language/getLanguageName';
 import { useTranslations } from 'next-intl';
-import { Review } from '@planet-sdk/common/build/types/project/common';
 
 interface Props {
   projectReviews: Review[] | undefined;

--- a/src/features/user/Account/CancelModal.tsx
+++ b/src/features/user/Account/CancelModal.tsx
@@ -1,3 +1,6 @@
+import type { APIError } from '@planet-sdk/common';
+import type { Subscription } from '../../common/types/payments';
+
 import React from 'react';
 import { ThemeContext } from '../../../theme/themeContext';
 import styles from './AccountHistory.module.scss';
@@ -16,13 +19,11 @@ import {
   FormControlLabel,
   styled,
 } from '@mui/material';
-
 import { CalendarPicker } from '@mui/x-date-pickers/CalendarPicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import themeProperties from '../../../theme/themeProperties';
-import { handleError, APIError } from '@planet-sdk/common';
-import { Subscription } from '../../common/types/payments';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../common/Layout/TenantContext';
 
 const MuiCalendarPicker = styled(CalendarPicker<Date>)({

--- a/src/features/user/Account/EditModal.tsx
+++ b/src/features/user/Account/EditModal.tsx
@@ -1,3 +1,10 @@
+import type { SxProps } from '@mui/material';
+import type { APIError } from '@planet-sdk/common';
+import type {
+  ModifyDonations,
+  Subscription,
+} from '../../common/types/payments';
+
 import React from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import { putAuthenticatedRequest } from '../../../utils/apiRequests/api';
@@ -11,7 +18,6 @@ import {
   Fade,
   InputAdornment,
   Autocomplete,
-  SxProps,
 } from '@mui/material';
 import { localeMapForDate } from '../../../utils/language/getLanguageName';
 import { ThemeContext } from '../../../theme/themeContext';
@@ -22,8 +28,7 @@ import { MobileDatePicker as MuiDatePicker } from '@mui/x-date-pickers/MobileDat
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import themeProperties from '../../../theme/themeProperties';
-import { handleError, APIError } from '@planet-sdk/common';
-import { ModifyDonations, Subscription } from '../../common/types/payments';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../common/Layout/TenantContext';
 
 // interface EditDonationProps {

--- a/src/features/user/Account/PauseModal.tsx
+++ b/src/features/user/Account/PauseModal.tsx
@@ -1,3 +1,6 @@
+import type { APIError } from '@planet-sdk/common';
+import type { Subscription } from '../../common/types/payments';
+
 import React from 'react';
 import { ThemeContext } from '../../../theme/themeContext';
 import styles from './AccountHistory.module.scss';
@@ -20,8 +23,7 @@ import { CalendarPicker } from '@mui/x-date-pickers/CalendarPicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import themeProperties from '../../../theme/themeProperties';
-import { handleError, APIError } from '@planet-sdk/common';
-import { Subscription } from '../../common/types/payments';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../common/Layout/TenantContext';
 
 const MuiCalendarPicker = styled(CalendarPicker<Date>)({

--- a/src/features/user/Account/ReactivateModal.tsx
+++ b/src/features/user/Account/ReactivateModal.tsx
@@ -1,3 +1,6 @@
+import type { APIError } from '@planet-sdk/common';
+import type { Subscription } from '../../common/types/payments';
+
 import React from 'react';
 import { ThemeContext } from '../../../theme/themeContext';
 import styles from './AccountHistory.module.scss';
@@ -7,8 +10,7 @@ import { useUserProps } from '../../common/Layout/UserPropsContext';
 import Close from '../../../../public/assets/images/icons/headerIcons/Close';
 import { ErrorHandlingContext } from '../../common/Layout/ErrorHandlingContext';
 import { CircularProgress, Modal, Fade } from '@mui/material';
-import { handleError, APIError } from '@planet-sdk/common';
-import { Subscription } from '../../common/types/payments';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../common/Layout/TenantContext';
 
 interface ReactivateModalProps {

--- a/src/features/user/Account/Recurrency.tsx
+++ b/src/features/user/Account/Recurrency.tsx
@@ -1,4 +1,7 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { Subscription } from '../../common/types/payments';
+
+import React from 'react';
 import TransactionListLoader from '../../../../public/assets/images/icons/TransactionListLoader';
 import TransactionsNotFound from '../../../../public/assets/images/icons/TransactionsNotFound';
 import styles from './AccountHistory.module.scss';
@@ -7,7 +10,6 @@ import { PauseModal } from './PauseModal';
 import { CancelModal } from './CancelModal';
 import { ReactivateModal } from './ReactivateModal';
 import { EditModal } from './EditModal';
-import { Subscription } from '../../common/types/payments';
 
 interface Props {
   isDataLoading: boolean;

--- a/src/features/user/Account/RecurrentPayments.tsx
+++ b/src/features/user/Account/RecurrentPayments.tsx
@@ -1,7 +1,8 @@
+import type { Subscription } from '../../common/types/payments';
+
 import React from 'react';
 import DashboardView from '../../common/Layout/DashboardView';
 import Recurrency from './Recurrency';
-import { Subscription } from '../../common/types/payments';
 import { useTranslations } from 'next-intl';
 
 interface Props {

--- a/src/features/user/Account/components/DownloadCodes.tsx
+++ b/src/features/user/Account/components/DownloadCodes.tsx
@@ -1,10 +1,13 @@
-import React, { ReactElement, useState } from 'react';
+import type { ReactElement } from 'react';
+import type { APIError } from '@planet-sdk/common';
+
+import React, { useState } from 'react';
 import { getRequest } from '../../../../utils/apiRequests/api';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
 import { unparse } from 'papaparse';
 import styles from '../AccountHistory.module.scss';
 import { useTranslations } from 'next-intl';
-import { handleError, APIError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 interface DownloadCodesProps {

--- a/src/features/user/Account/components/RecurrencyRecord.tsx
+++ b/src/features/user/Account/components/RecurrencyRecord.tsx
@@ -1,4 +1,10 @@
-import React, { Dispatch, ReactElement, SetStateAction, useMemo } from 'react';
+import type { Dispatch, ReactElement, SetStateAction } from 'react';
+import type {
+  MultipleDestinations,
+  Subscription,
+} from '../../../common/types/payments';
+import React, { useMemo } from 'react';
+
 import styles from '../AccountHistory.module.scss';
 import getFormatedCurrency from '../../../../utils/countryCurrency/getFormattedCurrency';
 import formatDate from '../../../../utils/countryCurrency/getFormattedDate';
@@ -6,10 +12,6 @@ import { useLocale, useTranslations } from 'next-intl';
 import TransferDetails from './TransferDetails';
 import themeProperties from '../../../../theme/themeProperties';
 import BackButton from '../../../../../public/assets/images/icons/BackButton';
-import {
-  MultipleDestinations,
-  Subscription,
-} from '../../../common/types/payments';
 
 interface HeaderProps {
   record: Subscription;

--- a/src/features/user/Account/components/TransferDetails.tsx
+++ b/src/features/user/Account/components/TransferDetails.tsx
@@ -1,7 +1,8 @@
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { BankAccount } from '../../../common/types/payments';
+
 import { useTranslations } from 'next-intl';
 import styles from '../AccountHistory.module.scss';
-import { BankAccount } from '../../../common/types/payments';
 
 interface TransferDetailsProps {
   account: BankAccount;

--- a/src/features/user/BulkCodes/components/BulkCodesError.tsx
+++ b/src/features/user/BulkCodes/components/BulkCodesError.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import { useTranslations } from 'next-intl';
 import { styled } from '@mui/material';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';

--- a/src/features/user/BulkCodes/components/GenericCodesPartial.tsx
+++ b/src/features/user/BulkCodes/components/GenericCodesPartial.tsx
@@ -1,7 +1,9 @@
+import type { ReactElement, FocusEvent } from 'react';
+import type { SetState } from '../../../common/Layout/BulkCodeContext';
+
 import { TextField } from '@mui/material';
-import { ReactElement, useState, FocusEvent } from 'react';
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { SetState } from '../../../common/Layout/BulkCodeContext';
 import { BulkCodeLimits } from '../../../../utils/constants/bulkCodeConstants';
 import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDisplayGroup';
 

--- a/src/features/user/BulkCodes/components/RecipientHeader.tsx
+++ b/src/features/user/BulkCodes/components/RecipientHeader.tsx
@@ -1,7 +1,8 @@
+import type { TableHeader } from '../BulkCodesTypes';
+
 import TableCell from '@mui/material/TableCell';
 import Tooltip from '@mui/material/Tooltip';
 import InfoIcon from '../../../../../public/assets/images/icons/InfoIcon';
-import { TableHeader } from '../BulkCodesTypes';
 import styles from '../BulkCodes.module.scss';
 
 interface Props {

--- a/src/features/user/BulkCodes/components/SelectorOption.tsx
+++ b/src/features/user/BulkCodes/components/SelectorOption.tsx
@@ -1,6 +1,8 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { BulkCodeMethods } from '../../../../utils/constants/bulkCodeConstants';
+
+import React from 'react';
 import { styled } from '@mui/material';
-import { BulkCodeMethods } from '../../../../utils/constants/bulkCodeConstants';
 
 export interface SelectorOptionProps {
   method: BulkCodeMethods.GENERIC | BulkCodeMethods.IMPORT;

--- a/src/features/user/BulkCodes/components/UpdateRecipient.tsx
+++ b/src/features/user/BulkCodes/components/UpdateRecipient.tsx
@@ -1,8 +1,9 @@
+import type { Recipient } from '../BulkCodesTypes';
+
 import { TableRow, TableCell, IconButton } from '@mui/material';
 import { useForm } from 'react-hook-form';
 // import { DevTool } from '@hookform/devtools';
 import themeProperties from '../../../../theme/themeProperties';
-import { Recipient } from '../BulkCodesTypes';
 import AcceptIcon from '../../../../../public/assets/images/icons/AcceptIcon';
 import RejectIcon from '../../../../../public/assets/images/icons/RejectIcon';
 import RecipientFormFields from './RecipientFormFields';

--- a/src/features/user/BulkCodes/components/UploadWidget.tsx
+++ b/src/features/user/BulkCodes/components/UploadWidget.tsx
@@ -1,10 +1,13 @@
-import { ReactElement, useCallback, useEffect, useState } from 'react';
-import { useDropzone, ErrorCode, FileRejection } from 'react-dropzone';
+import type { ReactElement } from 'react';
+import type { FileRejection } from 'react-dropzone';
+import type { FileImportError, UploadStates } from '../BulkCodesTypes';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useDropzone, ErrorCode } from 'react-dropzone';
 import { useTranslations } from 'next-intl';
 import FileUploadIcon from '../../../../../public/assets/images/icons/FileUploadIcon';
 import FileProcessingIcon from '../../../../../public/assets/images/icons/FileProcessingIcon';
 import FileAttachedIcon from '../../../../../public/assets/images/icons/FileAttachedIcon';
-import { FileImportError, UploadStates } from '../BulkCodesTypes';
 import styles from '../BulkCodes.module.scss';
 import handleFileUpload from '../../../../utils/handleFileUpload';
 

--- a/src/features/user/BulkCodes/stories/BulkGiftTotal.stories.tsx
+++ b/src/features/user/BulkCodes/stories/BulkGiftTotal.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 
 import BulkGiftTotal from '../components/BulkGiftTotal';
 

--- a/src/features/user/BulkCodes/stories/SelectorOption.stories.tsx
+++ b/src/features/user/BulkCodes/stories/SelectorOption.stories.tsx
@@ -1,4 +1,5 @@
-import { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
+
 import SelectorOption from '../components/SelectorOption';
 import { BulkCodeMethods } from '../../../../utils/constants/bulkCodeConstants';
 

--- a/src/features/user/BulkCodes/stories/UnitCostDisplay.stories.tsx
+++ b/src/features/user/BulkCodes/stories/UnitCostDisplay.stories.tsx
@@ -1,4 +1,5 @@
-import { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
+
 import UnitCostDisplay from '../components/UnitCostDisplay';
 
 const meta: Meta<typeof UnitCostDisplay> = {

--- a/src/features/user/BulkCodes/stories/UploadWidget.stories.tsx
+++ b/src/features/user/BulkCodes/stories/UploadWidget.stories.tsx
@@ -1,4 +1,5 @@
-import { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
+
 import UploadWidget from '../components/UploadWidget';
 
 const meta: Meta<typeof UploadWidget> = {

--- a/src/features/user/CompleteSignup/index.tsx
+++ b/src/features/user/CompleteSignup/index.tsx
@@ -1,4 +1,19 @@
-import React, { ReactElement, useState } from 'react';
+import type { ReactElement } from 'react';
+import type { AlertColor } from '@mui/material';
+import type {
+  AddressSuggestionsType,
+  AddressType,
+} from '../../common/types/geocoder';
+import type { ExtendedCountryCode } from '../../common/types/country';
+import type {
+  APIError,
+  User,
+  UserType,
+  CreateUserRequest,
+  CountryCode,
+} from '@planet-sdk/common';
+
+import React, { useState } from 'react';
 import { useRouter } from 'next/router';
 import styles from '../../../../src/features/user/CompleteSignup/CompleteSignup.module.scss';
 import ToggleSwitch from '../../common/InputTypes/ToggleSwitch';
@@ -8,7 +23,6 @@ import {
   MenuItem,
   styled,
   TextField,
-  AlertColor,
 } from '@mui/material';
 import AutoCompleteCountry from '../../common/InputTypes/AutoCompleteCountry';
 import COUNTRY_ADDRESS_POSTALS from '../../../utils/countryZipCode';
@@ -24,19 +38,7 @@ import { postRequest } from '../../../utils/apiRequests/api';
 import { ErrorHandlingContext } from '../../common/Layout/ErrorHandlingContext';
 import { useLocale, useTranslations } from 'next-intl';
 import InlineFormDisplayGroup from '../../common/Layout/Forms/InlineFormDisplayGroup';
-import {
-  handleError,
-  APIError,
-  User,
-  UserType,
-  CreateUserRequest,
-  CountryCode,
-} from '@planet-sdk/common';
-import {
-  AddressSuggestionsType,
-  AddressType,
-} from '../../common/types/geocoder';
-import { ExtendedCountryCode } from '../../common/types/country';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../common/Layout/TenantContext';
 
 const Alert = styled(MuiAlert)(({ theme }) => {

--- a/src/features/user/GiftFunds/GiftFundDetails.tsx
+++ b/src/features/user/GiftFunds/GiftFundDetails.tsx
@@ -1,8 +1,10 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { GiftFund } from '@planet-sdk/common';
+
+import React from 'react';
 import { useUserProps } from '../../common/Layout/UserPropsContext';
 import { useTranslations } from 'next-intl';
 import { Divider, Grid, styled } from '@mui/material';
-import { GiftFund } from '@planet-sdk/common';
 
 interface Props {
   giftFund: GiftFund;

--- a/src/features/user/GiftFunds/index.tsx
+++ b/src/features/user/GiftFunds/index.tsx
@@ -1,3 +1,5 @@
+import type { GiftFund } from '@planet-sdk/common/build/types/user';
+
 import React, { useEffect, useState } from 'react';
 import DashboardView from '../../common/Layout/DashboardView';
 import GiftFundDetails from './GiftFundDetails';
@@ -5,7 +7,6 @@ import { useTranslations } from 'next-intl';
 import { useUserProps } from '../../common/Layout/UserPropsContext';
 import { useRouter } from 'next/router';
 import SingleColumnView from '../../common/Layout/SingleColumnView';
-import { GiftFund } from '@planet-sdk/common/build/types/user';
 
 const GiftFunds = () => {
   const t = useTranslations('Giftfunds');

--- a/src/features/user/ManagePayouts/components/BankAccountDetails.tsx
+++ b/src/features/user/ManagePayouts/components/BankAccountDetails.tsx
@@ -1,9 +1,10 @@
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { BankAccount } from '../../../common/types/payouts';
+
 import { styled, Grid, Button, Divider } from '@mui/material';
 import getFormatedCurrency from '../../../../utils/countryCurrency/getFormattedCurrency';
 import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
-import { BankAccount } from '../../../common/types/payouts';
 
 // TODOO - See if something can be made common between accounts of Manage Accounts and Planet Cash
 const AccountDetailsGrid = styled('article')(({ theme }) => ({

--- a/src/features/user/ManagePayouts/components/BankDetailsForm.tsx
+++ b/src/features/user/ManagePayouts/components/BankDetailsForm.tsx
@@ -1,4 +1,7 @@
-import { ChangeEvent, ReactElement, useCallback } from 'react';
+import type { ChangeEvent, ReactElement } from 'react';
+import type { BankAccount } from '../../../common/types/payouts';
+
+import { useCallback } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { Button, TextField, MenuItem, CircularProgress } from '@mui/material';
 import StyledForm from '../../../common/Layout/StyledForm';
@@ -6,7 +9,6 @@ import ReactHookFormSelect from '../../../common/InputTypes/ReactHookFormSelect'
 import { PayoutCurrency } from '../../../../utils/constants/payoutConstants';
 import { useTranslations } from 'next-intl';
 import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDisplayGroup';
-import { BankAccount } from '../../../common/types/payouts';
 import AutoCompleteCountry from '../../../common/InputTypes/AutoCompleteCountry';
 import { getStoredConfig } from '../../../../utils/storeConfig';
 

--- a/src/features/user/ManagePayouts/components/NoBankAccount.tsx
+++ b/src/features/user/ManagePayouts/components/NoBankAccount.tsx
@@ -1,4 +1,5 @@
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
 import { Button } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';

--- a/src/features/user/ManagePayouts/index.tsx
+++ b/src/features/user/ManagePayouts/index.tsx
@@ -1,14 +1,11 @@
-import {
-  ReactElement,
-  useState,
-  useEffect,
-  useContext,
-  useCallback,
-} from 'react';
+import type { ReactElement } from 'react';
+import { useState, useEffect, useContext, useCallback } from 'react';
+import type { TabItem } from '../../common/Layout/TabbedView/TabbedViewTypes';
+import type { APIError } from '@planet-sdk/common';
+import type { BankAccount, PayoutMinAmounts } from '../../common/types/payouts';
 import { useLocale, useTranslations } from 'next-intl';
 import DashboardView from '../../common/Layout/DashboardView';
 import TabbedView from '../../common/Layout/TabbedView';
-import { TabItem } from '../../common/Layout/TabbedView/TabbedViewTypes';
 import {
   getAuthenticatedRequest,
   getRequest,
@@ -21,8 +18,7 @@ import Overview from './screens/Overview';
 import EditBankAccount from './screens/EditBankAccount';
 import AddBankAccount from './screens/AddBankAccount';
 import { useRouter } from 'next/router';
-import { handleError, APIError } from '@planet-sdk/common';
-import { BankAccount, PayoutMinAmounts } from '../../common/types/payouts';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../common/Layout/TenantContext';
 
 export enum ManagePayoutTabs {

--- a/src/features/user/ManagePayouts/screens/AddBankAccount.tsx
+++ b/src/features/user/ManagePayouts/screens/AddBankAccount.tsx
@@ -1,16 +1,20 @@
-import { ReactElement, useContext, useState } from 'react';
+import type { ReactElement } from 'react';
+import type { FormData } from '../components/BankDetailsForm';
+import type { APIError, SerializedError } from '@planet-sdk/common';
+import type { BankAccount } from '../../../common/types/payouts';
+
+import { useContext, useState } from 'react';
 import { postAuthenticatedRequest } from '../../../../utils/apiRequests/api';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
 import { usePayouts } from '../../../common/Layout/PayoutsContext';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 import { useRouter } from 'next/router';
 import { useTranslations } from 'next-intl';
-import BankDetailsForm, { FormData } from '../components/BankDetailsForm';
+import BankDetailsForm from '../components/BankDetailsForm';
 import CustomSnackbar from '../../../common/CustomSnackbar';
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
 import { PayoutCurrency } from '../../../../utils/constants/payoutConstants';
-import { handleError, APIError, SerializedError } from '@planet-sdk/common';
-import { BankAccount } from '../../../common/types/payouts';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 const AddBankAccount = (): ReactElement | null => {

--- a/src/features/user/ManagePayouts/screens/EditBankAccount.tsx
+++ b/src/features/user/ManagePayouts/screens/EditBankAccount.tsx
@@ -1,19 +1,23 @@
-import { ReactElement, useContext, useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
+import type { FormData } from '../components/BankDetailsForm';
+import type { APIError, SerializedError } from '@planet-sdk/common';
+import type { BankAccount } from '../../../common/types/payouts';
+
+import { useContext, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { putAuthenticatedRequest } from '../../../../utils/apiRequests/api';
 import { usePayouts } from '../../../common/Layout/PayoutsContext';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
-import BankDetailsForm, { FormData } from '../components/BankDetailsForm';
+import BankDetailsForm from '../components/BankDetailsForm';
 import BackArrow from '../../../../../public/assets/images/icons/headerIcons/BackArrow';
 import CustomSnackbar from '../../../common/CustomSnackbar';
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
 import FormHeader from '../../../common/Layout/Forms/FormHeader';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 import { PayoutCurrency } from '../../../../utils/constants/payoutConstants';
-import { handleError, APIError, SerializedError } from '@planet-sdk/common';
-import { BankAccount } from '../../../common/types/payouts';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 const EditBankAccount = (): ReactElement | null => {

--- a/src/features/user/ManagePayouts/screens/Overview.tsx
+++ b/src/features/user/ManagePayouts/screens/Overview.tsx
@@ -1,4 +1,5 @@
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
 import BankAccountLoader from '../../../../../public/assets/images/icons/BankAccountLoader';
 import BankAccountDetails from '../components/BankAccountDetails';
 import NoBankAccount from '../components/NoBankAccount';

--- a/src/features/user/ManagePayouts/screens/PayoutScheduleForm.tsx
+++ b/src/features/user/ManagePayouts/screens/PayoutScheduleForm.tsx
@@ -1,4 +1,7 @@
-import { ReactElement, useContext, useState } from 'react';
+import type { ReactElement } from 'react';
+import type { APIError, User } from '@planet-sdk/common';
+
+import { useContext, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Button, MenuItem, CircularProgress } from '@mui/material';
 import ReactHookFormSelect from '../../../common/InputTypes/ReactHookFormSelect';
@@ -10,7 +13,7 @@ import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContex
 import { putAuthenticatedRequest } from '../../../../utils/apiRequests/api';
 import CustomSnackbar from '../../../common/CustomSnackbar';
 import { PaymentFrequencies } from '../../../../utils/constants/payoutConstants';
-import { handleError, APIError, User } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 const paymentFrequencies = [

--- a/src/features/user/ManageProjects/ProjectsContainer.tsx
+++ b/src/features/user/ManageProjects/ProjectsContainer.tsx
@@ -1,3 +1,7 @@
+import type { APIError } from '@planet-sdk/common';
+import type { Properties } from '../../common/types/project';
+import type { Geometry } from '@turf/turf';
+
 import Link from 'next/link';
 import React from 'react';
 import LazyLoad from 'react-lazyload';
@@ -10,9 +14,7 @@ import { useUserProps } from '../../common/Layout/UserPropsContext';
 import styles from './ProjectsContainer.module.scss';
 import GlobeContentLoader from '../../../../src/features/common/ContentLoaders/Projects/GlobeLoader';
 import { useLocale, useTranslations } from 'next-intl';
-import { handleError, APIError } from '@planet-sdk/common';
-import { Properties } from '../../common/types/project';
-import { Geometry } from '@turf/turf';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../common/Layout/TenantContext';
 import DashboardView from '../../common/Layout/DashboardView';
 import SingleColumnView from '../../common/Layout/SingleColumnView';

--- a/src/features/user/ManageProjects/components/BasicDetails.tsx
+++ b/src/features/user/ManageProjects/components/BasicDetails.tsx
@@ -1,11 +1,14 @@
-import React, {
-  ChangeEvent,
-  ReactElement,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import type { ChangeEvent, ReactElement } from 'react';
+import type { APIError } from '@planet-sdk/common';
+import type {
+  BasicDetailsProps,
+  ProfileProjectConservation,
+  ProfileProjectTrees,
+  ViewPort,
+} from '../../../common/types/project';
+import type { ReverseAddress } from '../../../common/types/geocoder';
+
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { Button, FormControlLabel, Switch, Tooltip } from '@mui/material';
 import { useLocale, useTranslations } from 'next-intl';
@@ -35,16 +38,9 @@ import GeocoderArcGIS from 'geocoder-arcgis';
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
 import StyledForm from '../../../common/Layout/StyledForm';
 import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDisplayGroup';
-import { handleError, APIError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 import { ProjectCreationTabs } from '..';
-import {
-  BasicDetailsProps,
-  ProfileProjectConservation,
-  ProfileProjectTrees,
-  ViewPort,
-} from '../../../common/types/project';
-import { ReverseAddress } from '../../../common/types/geocoder';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 type FormData = {

--- a/src/features/user/ManageProjects/components/DetailedAnalysis.tsx
+++ b/src/features/user/ManageProjects/components/DetailedAnalysis.tsx
@@ -1,4 +1,16 @@
-import React, { ReactElement, useEffect } from 'react';
+import type { ReactElement } from 'react';
+import type { SxProps } from '@mui/material';
+import type { APIError, InterventionTypes } from '@planet-sdk/common';
+import type {
+  DetailedAnalysisProps,
+  SiteOwners,
+  PlantingSeason,
+  ProfileProjectTrees,
+  ProfileProjectConservation,
+  InterventionOption,
+} from '../../../common/types/project';
+
+import React, { useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
 import styles from './../StepForm.module.scss';
@@ -8,10 +20,10 @@ import InfoIcon from '../../../../../public/assets/images/icons/manageProjects/I
 import { putAuthenticatedRequest } from '../../../../utils/apiRequests/api';
 import { localeMapForDate } from '../../../../utils/language/getLanguageName';
 import { useRouter } from 'next/router';
-import { SxProps, TextField, Button, Tooltip } from '@mui/material';
+import { handleError } from '@planet-sdk/common';
+import { TextField, Button, Tooltip } from '@mui/material';
 import themeProperties from '../../../../theme/themeProperties';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
-import { handleError, APIError, InterventionTypes } from '@planet-sdk/common';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 import { MobileDatePicker as MuiDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -20,14 +32,6 @@ import { ProjectCreationTabs } from '..';
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
 import StyledForm from '../../../common/Layout/StyledForm';
 import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDisplayGroup';
-import {
-  DetailedAnalysisProps,
-  SiteOwners,
-  PlantingSeason,
-  ProfileProjectTrees,
-  ProfileProjectConservation,
-  InterventionOption,
-} from '../../../common/types/project';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 const dialogSx: SxProps = {

--- a/src/features/user/ManageProjects/components/MapComponent.tsx
+++ b/src/features/user/ManageProjects/components/MapComponent.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import * as turf from '@turf/turf';
 import ReactMapboxGl, { ZoomControl, Source, Layer } from 'react-mapbox-gl';
 import DrawControl from 'react-mapbox-gl-draw';

--- a/src/features/user/ManageProjects/components/ProjectCertificates.tsx
+++ b/src/features/user/ManageProjects/components/ProjectCertificates.tsx
@@ -1,4 +1,12 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { APIError, Certificate } from '@planet-sdk/common';
+import type {
+  CertificateScopeProjects,
+  ProjectCertificatesProps,
+} from '../../../common/types/project';
+import type { SxProps } from '@mui/material';
+
+import React from 'react';
 import styles from './../StepForm.module.scss';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
@@ -16,20 +24,10 @@ import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContex
 import { MobileDatePicker as MuiDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import {
-  SxProps,
-  TextField,
-  Button,
-  FormControlLabel,
-  Switch,
-} from '@mui/material';
+import { TextField, Button, FormControlLabel, Switch } from '@mui/material';
 import themeProperties from '../../../../theme/themeProperties';
-import { handleError, APIError, Certificate } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
-import {
-  CertificateScopeProjects,
-  ProjectCertificatesProps,
-} from '../../../common/types/project';
 import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDisplayGroup';
 import { useTenant } from '../../../common/Layout/TenantContext';
 

--- a/src/features/user/ManageProjects/components/ProjectMedia.tsx
+++ b/src/features/user/ManageProjects/components/ProjectMedia.tsx
@@ -1,11 +1,14 @@
-import React, {
-  ReactElement,
-  useCallback,
-  useEffect,
-  FocusEvent,
-  useContext,
-  useState,
-} from 'react';
+import type { APIError } from '@planet-sdk/common';
+import type {
+  ProjectMediaProps,
+  UploadImage,
+  ProfileProjectTrees,
+  ProfileProjectConservation,
+  ImagesScopeProjects,
+} from '../../../common/types/project';
+import type { ReactElement, FocusEvent } from 'react';
+
+import React, { useCallback, useEffect, useContext, useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useDropzone } from 'react-dropzone';
 import styles from '../StepForm.module.scss';
@@ -25,16 +28,9 @@ import { useTranslations } from 'next-intl';
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
 import StyledForm from '../../../common/Layout/StyledForm';
 import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDisplayGroup';
-import { handleError, APIError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 import { ProjectCreationTabs } from '..';
-import {
-  ProjectMediaProps,
-  UploadImage,
-  ProfileProjectTrees,
-  ProfileProjectConservation,
-  ImagesScopeProjects,
-} from '../../../common/types/project';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 export default function ProjectMedia({

--- a/src/features/user/ManageProjects/components/ProjectSelection.tsx
+++ b/src/features/user/ManageProjects/components/ProjectSelection.tsx
@@ -1,8 +1,10 @@
+import type { ReactElement } from 'react';
+import type { SetState } from '../../../common/types/common';
+
 import { useRouter } from 'next/router';
-import React, { ReactElement } from 'react';
+import React from 'react';
 import { useTranslations } from 'next-intl';
 import Styles from '../../../../../src/features/user/ManageProjects/StepForm.module.scss';
-import { SetState } from '../../../common/types/common';
 
 interface ProjectSelectionProps {
   setTabSelected: SetState<number>;

--- a/src/features/user/ManageProjects/components/ProjectSites.tsx
+++ b/src/features/user/ManageProjects/components/ProjectSites.tsx
@@ -1,4 +1,16 @@
-import React, { ChangeEvent, ReactElement } from 'react';
+import type { ChangeEvent, ReactElement } from 'react';
+import type { APIError } from '@planet-sdk/common';
+import type {
+  SiteDetails,
+  ProjectSitesProps,
+  GeoLocation,
+  EditSiteProps,
+  Site,
+  SitesScopeProjects,
+} from '../../../common/types/project';
+import type { FeatureCollection as GeoJson } from 'geojson';
+
+import React from 'react';
 import styles from './../StepForm.module.scss';
 import { Controller, useForm } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
@@ -28,18 +40,9 @@ import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContex
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
 import StyledForm from '../../../common/Layout/StyledForm';
 import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDisplayGroup';
-import { handleError, APIError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 import { ProjectCreationTabs } from '..';
-import {
-  SiteDetails,
-  ProjectSitesProps,
-  GeoLocation,
-  EditSiteProps,
-  Site,
-  SitesScopeProjects,
-} from '../../../common/types/project';
-import { FeatureCollection as GeoJson } from 'geojson';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 const MapStatic = ReactMapboxGl({

--- a/src/features/user/ManageProjects/components/ProjectSpending.tsx
+++ b/src/features/user/ManageProjects/components/ProjectSpending.tsx
@@ -1,4 +1,12 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { SxProps } from '@mui/material';
+import type { APIError, ProjectExpense } from '@planet-sdk/common';
+import type {
+  ProjectSpendingProps,
+  ExpensesScopeProjects,
+} from '../../../common/types/project';
+
+import React from 'react';
 import styles from './../StepForm.module.scss';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
@@ -17,18 +25,14 @@ import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContex
 import { MobileDatePicker as MuiDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { SxProps, Button, TextField, IconButton } from '@mui/material';
+import { Button, TextField, IconButton } from '@mui/material';
 import themeProperties from '../../../../theme/themeProperties';
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
 import StyledForm from '../../../common/Layout/StyledForm';
 import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDisplayGroup';
-import { handleError, APIError, ProjectExpense } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { ProjectCreationTabs } from '..';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
-import {
-  ProjectSpendingProps,
-  ExpensesScopeProjects,
-} from '../../../common/types/project';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 const yearDialogSx: SxProps = {

--- a/src/features/user/ManageProjects/components/SubmitForReview.tsx
+++ b/src/features/user/ManageProjects/components/SubmitForReview.tsx
@@ -1,4 +1,7 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { SubmitForReviewProps } from '../../../common/types/project';
+
+import React from 'react';
 import BackArrow from '../../../../../public/assets/images/icons/headerIcons/BackArrow';
 import styles from './../StepForm.module.scss';
 import SubmitForReviewImage from '../../../../../public/assets/images/icons/manageProjects/SubmitForReviewImage';
@@ -8,7 +11,6 @@ import NotReviewed from '../../../../../public/assets/images/icons/manageProject
 import router from 'next/router';
 import { Button, FormControlLabel, Switch } from '@mui/material';
 import { ProjectCreationTabs } from '..';
-import { SubmitForReviewProps } from '../../../common/types/project';
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
 
 function SubmitForReview({

--- a/src/features/user/ManageProjects/index.tsx
+++ b/src/features/user/ManageProjects/index.tsx
@@ -1,3 +1,11 @@
+import type { TabItem } from '../../common/Layout/TabbedView/TabbedViewTypes';
+import type { APIError } from '@planet-sdk/common';
+import type {
+  ManageProjectsProps,
+  ProfileProjectTrees,
+  ProfileProjectConservation,
+} from '../../common/types/project';
+
 import React from 'react';
 import BasicDetails from './components/BasicDetails';
 import ProjectMedia from './components/ProjectMedia';
@@ -15,14 +23,8 @@ import { useRouter } from 'next/router';
 import { useLocale, useTranslations } from 'next-intl';
 import { ErrorHandlingContext } from '../../common/Layout/ErrorHandlingContext';
 import TabbedView from '../../common/Layout/TabbedView';
-import { TabItem } from '../../common/Layout/TabbedView/TabbedViewTypes';
-import { handleError, APIError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import DashboardView from '../../common/Layout/DashboardView';
-import {
-  ManageProjectsProps,
-  ProfileProjectTrees,
-  ProfileProjectConservation,
-} from '../../common/types/project';
 import { useTenant } from '../../common/Layout/TenantContext';
 
 export enum ProjectCreationTabs {

--- a/src/features/user/PlanetCash/components/AccountDetails.tsx
+++ b/src/features/user/PlanetCash/components/AccountDetails.tsx
@@ -1,10 +1,11 @@
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { PlanetCashAccount } from '../../../common/types/planetcash';
+
 import { styled, Grid, Button, Divider } from '@mui/material';
 import { useLocale, useTranslations } from 'next-intl';
 import getFormatedCurrency from '../../../../utils/countryCurrency/getFormattedCurrency';
 import { getDonationUrl } from '../../../../utils/getDonationUrl';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
-import { PlanetCashAccount } from '../../../common/types/planetcash';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 const AccountDetailsGrid = styled('article')(({ theme }) => ({

--- a/src/features/user/PlanetCash/components/CreateAccountForm.tsx
+++ b/src/features/user/PlanetCash/components/CreateAccountForm.tsx
@@ -1,4 +1,12 @@
-import { ReactElement, useState, useContext, FormEvent } from 'react';
+import type { ReactElement, FormEvent } from 'react';
+import type {
+  CountryType,
+  ExtendedCountryCode,
+} from '../../../common/types/country';
+import { useRouter } from 'next/router';
+import type { APIError, SerializedError } from '@planet-sdk/common';
+
+import { useState, useContext } from 'react';
 import { Button, CircularProgress } from '@mui/material';
 import AutoCompleteCountry from '../../../common/InputTypes/AutoCompleteCountry';
 import CustomSnackbar from '../../../common/CustomSnackbar';
@@ -9,12 +17,7 @@ import { postAuthenticatedRequest } from '../../../../utils/apiRequests/api';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
 import { usePlanetCash } from '../../../common/Layout/PlanetCashContext';
-import {
-  CountryType,
-  ExtendedCountryCode,
-} from '../../../common/types/country';
-import { useRouter } from 'next/router';
-import { handleError, APIError, SerializedError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 interface Props {

--- a/src/features/user/PlanetCash/components/NoPlanetCashAccount.tsx
+++ b/src/features/user/PlanetCash/components/NoPlanetCashAccount.tsx
@@ -1,4 +1,5 @@
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
 import { useTranslations } from 'next-intl';
 import { Button } from '@mui/material';
 import { useRouter } from 'next/router';

--- a/src/features/user/PlanetCash/components/NoTransactionsFound.tsx
+++ b/src/features/user/PlanetCash/components/NoTransactionsFound.tsx
@@ -1,4 +1,5 @@
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
 import TransactionsNotFound from '../../../../../public/assets/images/icons/TransactionsNotFound';
 

--- a/src/features/user/PlanetCash/index.tsx
+++ b/src/features/user/PlanetCash/index.tsx
@@ -1,14 +1,11 @@
-import {
-  ReactElement,
-  useState,
-  useEffect,
-  useContext,
-  useCallback,
-} from 'react';
+import type { TabItem } from '../../common/Layout/TabbedView/TabbedViewTypes';
+import type { APIError } from '@planet-sdk/common';
+import type { PlanetCashAccount } from '../../common/types/planetcash';
+import type { ReactElement } from 'react';
+import { useState, useEffect, useContext, useCallback } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import DashboardView from '../../common/Layout/DashboardView';
 import TabbedView from '../../common/Layout/TabbedView';
-import { TabItem } from '../../common/Layout/TabbedView/TabbedViewTypes';
 import CreateAccount from './screens/CreateAccount';
 import Accounts from './screens/Accounts';
 import Transactions from './screens/Transactions';
@@ -17,9 +14,8 @@ import { useUserProps } from '../../common/Layout/UserPropsContext';
 import { ErrorHandlingContext } from '../../common/Layout/ErrorHandlingContext';
 import { usePlanetCash } from '../../common/Layout/PlanetCashContext';
 import { useRouter } from 'next/router';
-import { handleError, APIError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../common/Layout/TenantContext';
-import { PlanetCashAccount } from '../../common/types/planetcash';
 
 export enum PlanetCashTabs {
   ACCOUNTS = 'accounts',

--- a/src/features/user/PlanetCash/screens/Accounts.tsx
+++ b/src/features/user/PlanetCash/screens/Accounts.tsx
@@ -1,4 +1,5 @@
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
 import AccountListLoader from '../../../../../public/assets/images/icons/AccountListLoader';
 import AccountDetails from '../components/AccountDetails';
 import { usePlanetCash } from '../../../common/Layout/PlanetCashContext';

--- a/src/features/user/PlanetCash/screens/CreateAccount.tsx
+++ b/src/features/user/PlanetCash/screens/CreateAccount.tsx
@@ -1,8 +1,10 @@
-import { ReactElement, useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
+import type { CountryType } from '../../../common/types/country';
+
+import { useState, useEffect } from 'react';
 import CreateAccountForm from '../components/CreateAccountForm';
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
 import { usePlanetCash } from '../../../common/Layout/PlanetCashContext';
-import { CountryType } from '../../../common/types/country';
 import { useTranslations } from 'next-intl';
 import AccountListLoader from '../../../../../public/assets/images/icons/AccountListLoader';
 

--- a/src/features/user/PlanetCash/screens/Transactions.tsx
+++ b/src/features/user/PlanetCash/screens/Transactions.tsx
@@ -1,10 +1,7 @@
-import {
-  ReactElement,
-  useContext,
-  useState,
-  useEffect,
-  useCallback,
-} from 'react';
+import type { APIError } from '@planet-sdk/common';
+import type { PaymentHistory } from '../../../common/types/payments';
+import type { ReactElement } from 'react';
+import { useContext, useState, useEffect, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import AccountRecord from '../../Account/components/AccountRecord';
 import TransactionListLoader from '../../../../../public/assets/images/icons/TransactionListLoader';
@@ -14,8 +11,7 @@ import { getAuthenticatedRequest } from '../../../../utils/apiRequests/api';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
 import NoTransactionsFound from '../components/NoTransactionsFound';
-import { handleError, APIError } from '@planet-sdk/common';
-import { PaymentHistory } from '../../../common/types/payments';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 interface TransactionsProps {

--- a/src/features/user/Profile/CommunityContributions/ContributionListItem.tsx
+++ b/src/features/user/Profile/CommunityContributions/ContributionListItem.tsx
@@ -1,5 +1,6 @@
+import type { LeaderboardItem } from '../../../common/types/myForest';
+
 import { useTranslations } from 'next-intl';
-import { LeaderboardItem } from '../../../common/types/myForest';
 import styles from './communityContributions.module.scss';
 
 const ContributionListItem = ({

--- a/src/features/user/Profile/CommunityContributions/NoContributions.tsx
+++ b/src/features/user/Profile/CommunityContributions/NoContributions.tsx
@@ -1,9 +1,10 @@
+import type { ProfileV2Props } from '../../../common/types/profile';
+
 import { useTranslations } from 'next-intl';
 import {
   NoContributionsIcon,
   SupportUserIcon,
 } from '../../../../../public/assets/images/icons/ProfilePageV2Icons';
-import { ProfileV2Props } from '../../../common/types/profile';
 import WebappButton from '../../../common/WebappButton';
 import styles from './communityContributions.module.scss';
 

--- a/src/features/user/Profile/CommunityContributions/index.tsx
+++ b/src/features/user/Profile/CommunityContributions/index.tsx
@@ -1,10 +1,11 @@
+import type { ProfileV2Props } from '../../../common/types/profile';
+import type { LeaderboardItem } from '../../../common/types/myForest';
+
 import { useEffect, useState } from 'react';
 import styles from './communityContributions.module.scss';
 import NoContributions from './NoContributions';
-import { ProfileV2Props } from '../../../common/types/profile';
 import ContributionListItem from './ContributionListItem';
 import CustomTooltip from '../../../common/Layout/CustomTooltip';
-import { LeaderboardItem } from '../../../common/types/myForest';
 import { useTranslations } from 'next-intl';
 import { useMyForest } from '../../../common/Layout/MyForestContext';
 import CommunityContributionsIcon from '../../../../../public/assets/images/icons/CommunityContributionsIcon';

--- a/src/features/user/Profile/ContributionsMap/Common/ContributionStats.tsx
+++ b/src/features/user/Profile/ContributionsMap/Common/ContributionStats.tsx
@@ -1,10 +1,11 @@
+import type { JSX } from 'react';
+
 import {
   ProjectStatIcon,
   CountryStatIcon,
 } from '../../../../../../public/assets/images/icons/myForestMapIcons';
 import style from './common.module.scss';
 import { useTranslations } from 'next-intl';
-import { JSX } from 'react';
 import { useMyForest } from '../../../../common/Layout/MyForestContext';
 
 interface StatItemProps {

--- a/src/features/user/Profile/ContributionsMap/Markers/ClusterIcon.tsx
+++ b/src/features/user/Profile/ContributionsMap/Markers/ClusterIcon.tsx
@@ -1,4 +1,6 @@
-import { TreeProjectClassification } from '@planet-sdk/common';
+import type { TreeProjectClassification } from '@planet-sdk/common';
+import type { ProjectPurpose } from './ProjectTypeIcon';
+
 import {
   MangrovesClusterMarker,
   NaturalRegenerationClusterMarker,
@@ -9,7 +11,6 @@ import {
   ConservationClusterMarker,
   OtherPlantingClusterMarker,
 } from '../../../../../../public/assets/images/icons/myForestMapIcons/ClusterMarkerIcons';
-import { ProjectPurpose } from './ProjectTypeIcon';
 
 type ClusterIconProps = {
   classification: TreeProjectClassification | undefined | null;

--- a/src/features/user/Profile/ContributionsMap/Markers/DonationClusterMarker.tsx
+++ b/src/features/user/Profile/ContributionsMap/Markers/DonationClusterMarker.tsx
@@ -1,19 +1,22 @@
-import { Marker, ViewState } from 'react-map-gl-v7/maplibre';
-import { MutableRefObject, useEffect, useState } from 'react';
-import { PointFeature } from 'supercluster';
+import type { ViewState } from 'react-map-gl-v7/maplibre';
+import type {
+  DonationProperties,
+  DonationSuperclusterProperties,
+} from '../../../../common/types/myForest';
+import type { ProjectPurpose } from './ProjectTypeIcon';
+import type { MutableRefObject } from 'react';
+import type { PointFeature } from 'supercluster';
+import type { TreeProjectClassification, UnitTypes } from '@planet-sdk/common';
+
+import { Marker } from 'react-map-gl-v7/maplibre';
+import { useEffect, useState } from 'react';
 import { getClusterGeojson } from '../../../../../utils/superclusterConfig';
 import { useMyForest } from '../../../../common/Layout/MyForestContext';
 import ClusterIcon from './ClusterIcon';
-import { TreeProjectClassification, UnitTypes } from '@planet-sdk/common';
 import {
   getDonationClusterMarkerColors,
   extractAndClassifyProjectData,
 } from '../../../../../utils/myForestUtils';
-import {
-  DonationProperties,
-  DonationSuperclusterProperties,
-} from '../../../../common/types/myForest';
-import { ProjectPurpose } from './ProjectTypeIcon';
 import style from '../Common/common.module.scss';
 
 export interface DonationClusterMarkerProps {

--- a/src/features/user/Profile/ContributionsMap/Markers/PointMarkers.tsx
+++ b/src/features/user/Profile/ContributionsMap/Markers/PointMarkers.tsx
@@ -1,16 +1,17 @@
+import type { PointFeature } from 'supercluster';
+import type {
+  DonationProperties,
+  MyContributionsSingleRegistration,
+  ProfilePageType,
+} from '../../../../common/types/myForest';
+
 import { Marker } from 'react-map-gl-v7';
-import { PointFeature } from 'supercluster';
 import style from '../Common/common.module.scss';
 import ProjectTypeIcon from './ProjectTypeIcon';
 import { useState } from 'react';
 import { RegisteredTreeIcon } from '../../../../../../public/assets/images/icons/myForestMapIcons/PointMarkerIcons';
 import DonationPopup from '../Popup/DonationPopup';
 import RegisteredTreesPopup from '../Popup/RegisteredTreesPopup';
-import {
-  DonationProperties,
-  MyContributionsSingleRegistration,
-  ProfilePageType,
-} from '../../../../common/types/myForest';
 
 interface PointMarkersProps {
   superclusterResponse: PointFeature<

--- a/src/features/user/Profile/ContributionsMap/Markers/ProjectTypeIcon.tsx
+++ b/src/features/user/Profile/ContributionsMap/Markers/ProjectTypeIcon.tsx
@@ -1,5 +1,6 @@
+import type { TreeProjectClassification } from '@planet-sdk/common';
+
 import { useMemo } from 'react';
-import { TreeProjectClassification } from '@planet-sdk/common';
 import themeProperties from '../../../../../theme/themeProperties';
 import {
   NaturalRegeneration,

--- a/src/features/user/Profile/ContributionsMap/Markers/RegisteredTreeClusterMarker.tsx
+++ b/src/features/user/Profile/ContributionsMap/Markers/RegisteredTreeClusterMarker.tsx
@@ -1,6 +1,7 @@
+import type { ClusterProperties, PointFeature } from 'supercluster';
+
 import { Marker } from 'react-map-gl-v7';
 import { RegisteredTreeClusterMarkerIcon } from '../../../../../../public/assets/images/icons/myForestMapIcons/ClusterMarkerIcons';
-import { ClusterProperties, PointFeature } from 'supercluster';
 import style from '../Common/common.module.scss';
 
 type RegisteredTreeClusterMarkerProp = {

--- a/src/features/user/Profile/ContributionsMap/Markers/index.tsx
+++ b/src/features/user/Profile/ContributionsMap/Markers/index.tsx
@@ -1,20 +1,22 @@
-import { ClusterProperties, PointFeature } from 'supercluster';
-import { MutableRefObject, useEffect, useRef, useState } from 'react';
-import { getClusterGeojson } from '../../../../../utils/superclusterConfig';
-import DonationClusterMarker from './DonationClusterMarker';
-import PointMarkers from './PointMarkers';
-import RegisteredTreeClusterMarker from './RegisteredTreeClusterMarker';
-import { useMyForest } from '../../../../common/Layout/MyForestContext';
-import {
+import type { ClusterProperties, PointFeature } from 'supercluster';
+import type { MutableRefObject } from 'react';
+import type {
   DonationProperties,
   DonationSuperclusterProperties,
   MyContributionsSingleRegistration,
   ProfilePageType,
   RegistrationSuperclusterProperties,
 } from '../../../../common/types/myForest';
+import type { SetState } from '../../../../common/types/common';
+import type { ViewState } from 'react-map-gl-v7/maplibre';
+
+import { useEffect, useRef, useState } from 'react';
+import { getClusterGeojson } from '../../../../../utils/superclusterConfig';
+import DonationClusterMarker from './DonationClusterMarker';
+import PointMarkers from './PointMarkers';
+import RegisteredTreeClusterMarker from './RegisteredTreeClusterMarker';
+import { useMyForest } from '../../../../common/Layout/MyForestContext';
 import * as turf from '@turf/turf';
-import { SetState } from '../../../../common/types/common';
-import { ViewState } from 'react-map-gl-v7/maplibre';
 
 interface MarkersProps {
   mapRef: MutableRefObject<null>;

--- a/src/features/user/Profile/ContributionsMap/Popup/DonationPopup.tsx
+++ b/src/features/user/Profile/ContributionsMap/Popup/DonationPopup.tsx
@@ -1,13 +1,14 @@
-import { Popup } from 'react-map-gl-v7';
-import { PointFeature } from 'supercluster';
-import style from '../ContributionsMap.module.scss';
-import { SetState } from '../../../../common/types/common';
-import ProjectInfoSection from './ProjectInfoSection';
-import PopupImageSection from './PopupImageSection';
-import {
+import type { PointFeature } from 'supercluster';
+import type { SetState } from '../../../../common/types/common';
+import type {
   ProfilePageType,
   DonationProperties,
 } from '../../../../common/types/myForest';
+
+import { Popup } from 'react-map-gl-v7';
+import style from '../ContributionsMap.module.scss';
+import ProjectInfoSection from './ProjectInfoSection';
+import PopupImageSection from './PopupImageSection';
 
 interface DonationPopupProps {
   superclusterResponse: PointFeature<DonationProperties>;

--- a/src/features/user/Profile/ContributionsMap/Popup/PopupImageSection.tsx
+++ b/src/features/user/Profile/ContributionsMap/Popup/PopupImageSection.tsx
@@ -1,8 +1,9 @@
+import type { PointFeature } from 'supercluster';
+import type { DonationProperties } from '../../../../common/types/myForest';
+
 import { useTranslations } from 'next-intl';
 import getImageUrl from '../../../../../utils/getImageURL';
 import style from '../ContributionsMap.module.scss';
-import { PointFeature } from 'supercluster';
-import { DonationProperties } from '../../../../common/types/myForest';
 
 const PopupImageSection = ({
   superclusterResponse,

--- a/src/features/user/Profile/ContributionsMap/Popup/ProjectInfoSection.tsx
+++ b/src/features/user/Profile/ContributionsMap/Popup/ProjectInfoSection.tsx
@@ -1,12 +1,13 @@
-import { useTranslations } from 'next-intl';
-import style from '../ContributionsMap.module.scss';
-import { CountryCode } from '@planet-sdk/common';
-import DonateButton from '../../MyContributions/DonateButton';
-import { PointFeature } from 'supercluster';
-import {
+import type { CountryCode } from '@planet-sdk/common';
+import type { PointFeature } from 'supercluster';
+import type {
   ProfilePageType,
   DonationProperties,
 } from '../../../../common/types/myForest';
+
+import { useTranslations } from 'next-intl';
+import style from '../ContributionsMap.module.scss';
+import DonateButton from '../../MyContributions/DonateButton';
 
 interface ProjectInfoSectionProps {
   superclusterResponse: PointFeature<DonationProperties>;

--- a/src/features/user/Profile/ContributionsMap/Popup/RegisteredTreesPopup.tsx
+++ b/src/features/user/Profile/ContributionsMap/Popup/RegisteredTreesPopup.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
-import { useTranslations } from 'next-intl';
-import { Popup } from 'react-map-gl-v7';
-import { PointFeature } from 'supercluster';
-import RegisteredTreePopupIcon from '../../../../../../public/assets/images/icons/myForestMapIcons/RegisteredTreePopupIcon';
-import style from '../ContributionsMap.module.scss';
-import formatDate from '../../../../../utils/countryCurrency/getFormattedDate';
-import {
+import type { PointFeature } from 'supercluster';
+import type {
   MyContributionsSingleRegistration,
   SingleRegistration,
 } from '../../../../common/types/myForest';
-import { SetState } from '../../../../common/types/common';
+import type { SetState } from '../../../../common/types/common';
+
+import React from 'react';
+import { useTranslations } from 'next-intl';
+import { Popup } from 'react-map-gl-v7';
+import RegisteredTreePopupIcon from '../../../../../../public/assets/images/icons/myForestMapIcons/RegisteredTreePopupIcon';
+import style from '../ContributionsMap.module.scss';
+import formatDate from '../../../../../utils/countryCurrency/getFormattedDate';
 
 type RegisteredTreesInfoProps = {
   contributions: SingleRegistration[];

--- a/src/features/user/Profile/ContributionsMap/index.tsx
+++ b/src/features/user/Profile/ContributionsMap/index.tsx
@@ -1,15 +1,18 @@
+import type { MapStyle } from 'react-map-gl-v7/maplibre';
+import type { MutableRefObject } from 'react';
+import type { ProfilePageType } from '../../../common/types/myForest';
+import type { ViewState } from 'react-map-gl-v7';
+
 import { useEffect, useState } from 'react';
-import Map, { MapStyle } from 'react-map-gl-v7/maplibre';
+import Map from 'react-map-gl-v7/maplibre';
 import getMapStyle from '../../../../utils/maps/getMapStyle';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { NavigationControl } from 'react-map-gl-v7/maplibre';
 import MapCredits from './Common/MapCredits';
 import Markers from './Markers';
-import { useRef, MutableRefObject } from 'react';
+import { useRef } from 'react';
 import style from './Common/common.module.scss';
 import ContributionStats from './Common/ContributionStats';
-import { ProfilePageType } from '../../../common/types/myForest';
-import { ViewState } from 'react-map-gl-v7';
 
 interface ContributionsMapProps {
   profilePageType: ProfilePageType;

--- a/src/features/user/Profile/ForestProgress/ForestProgressItem.tsx
+++ b/src/features/user/Profile/ForestProgress/ForestProgressItem.tsx
@@ -1,9 +1,10 @@
+import type { ProfilePageType } from '../../../common/types/myForest';
+
 import styles from './ForestProgress.module.scss';
 import { calculateGraphSegmentLengths } from '../../../../utils/myForestUtils';
 import { useMemo } from 'react';
 import EditButton from './microComponents/EditButton';
 import ProgressData from './microComponents/ProgressData';
-import { ProfilePageType } from '../../../common/types/myForest';
 
 export type ProgressDataType =
   | 'treesPlanted'

--- a/src/features/user/Profile/ForestProgress/TargetFormInput.tsx
+++ b/src/features/user/Profile/ForestProgress/TargetFormInput.tsx
@@ -1,12 +1,14 @@
+import type { ChangeEvent } from 'react';
+import type { SetState } from '../../../common/types/common';
+import type { ProgressDataType } from './ForestProgressItem';
+
 import styles from './ForestProgress.module.scss';
 import { useTranslations } from 'next-intl';
 import { targetColor } from '../../../../utils/myForestUtils';
-import { ChangeEvent, useMemo } from 'react';
+import { useMemo } from 'react';
 import TargetSwitch from './TargetSwitch';
 import TargetTextField from './TargetTextField';
-import { SetState } from '../../../common/types/common';
 import TargetFormInputLabel from './microComponents/TargetFormInputLabel';
-import { ProgressDataType } from './ForestProgressItem';
 
 type TargetFormInputProps = {
   dataType: ProgressDataType;

--- a/src/features/user/Profile/ForestProgress/TargetsModal.tsx
+++ b/src/features/user/Profile/ForestProgress/TargetsModal.tsx
@@ -1,3 +1,6 @@
+import type { APIError, User } from '@planet-sdk/common';
+import type { SetState } from '../../../common/types/common';
+
 import { Modal } from '@mui/material';
 import styles from './ForestProgress.module.scss';
 import { useContext, useEffect } from 'react';
@@ -5,9 +8,8 @@ import { useMyForest } from '../../../common/Layout/MyForestContext';
 import { putAuthenticatedRequest } from '../../../../utils/apiRequests/api';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 import { useTenant } from '../../../common/Layout/TenantContext';
-import { handleError, APIError, User } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
-import { SetState } from '../../../common/types/common';
 import { useTranslations } from 'next-intl';
 import CrossIcon from '../../../../../public/assets/images/icons/manageProjects/Cross';
 import TargetFormInput from './TargetFormInput';

--- a/src/features/user/Profile/ForestProgress/index.tsx
+++ b/src/features/user/Profile/ForestProgress/index.tsx
@@ -1,10 +1,11 @@
+import type { ProfilePageType } from '../../../common/types/myForest';
+
 import { useState, useEffect } from 'react';
 import styles from './ForestProgress.module.scss';
 import TargetsModal from './TargetsModal';
 import { useMyForest } from '../../../common/Layout/MyForestContext';
 import EmptyProgress from './EmptyProgress';
 import ForestProgressItem from './ForestProgressItem';
-import { ProfilePageType } from '../../../common/types/myForest';
 import {
   checkProgressEnabled,
   aggregateProgressData,

--- a/src/features/user/Profile/ForestProgress/microComponents/EditButton.tsx
+++ b/src/features/user/Profile/ForestProgress/microComponents/EditButton.tsx
@@ -1,4 +1,5 @@
-import { ForestProgressItemProps } from '../ForestProgressItem';
+import type { ForestProgressItemProps } from '../ForestProgressItem';
+
 import { useTranslations } from 'next-intl';
 import styles from '../ForestProgress.module.scss';
 import { EditTargetIcon } from '../../../../../../public/assets/images/icons/ProgressBarIcons';

--- a/src/features/user/Profile/ForestProgress/microComponents/ProgressData.tsx
+++ b/src/features/user/Profile/ForestProgress/microComponents/ProgressData.tsx
@@ -1,9 +1,10 @@
+import type { ProgressDataType } from '../ForestProgressItem';
+
 import {
   TreesPlantedIcon,
   AreaRestoredIcon,
   ConservedAreaIcon,
 } from '../../../../../../public/assets/images/icons/ProgressBarIcons';
-import { ProgressDataType } from '../ForestProgressItem';
 import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
 import styles from '../ForestProgress.module.scss';

--- a/src/features/user/Profile/ForestProgress/microComponents/StackedBarGraph.tsx
+++ b/src/features/user/Profile/ForestProgress/microComponents/StackedBarGraph.tsx
@@ -1,5 +1,6 @@
+import type { ProgressDataProps } from './ProgressData';
+
 import styles from '../ForestProgress.module.scss';
-import { ProgressDataProps } from './ProgressData';
 
 export type StackedBarGraphProps = Omit<ProgressDataProps, 'dataType'>;
 

--- a/src/features/user/Profile/ForestProgress/microComponents/TargetFormInputLabel.tsx
+++ b/src/features/user/Profile/ForestProgress/microComponents/TargetFormInputLabel.tsx
@@ -1,3 +1,5 @@
+import type { ProgressDataType } from '../ForestProgressItem';
+
 import styles from '../ForestProgress.module.scss';
 import { useTranslations } from 'next-intl';
 import {
@@ -5,7 +7,6 @@ import {
   AreaRestoredIcon,
   ConservedAreaIcon,
 } from '../../../../../../public/assets/images/icons/ProgressBarIcons';
-import { ProgressDataType } from '../ForestProgressItem';
 
 type TargetFormInputLabelProps = {
   dataType: ProgressDataType;

--- a/src/features/user/Profile/MyContributions/ContributionSummary.tsx
+++ b/src/features/user/Profile/MyContributions/ContributionSummary.tsx
@@ -1,6 +1,7 @@
+import type { MySingleContribution } from '../../../common/types/myForest';
+
 import { useTranslations } from 'next-intl';
 import GiftIcon from '../../../../../public/assets/images/icons/Gift';
-import { MySingleContribution } from '../../../common/types/myForest';
 import styles from './MyContributions.module.scss';
 import format from 'date-fns/format';
 import { localeMapForDate } from '../../../../utils/language/getLanguageName';

--- a/src/features/user/Profile/MyContributions/GiftInfoTooltip.tsx
+++ b/src/features/user/Profile/MyContributions/GiftInfoTooltip.tsx
@@ -1,4 +1,6 @@
-import { Tooltip, TooltipProps, styled, tooltipClasses } from '@mui/material';
+import type { TooltipProps } from '@mui/material';
+
+import { Tooltip, styled, tooltipClasses } from '@mui/material';
 
 // Could be updated for reuse, but currently only needed for the GiftInfo tooltip
 

--- a/src/features/user/Profile/MyContributions/GiftLabel.tsx
+++ b/src/features/user/Profile/MyContributions/GiftLabel.tsx
@@ -1,10 +1,11 @@
-import { useTranslations } from 'next-intl';
-import styles from './MyContributions.module.scss';
-import GiftIcon from '../../../../../public/assets/images/icons/Gift';
-import {
+import type {
   GiftReceivedDetails,
   GiftGivenDetails,
 } from '../../../common/types/myForest';
+
+import { useTranslations } from 'next-intl';
+import styles from './MyContributions.module.scss';
+import GiftIcon from '../../../../../public/assets/images/icons/Gift';
 
 type Props = {
   giftDetails: GiftGivenDetails | GiftReceivedDetails;

--- a/src/features/user/Profile/MyContributions/ItemImage.tsx
+++ b/src/features/user/Profile/MyContributions/ItemImage.tsx
@@ -1,7 +1,8 @@
-import {
+import type {
   GiftGivenDetails,
   GiftReceivedDetails,
 } from '../../../common/types/myForest';
+
 import GiftLabel from './GiftLabel';
 import styles from './MyContributions.module.scss';
 

--- a/src/features/user/Profile/MyContributions/ItemMobileHeader.tsx
+++ b/src/features/user/Profile/MyContributions/ItemMobileHeader.tsx
@@ -1,9 +1,13 @@
-import styles from './MyContributions.module.scss';
-import { EcosystemTypes, TreeProjectClassification } from '@planet-sdk/common';
-import {
+import type {
+  EcosystemTypes,
+  TreeProjectClassification,
+} from '@planet-sdk/common';
+import type {
   GiftGivenDetails,
   GiftReceivedDetails,
 } from '../../../common/types/myForest';
+
+import styles from './MyContributions.module.scss';
 import GiftLabel from './GiftLabel';
 import ProjectHeader from './ProjectHeader';
 

--- a/src/features/user/Profile/MyContributions/ProjectHeader.tsx
+++ b/src/features/user/Profile/MyContributions/ProjectHeader.tsx
@@ -1,7 +1,11 @@
+import type {
+  EcosystemTypes,
+  TreeProjectClassification,
+} from '@planet-sdk/common';
+
 import styles from './MyContributions.module.scss';
 import ProjectTypeIcon from '../../../common/ProjectTypeIcon';
 import { useTranslations } from 'next-intl';
-import { EcosystemTypes, TreeProjectClassification } from '@planet-sdk/common';
 import { useMemo } from 'react';
 
 type ConservationProps = {

--- a/src/features/user/Profile/MyContributions/ProjectItemCard.tsx
+++ b/src/features/user/Profile/MyContributions/ProjectItemCard.tsx
@@ -1,20 +1,21 @@
+import type {
+  MyForestProject,
+  ProfilePageType,
+} from '../../../common/types/myForest';
+import type { MyContributionsSingleProject } from '../../../common/types/myForest';
+import type { CountryCode } from '@planet-sdk/common';
+import type { ComponentProps } from 'react';
+
 import ContributionCountOverflow from './ContributionCountOverflow';
 import ContributionSummary from './ContributionSummary';
 import DonateButton from './DonateButton';
 import ItemMobileHeader from './ItemMobileHeader';
 import ProjectTotalContributions from './ProjectTotalContributions';
 import styles from './MyContributions.module.scss';
-import {
-  MyForestProject,
-  ProfilePageType,
-} from '../../../common/types/myForest';
-import { MyContributionsSingleProject } from '../../../common/types/myForest';
 import { useTranslations } from 'next-intl';
-import { CountryCode } from '@planet-sdk/common';
 import ItemImage from './ItemImage';
 import ProjectSummary from './ProjectSummary';
 import getImageUrl from '../../../../utils/getImageURL';
-import { ComponentProps } from 'react';
 
 interface Props {
   project: MyForestProject;

--- a/src/features/user/Profile/MyContributions/ProjectSummary.tsx
+++ b/src/features/user/Profile/MyContributions/ProjectSummary.tsx
@@ -1,10 +1,11 @@
-import { useTranslations } from 'next-intl';
-import styles from './MyContributions.module.scss';
-import {
+import type {
   CountryCode,
   EcosystemTypes,
   TreeProjectClassification,
 } from '@planet-sdk/common';
+
+import { useTranslations } from 'next-intl';
+import styles from './MyContributions.module.scss';
 import ProjectHeader from './ProjectHeader';
 
 type ConservationProps = {

--- a/src/features/user/Profile/MyContributions/RegistrationItemCard.tsx
+++ b/src/features/user/Profile/MyContributions/RegistrationItemCard.tsx
@@ -1,9 +1,10 @@
-import { ComponentProps } from 'react';
-import getImageUrl from '../../../../utils/getImageURL';
-import {
+import type { ComponentProps } from 'react';
+import type {
   MyContributionsSingleRegistration,
   MyForestProject,
 } from '../../../common/types/myForest';
+import getImageUrl from '../../../../utils/getImageURL';
+
 import ItemImage from './ItemImage';
 import styles from './MyContributions.module.scss';
 import RegistrationSummary from './RegistrationSummary';

--- a/src/features/user/Profile/MyContributions/RegistrationSummary.tsx
+++ b/src/features/user/Profile/MyContributions/RegistrationSummary.tsx
@@ -1,6 +1,7 @@
-import { CountryCode } from '@planet-sdk/common';
+import type { CountryCode } from '@planet-sdk/common';
+import type { DateString } from '../../../common/types/common';
+
 import styles from './MyContributions.module.scss';
-import { DateString } from '../../../common/types/common';
 import { useTranslations } from 'next-intl';
 import { localeMapForDate } from '../../../../utils/language/getLanguageName';
 import format from 'date-fns/format';

--- a/src/features/user/Profile/MyContributions/index.tsx
+++ b/src/features/user/Profile/MyContributions/index.tsx
@@ -1,13 +1,15 @@
-import { ReactElement, useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
+import type { ProjectItemCardProps } from './ProjectItemCard';
+import type { RegistrationItemCardProps } from './RegistrationItemCard';
+import type { ProfileV2Props } from '../../../common/types/profile';
+
+import { useEffect, useState } from 'react';
 import { useMyForest } from '../../../common/Layout/MyForestContext';
 import ListHeader from './ListHeader';
 import styles from './MyContributions.module.scss';
-import ProjectItemCard, { ProjectItemCardProps } from './ProjectItemCard';
-import RegistrationItemCard, {
-  RegistrationItemCardProps,
-} from './RegistrationItemCard';
+import ProjectItemCard from './ProjectItemCard';
+import RegistrationItemCard from './RegistrationItemCard';
 import NoContributions from '../CommunityContributions/NoContributions';
-import { ProfileV2Props } from '../../../common/types/profile';
 
 const MyContributions = ({ profilePageType, userProfile }: ProfileV2Props) => {
   const { contributionsMap, projectListResult } = useMyForest();

--- a/src/features/user/Profile/ProfileCard/ProfileActions/SocialMediaShareButton.tsx
+++ b/src/features/user/Profile/ProfileCard/ProfileActions/SocialMediaShareButton.tsx
@@ -1,10 +1,11 @@
+import type { ProfileV2Props } from '../../../../common/types/profile';
+
 import React from 'react';
 import { ShareIcon } from '../../../../../../public/assets/images/icons/ProfilePageV2Icons';
 import WebappButton from '../../../../common/WebappButton';
 import ShareModal from '../ShareModal';
 import { useTranslations } from 'next-intl';
 import { useTenant } from '../../../../common/Layout/TenantContext';
-import { ProfileV2Props } from '../../../../common/types/profile';
 
 interface SocialMediaShareButtonProps {
   userProfile: ProfileV2Props['userProfile'];

--- a/src/features/user/Profile/ProfileCard/ProfileActions/index.tsx
+++ b/src/features/user/Profile/ProfileCard/ProfileActions/index.tsx
@@ -1,3 +1,5 @@
+import type { ProfileV2Props } from '../../../../common/types/profile';
+
 import React, { useState } from 'react';
 import {
   AllDonations,
@@ -9,7 +11,6 @@ import styles from './ProfileActions.module.scss';
 import RedeemModal from '../RedeemModal';
 import SocialMediaShareButton from './SocialMediaShareButton';
 import { useTranslations } from 'next-intl';
-import { ProfileV2Props } from '../../../../common/types/profile';
 import WebappButton from '../../../../common/WebappButton';
 
 const ProfileActions = ({ profilePageType, userProfile }: ProfileV2Props) => {

--- a/src/features/user/Profile/ProfileCard/ShareModal/index.tsx
+++ b/src/features/user/Profile/ProfileCard/ShareModal/index.tsx
@@ -1,3 +1,5 @@
+import type { ProfileV2Props } from '../../../../common/types/profile';
+
 import React from 'react';
 import styles from './ShareModal.module.scss';
 import { Modal, Fade, TextField } from '@mui/material';
@@ -12,7 +14,6 @@ import {
 } from '../../../../../../public/assets/images/icons/ProfilePageV2Icons';
 import { useTranslations } from 'next-intl';
 import { useTenant } from '../../../../common/Layout/TenantContext';
-import { ProfileV2Props } from '../../../../common/types/profile';
 
 const CustomCopyButton = () => {
   const t = useTranslations('Profile');

--- a/src/features/user/Profile/ProfileLayout/index.tsx
+++ b/src/features/user/Profile/ProfileLayout/index.tsx
@@ -1,6 +1,7 @@
+import type { User } from '@planet-sdk/common';
+
 import ContributionsMap from '../ContributionsMap';
 import styles from './ProfileLayout.module.scss';
-import { User } from '@planet-sdk/common';
 import { useRouter } from 'next/router';
 import React, { useEffect } from 'react';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';

--- a/src/features/user/Profile/ProfileOuterContainer/index.tsx
+++ b/src/features/user/Profile/ProfileOuterContainer/index.tsx
@@ -1,4 +1,5 @@
-import { FC } from 'react';
+import type { FC } from 'react';
+
 import styles from './ProfileOuterContainer.module.scss';
 
 const ProfileOuterContainer: FC = ({ children }) => {

--- a/src/features/user/Profile/PublicProfileLayout/index.tsx
+++ b/src/features/user/Profile/PublicProfileLayout/index.tsx
@@ -1,6 +1,7 @@
+import type { UserPublicProfile } from '@planet-sdk/common';
+
 import styles from './PublicProfileLayout.module.scss';
 import ProfileCard from '../ProfileCard';
-import { UserPublicProfile } from '@planet-sdk/common';
 import { ProfileLoader } from '../../../common/ContentLoaders/ProfileV2';
 import ForestProgress from '../ForestProgress';
 import ContributionsMap from '../ContributionsMap';

--- a/src/features/user/Profile/PublicProfileOuterContainer/index.tsx
+++ b/src/features/user/Profile/PublicProfileOuterContainer/index.tsx
@@ -1,4 +1,5 @@
-import { FC } from 'react';
+import type { FC } from 'react';
+
 import styles from './PublicProfileOuterContainer.module.scss';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 

--- a/src/features/user/Profile/TpoProjects/index.tsx
+++ b/src/features/user/Profile/TpoProjects/index.tsx
@@ -1,3 +1,6 @@
+import type { APIError, UserPublicProfile } from '@planet-sdk/common';
+import type { MapProject } from '../../../common/types/ProjectPropsContextInterface';
+
 import dynamic from 'next/dynamic';
 import React from 'react';
 import LazyLoad from 'react-lazyload';
@@ -7,8 +10,7 @@ import { useLocale, useTranslations } from 'next-intl';
 import styles from './TpoProjects.module.scss';
 import { getRequest } from '../../../../utils/apiRequests/api';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
-import { handleError, APIError, UserPublicProfile } from '@planet-sdk/common';
-import { MapProject } from '../../../common/types/ProjectPropsContextInterface';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 const ProjectSnippet = dynamic(

--- a/src/features/user/Profile/stories/MyContributions/ProjectItemCard.stories.tsx
+++ b/src/features/user/Profile/stories/MyContributions/ProjectItemCard.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import type { MyForestProject } from '../../../../common/types/myForest';
+import type { MyContributionsSingleProject } from '../../../../common/types/myForest';
+
 import ProjectItemCard from '../../MyContributions/ProjectItemCard';
-import { MyForestProject } from '../../../../common/types/myForest';
-import { MyContributionsSingleProject } from '../../../../common/types/myForest';
 
 const meta: Meta<typeof ProjectItemCard> = {
   component: ProjectItemCard,

--- a/src/features/user/Profile/stories/MyContributions/ProjectSummary.stories.tsx
+++ b/src/features/user/Profile/stories/MyContributions/ProjectSummary.stories.tsx
@@ -1,4 +1,5 @@
-import { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
+
 import ProjectSummary from '../../MyContributions/ProjectSummary';
 
 const meta: Meta<typeof ProjectSummary> = {

--- a/src/features/user/Profile/stories/MyContributions/ProjectTotalContributions.stories.tsx
+++ b/src/features/user/Profile/stories/MyContributions/ProjectTotalContributions.stories.tsx
@@ -1,4 +1,5 @@
-import { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
+
 import ProjectTotalContributions from '../../MyContributions/ProjectTotalContributions';
 
 const meta: Meta<typeof ProjectTotalContributions> = {

--- a/src/features/user/Profile/stories/MyContributions/RegistrationItemCard.stories.tsx
+++ b/src/features/user/Profile/stories/MyContributions/RegistrationItemCard.stories.tsx
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import RegistrationItemCard from '../../MyContributions/RegistrationItemCard';
-import {
+import type {
   MyContributionsSingleRegistration,
   MyForestProject,
 } from '../../../../common/types/myForest';
+
+import RegistrationItemCard from '../../MyContributions/RegistrationItemCard';
 
 const meta: Meta<typeof RegistrationItemCard> = {
   component: RegistrationItemCard,

--- a/src/features/user/Profile/stories/ProfileActions.stories.tsx
+++ b/src/features/user/Profile/stories/ProfileActions.stories.tsx
@@ -1,10 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import type { User, UserPublicProfile } from '@planet-sdk/common';
+
 import ProfileActions from '../ProfileCard/ProfileActions';
-import {
-  PaymentFrequencies,
-  User,
-  UserPublicProfile,
-} from '@planet-sdk/common';
+import { PaymentFrequencies } from '@planet-sdk/common';
 
 const meta: Meta<typeof ProfileActions> = {
   component: ProfileActions,

--- a/src/features/user/Profile/stories/ProfileCard.stories.tsx
+++ b/src/features/user/Profile/stories/ProfileCard.stories.tsx
@@ -1,10 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import type { User, UserPublicProfile } from '@planet-sdk/common';
+
 import ProfileCard from '../ProfileCard';
-import {
-  PaymentFrequencies,
-  User,
-  UserPublicProfile,
-} from '@planet-sdk/common';
+import { PaymentFrequencies } from '@planet-sdk/common';
 
 const meta: Meta<typeof ProfileCard> = {
   component: ProfileCard,

--- a/src/features/user/RegisterTrees/RegisterTrees/DrawMap.tsx
+++ b/src/features/user/RegisterTrees/RegisterTrees/DrawMap.tsx
@@ -1,11 +1,13 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { ViewportProps } from '../../../common/types/map';
+
+import React from 'react';
 import ReactMapboxGl, { ZoomControl } from 'react-mapbox-gl';
 import DrawControl from 'react-mapbox-gl-draw';
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
 import styles from '../RegisterModal.module.scss';
 import { useTranslations } from 'next-intl';
 import getMapStyle from '../../../../utils/maps/getMapStyle';
-import { ViewportProps } from '../../../common/types/map';
 
 interface Props {
   setGeometry: Function;

--- a/src/features/user/RegisterTrees/RegisterTrees/SingleContribution.tsx
+++ b/src/features/user/RegisterTrees/RegisterTrees/SingleContribution.tsx
@@ -1,14 +1,16 @@
+import type { ReactElement } from 'react';
+import type { Image } from '@planet-sdk/common';
+import type { Point, Polygon } from 'geojson';
+
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
-import React, { ReactElement } from 'react';
+import React from 'react';
 import CheckCircle from '../../../../../public/assets/images/icons/CheckCircle';
 import styles from '../RegisterModal.module.scss';
 import UploadImages from './UploadImages';
 import { useTranslations } from 'next-intl';
 import formatDate from '../../../../utils/countryCurrency/getFormattedDate';
 import { Button } from '@mui/material';
-import { Image } from '@planet-sdk/common';
-import { Point, Polygon } from 'geojson';
 
 export interface ContributionProperties {
   contributionImages: Image[];

--- a/src/features/user/RegisterTrees/RegisterTrees/StaticMap.tsx
+++ b/src/features/user/RegisterTrees/RegisterTrees/StaticMap.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import * as turf from '@turf/turf';
 import ReactMapboxGl, { GeoJSONLayer, Marker } from 'react-mapbox-gl';
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';

--- a/src/features/user/RegisterTrees/RegisterTrees/UploadImages.tsx
+++ b/src/features/user/RegisterTrees/RegisterTrees/UploadImages.tsx
@@ -1,4 +1,7 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { APIError, Image } from '@planet-sdk/common';
+
+import React from 'react';
 import styles from '../RegisterModal.module.scss';
 import { useDropzone } from 'react-dropzone';
 import {
@@ -9,7 +12,7 @@ import getImageUrl from '../../../../utils/getImageURL';
 import DeleteIcon from '../../../../../public/assets/images/icons/manageProjects/Delete';
 import { useTranslations } from 'next-intl';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
-import { handleError, APIError, Image } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDisplayGroup';
 import { Button } from '@mui/material';

--- a/src/features/user/RegisterTrees/RegisterTreesWidget.tsx
+++ b/src/features/user/RegisterTrees/RegisterTreesWidget.tsx
@@ -1,4 +1,15 @@
-import { MenuItem, SxProps, TextField, Button } from '@mui/material';
+import type { ContributionProperties } from './RegisterTrees/SingleContribution';
+import type { APIError } from '@planet-sdk/common';
+import type { ViewportProps } from '../../common/types/map';
+import type {
+  RegisterTreesFormProps,
+  RegisterTreeGeometry,
+  ProjectGeoJsonProps,
+} from '../../common/types/map';
+import { handleError } from '@planet-sdk/common';
+import type { SxProps } from '@mui/material';
+
+import { MenuItem, TextField, Button } from '@mui/material';
 import * as d3 from 'd3-ease';
 import dynamic from 'next/dynamic';
 import React from 'react';
@@ -18,11 +29,8 @@ import getMapStyle from '../../../utils/maps/getMapStyle';
 import { getStoredConfig } from '../../../utils/storeConfig';
 import { useUserProps } from '../../common/Layout/UserPropsContext';
 import styles from './RegisterModal.module.scss';
-import SingleContribution, {
-  ContributionProperties,
-} from './RegisterTrees/SingleContribution';
+import SingleContribution from './RegisterTrees/SingleContribution';
 import { ErrorHandlingContext } from '../../common/Layout/ErrorHandlingContext';
-import { handleError, APIError } from '@planet-sdk/common';
 import { MobileDatePicker as MuiDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
@@ -30,12 +38,6 @@ import themeProperties from '../../../theme/themeProperties';
 import StyledForm from '../../common/Layout/StyledForm';
 import InlineFormDisplayGroup from '../../common/Layout/Forms/InlineFormDisplayGroup';
 import { useTenant } from '../../common/Layout/TenantContext';
-import { ViewportProps } from '../../common/types/map';
-import {
-  RegisterTreesFormProps,
-  RegisterTreeGeometry,
-  ProjectGeoJsonProps,
-} from '../../common/types/map';
 
 const DrawMap = dynamic(() => import('./RegisterTrees/DrawMap'), {
   ssr: false,

--- a/src/features/user/RegisterTrees/index.tsx
+++ b/src/features/user/RegisterTrees/index.tsx
@@ -1,5 +1,6 @@
+import type { ReactElement } from 'react';
+
 import { useTranslations } from 'next-intl';
-import { ReactElement } from 'react';
 import DashboardView from '../../common/Layout/DashboardView';
 import SingleColumnView from '../../common/Layout/SingleColumnView';
 import RegisterTreesWidget from './RegisterTreesWidget';

--- a/src/features/user/Settings/ApiKey/ApiKeyForm.tsx
+++ b/src/features/user/Settings/ApiKey/ApiKeyForm.tsx
@@ -1,3 +1,5 @@
+import type { APIError } from '@planet-sdk/common';
+
 import React from 'react';
 import styles from './ApiKey.module.scss';
 import {
@@ -12,7 +14,7 @@ import EyeDisabled from '../../../../../public/assets/images/icons/EyeDisabled';
 import { useTranslations } from 'next-intl';
 import StyledForm from '../../../common/Layout/StyledForm';
 import { Button, InputAdornment, TextField } from '@mui/material';
-import { APIError, handleError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDisplayGroup';
 import { useTenant } from '../../../common/Layout/TenantContext';
 

--- a/src/features/user/Settings/ApiKey/index.tsx
+++ b/src/features/user/Settings/ApiKey/index.tsx
@@ -1,5 +1,6 @@
+import type { ReactElement } from 'react';
+
 import { useTranslations } from 'next-intl';
-import { ReactElement } from 'react';
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
 import DashboardView from '../../../common/Layout/DashboardView';
 import SingleColumnView from '../../../common/Layout/SingleColumnView';

--- a/src/features/user/Settings/DeleteProfile/DeleteProfileForm.tsx
+++ b/src/features/user/Settings/DeleteProfile/DeleteProfileForm.tsx
@@ -1,3 +1,5 @@
+import type { APIError, SerializedError } from '@planet-sdk/common';
+
 import React from 'react';
 import styles from './DeleteProfile.module.scss';
 import { deleteAuthenticatedRequest } from '../../../../utils/apiRequests/api';
@@ -8,7 +10,7 @@ import router from 'next/router';
 import { useTranslations } from 'next-intl';
 import { Button, TextField } from '@mui/material';
 import StyledForm from '../../../common/Layout/StyledForm';
-import { APIError, handleError, SerializedError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 export default function DeleteProfileForm() {

--- a/src/features/user/Settings/DeleteProfile/index.tsx
+++ b/src/features/user/Settings/DeleteProfile/index.tsx
@@ -1,5 +1,6 @@
+import type { ReactElement } from 'react';
+
 import { useTranslations } from 'next-intl';
-import { ReactElement } from 'react';
 import DashboardView from '../../../common/Layout/DashboardView';
 import SingleColumnView from '../../../common/Layout/SingleColumnView';
 import DeleteProfileForm from './DeleteProfileForm';

--- a/src/features/user/Settings/EditProfile/EditProfileForm.tsx
+++ b/src/features/user/Settings/EditProfile/EditProfileForm.tsx
@@ -1,10 +1,18 @@
+import type {
+  AddressSuggestionsType,
+  AddressType,
+} from '../../../common/types/geocoder';
+import type { AlertColor } from '@mui/lab';
+import type { APIError } from '@planet-sdk/common';
+import type { ExtendedCountryCode } from '../../../common/types/country';
+import type { User } from '@planet-sdk/common/build/types/user';
+
 import { styled, TextField } from '@mui/material';
 import Snackbar from '@mui/material/Snackbar';
 import MuiAlert from '@mui/material/Alert';
 import React, { useMemo, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Controller, useForm } from 'react-hook-form';
-import { User } from '@planet-sdk/common/build/types/user';
 import Camera from '../../../../../public/assets/images/icons/userProfileIcons/Camera';
 import { putAuthenticatedRequest } from '../../../../utils/apiRequests/api';
 import COUNTRY_ADDRESS_POSTALS from '../../../../utils/countryZipCode';
@@ -23,14 +31,8 @@ import {
   StyledAutoCompleteOption,
 } from '../../../common/InputTypes/MuiAutoComplete';
 import StyledForm from '../../../common/Layout/StyledForm';
-import {
-  AddressSuggestionsType,
-  AddressType,
-} from '../../../common/types/geocoder';
-import { AlertColor } from '@mui/lab';
-import { APIError, handleError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../../common/Layout/TenantContext';
-import { ExtendedCountryCode } from '../../../common/types/country';
 import Delete from '../../../../../public/assets/images/icons/manageProjects/Delete';
 import CustomTooltip from '../../../common/Layout/CustomTooltip';
 import NewToggleSwitch from '../../../common/InputTypes/NewToggleSwitch';

--- a/src/features/user/Settings/EditProfile/index.tsx
+++ b/src/features/user/Settings/EditProfile/index.tsx
@@ -1,5 +1,6 @@
+import type { ReactElement } from 'react';
+
 import { useTranslations } from 'next-intl';
-import { ReactElement } from 'react';
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
 import DashboardView from '../../../common/Layout/DashboardView';
 import EditProfileForm from './EditProfileForm';

--- a/src/features/user/Settings/EditProfile/index.tsx
+++ b/src/features/user/Settings/EditProfile/index.tsx
@@ -7,7 +7,7 @@ import EditProfileForm from './EditProfileForm';
 import SingleColumnView from '../../../common/Layout/SingleColumnView';
 import AddressManagement from './AddressManagement';
 
-export default function EditProfile(): React.ReactElement | null {
+export default function EditProfile(): ReactElement {
   const t = useTranslations('Me');
 
   return (

--- a/src/features/user/Settings/ImpersonateUser/ImpersonateUserForm.tsx
+++ b/src/features/user/Settings/ImpersonateUser/ImpersonateUserForm.tsx
@@ -1,4 +1,6 @@
-import { ReactElement, useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
+
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useTranslations } from 'next-intl';
 import { Controller, useForm } from 'react-hook-form';

--- a/src/features/user/Settings/ImpersonateUser/index.tsx
+++ b/src/features/user/Settings/ImpersonateUser/index.tsx
@@ -1,5 +1,6 @@
+import type { ReactElement } from 'react';
+
 import { useTranslations } from 'next-intl';
-import { ReactElement } from 'react';
 import DashboardView from '../../../common/Layout/DashboardView';
 import SingleColumnView from '../../../common/Layout/SingleColumnView';
 import CenteredContainer from '../../../common/Layout/CenteredContainer';

--- a/src/features/user/TreeMapper/Analytics/components/Counter/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Counter/index.tsx
@@ -1,3 +1,8 @@
+import type {
+  TotalSpeciesPlanted,
+  TotalTreesPlanted,
+} from '../../../../../common/types/dataExplorer';
+
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useAnalytics } from '../../../../../common/Layout/AnalyticsContext';
@@ -7,10 +12,6 @@ import { Grid } from '@mui/material';
 import useNextRequest, {
   HTTP_METHOD,
 } from '../../../../../../hooks/use-next-request';
-import {
-  TotalSpeciesPlanted,
-  TotalTreesPlanted,
-} from '../../../../../common/types/dataExplorer';
 
 export const Counter = () => {
   const { project, fromDate, toDate } = useAnalytics();

--- a/src/features/user/TreeMapper/Analytics/components/Export/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Export/index.tsx
@@ -1,18 +1,18 @@
+import type { IExportData } from '../../../../../common/types/dataExplorer';
+import type { SxProps } from '@mui/material';
+import type { Project } from '../../../../../common/Layout/AnalyticsContext';
+
 import styles from './index.module.scss';
 import MuiButton from '../../../../../common/InputTypes/MuiButton';
 import { utils, write } from 'xlsx';
 import { saveAs } from 'file-saver';
 import ProjectSelectAutocomplete from '../ProjectSelectAutocomplete';
-import {
-  Project,
-  useAnalytics,
-} from '../../../../../common/Layout/AnalyticsContext';
+import { useAnalytics } from '../../../../../common/Layout/AnalyticsContext';
 import { useContext, useEffect, useState } from 'react';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { localeMapForDate } from '../../../../../../utils/language/getLanguageName';
 import { useUserProps } from '../../../../../common/Layout/UserPropsContext';
-import { SxProps } from '@mui/material';
 import themeProperties from '../../../../../../theme/themeProperties';
 import { MobileDatePicker as MuiDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
 import { useTranslations } from 'next-intl';
@@ -24,7 +24,6 @@ import { ErrorHandlingContext } from '../../../../../common/Layout/ErrorHandling
 import useNextRequest, {
   HTTP_METHOD,
 } from '../../../../../../hooks/use-next-request';
-import { IExportData } from '../../../../../common/types/dataExplorer';
 
 const dialogSx: SxProps = {
   '& .MuiButtonBase-root.MuiPickersDay-root.Mui-selected': {

--- a/src/features/user/TreeMapper/Analytics/components/Map/components/LeftControls/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Map/components/LeftControls/index.tsx
@@ -1,13 +1,15 @@
-import styles from './index.module.scss';
-import ProjectTypeSelector, { ProjectType } from '../../../ProjectTypeSelector';
-import { MuiAutoComplete } from '../../../../../../../common/InputTypes/MuiAutoComplete';
-import SitesSelectorAutocomplete from '../SiteSelectorAutocomplete';
-import { TextField } from '@mui/material';
-import { SetState } from '../../../../../../../common/types/common';
-import {
+import type { ProjectType } from '../../../ProjectTypeSelector';
+import type { SetState } from '../../../../../../../common/types/common';
+import type {
   Feature,
   FeatureCollection,
 } from '../../../../../../../common/types/dataExplorer';
+
+import styles from './index.module.scss';
+import ProjectTypeSelector from '../../../ProjectTypeSelector';
+import { MuiAutoComplete } from '../../../../../../../common/InputTypes/MuiAutoComplete';
+import SitesSelectorAutocomplete from '../SiteSelectorAutocomplete';
+import { TextField } from '@mui/material';
 import { useTranslations } from 'next-intl';
 
 interface Props {

--- a/src/features/user/TreeMapper/Analytics/components/Map/components/MapCredit/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Map/components/MapCredit/index.tsx
@@ -1,4 +1,6 @@
-import { useState, MouseEvent } from 'react';
+import type { MouseEvent } from 'react';
+
+import { useState } from 'react';
 import { Typography, Popover } from '@mui/material';
 import styles from './MapCredit.module.scss';
 import { InfoIcon } from '../../../../../../../../../public/assets/images/ProfilePageIcons/index';

--- a/src/features/user/TreeMapper/Analytics/components/Map/components/PlantLocationDetails/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Map/components/PlantLocationDetails/index.tsx
@@ -1,10 +1,11 @@
-import { useLocale, useTranslations } from 'next-intl';
-import styles from './index.module.scss';
-import {
+import type {
   PlantLocationDetailsApiResponse,
   PlantLocation,
   PlantLocationProperties,
 } from '../../../../../../../common/types/dataExplorer';
+
+import { useLocale, useTranslations } from 'next-intl';
+import styles from './index.module.scss';
 import PlantLocationDetailsZeroState from '../PlantLocationDetailsZeroState';
 import TreeMapperIcon from '../TreeMapperIcon';
 import { getFormattedNumber } from '../../../../../../../../utils/getFormattedNumber';

--- a/src/features/user/TreeMapper/Analytics/components/Map/components/SiteSelectorAutocomplete/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Map/components/SiteSelectorAutocomplete/index.tsx
@@ -1,16 +1,11 @@
-import React, {
-  ReactElement,
-  useState,
-  useEffect,
-  CSSProperties,
-  useCallback,
-} from 'react';
-import { Autocomplete, TextField, styled } from '@mui/material';
-import { useTranslations } from 'next-intl';
-import {
+import type {
   Feature,
   FeatureCollection,
 } from '../../../../../../../common/types/dataExplorer';
+import type { ReactElement, CSSProperties } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import { Autocomplete, TextField, styled } from '@mui/material';
+import { useTranslations } from 'next-intl';
 
 const MuiAutocomplete = styled(Autocomplete)(() => {
   return {

--- a/src/features/user/TreeMapper/Analytics/components/Map/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Map/index.tsx
@@ -1,25 +1,4 @@
-import {
-  ChangeEvent,
-  MutableRefObject,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
-import { TextField } from '@mui/material';
-import { useTranslations } from 'next-intl';
-import { Search } from '@mui/icons-material';
-import moment from 'moment';
-import 'mapbox-gl/dist/mapbox-gl.css';
-import * as turf from '@turf/turf';
-import MapGL, {
-  Layer,
-  NavigationControl,
-  Source,
-  ViewportProps,
-} from 'react-map-gl';
-
-import {
+import type {
   DistinctSpecies,
   PlantLocation,
   PlantLocationDetailsApiResponse,
@@ -28,8 +7,20 @@ import {
   FeatureCollection,
   SinglePlantLocationApiResponse,
 } from '../../../../../common/types/dataExplorer';
+import type { ProjectType } from '../ProjectTypeSelector';
+import type { ChangeEvent, MutableRefObject } from 'react';
+import type { ViewportProps } from 'react-map-gl';
+
+import { useContext, useEffect, useRef, useState } from 'react';
+import { TextField } from '@mui/material';
+import { useTranslations } from 'next-intl';
+import { Search } from '@mui/icons-material';
+import moment from 'moment';
+import 'mapbox-gl/dist/mapbox-gl.css';
+import * as turf from '@turf/turf';
+import MapGL, { Layer, NavigationControl, Source } from 'react-map-gl';
+
 import { Container } from '../Container';
-import { ProjectType } from '../ProjectTypeSelector';
 import useNextRequest, {
   HTTP_METHOD,
 } from '../../../../../../hooks/use-next-request';

--- a/src/features/user/TreeMapper/Analytics/components/NoProjectsFound/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/NoProjectsFound/index.tsx
@@ -1,4 +1,5 @@
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
 import { Button } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';

--- a/src/features/user/TreeMapper/Analytics/components/ProjectFilter/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/ProjectFilter/index.tsx
@@ -1,13 +1,12 @@
+import type { Project } from '../../../../../common/Layout/AnalyticsContext';
+import type { SxProps } from '@mui/material';
+
 import React, { useState } from 'react';
-import {
-  Project,
-  useAnalytics,
-} from '../../../../../common/Layout/AnalyticsContext';
+import { useAnalytics } from '../../../../../common/Layout/AnalyticsContext';
 import ProjectSelectAutocomplete from '../ProjectSelectAutocomplete';
 import { MobileDatePicker as MuiDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
 import Grid from '@mui/material/Grid';
 import themeProperties from '../../../../../../theme/themeProperties';
-import { SxProps } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import MaterialTextField from '../../../../../common/InputTypes/MaterialTextField';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';

--- a/src/features/user/TreeMapper/Analytics/components/ProjectSelectAutocomplete.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/ProjectSelectAutocomplete.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement, useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
+import type { Project } from '../../../../common/Layout/AnalyticsContext';
+
+import React, { useState, useEffect } from 'react';
 import { Autocomplete, TextField, styled } from '@mui/material';
 import { useTranslations } from 'next-intl';
-
-import { Project } from '../../../../common/Layout/AnalyticsContext';
 
 const MuiAutocomplete = styled(Autocomplete)(() => {
   return {

--- a/src/features/user/TreeMapper/Analytics/components/ProjectTypeSelector.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/ProjectTypeSelector.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement, useState, useEffect, CSSProperties } from 'react';
+import type { ReactElement, CSSProperties } from 'react';
+
+import React, { useState, useEffect } from 'react';
 import { Autocomplete, TextField, styled } from '@mui/material';
 import { useTranslations } from 'next-intl';
 

--- a/src/features/user/TreeMapper/Analytics/components/SpeciesPlanted/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/SpeciesPlanted/index.tsx
@@ -1,3 +1,6 @@
+import type { ApexOptions } from 'apexcharts';
+import type { ISpeciesPlanted } from '../../../../../common/types/dataExplorer';
+
 import dynamic from 'next/dynamic';
 import { useEffect, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
@@ -9,12 +12,10 @@ import DownloadSolid from '../../../../../../../public/assets/images/icons/share
 import ReactDOMServer from 'react-dom/server';
 import { useAnalytics } from '../../../../../common/Layout/AnalyticsContext';
 import { format } from 'date-fns';
-import { ApexOptions } from 'apexcharts';
 import { Container } from '../Container';
 import useNextRequest, {
   HTTP_METHOD,
 } from '../../../../../../hooks/use-next-request';
-import { ISpeciesPlanted } from '../../../../../common/types/dataExplorer';
 
 const ReactApexChart = dynamic(() => import('react-apexcharts'), {
   ssr: false,

--- a/src/features/user/TreeMapper/Analytics/components/TreePlanted/TimeFrameSelector.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/TreePlanted/TimeFrameSelector.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement, useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
+
+import React, { useState, useEffect } from 'react';
 import { Autocomplete, TextField, styled } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import { getTimeFrames } from '.';

--- a/src/features/user/TreeMapper/Analytics/components/TreePlanted/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/TreePlanted/index.tsx
@@ -1,3 +1,11 @@
+import type { ApexOptions } from 'apexcharts';
+import type {
+  IDailyFrame,
+  IMonthlyFrame,
+  IWeeklyFrame,
+  IYearlyFrame,
+} from '../../../../../common/types/dataExplorer';
+
 import { differenceInDays, format } from 'date-fns';
 import { useLocale, useTranslations } from 'next-intl';
 import { useEffect, useRef, useState } from 'react';
@@ -7,16 +15,9 @@ import { getFormattedNumber } from '../../../../../../utils/getFormattedNumber';
 import { useAnalytics } from '../../../../../common/Layout/AnalyticsContext';
 import DownloadSolid from '../../../../../../../public/assets/images/icons/share/DownloadSolid';
 import ReactDOMServer from 'react-dom/server';
-import { ApexOptions } from 'apexcharts';
 import { Tooltip } from './Tooltip';
 import { Container } from '../Container';
 import TimeFrameSelector, { TIME_FRAME } from './TimeFrameSelector';
-import {
-  IDailyFrame,
-  IMonthlyFrame,
-  IWeeklyFrame,
-  IYearlyFrame,
-} from '../../../../../common/types/dataExplorer';
 import useNextRequest, {
   HTTP_METHOD,
 } from '../../../../../../hooks/use-next-request';

--- a/src/features/user/TreeMapper/Analytics/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/index.tsx
@@ -1,14 +1,17 @@
+import type { Project } from '../../../common/Layout/AnalyticsContext';
+import type { APIError } from '@planet-sdk/common';
+import type { MapProject } from '../../../common/types/ProjectPropsContextInterface';
+
 import React, { useEffect, useState } from 'react';
 import DashboardView from '../../../common/Layout/DashboardView';
 import { useTranslations } from 'next-intl';
 import ProjectFilter from './components/ProjectFilter';
-import { Project, useAnalytics } from '../../../common/Layout/AnalyticsContext';
+import { useAnalytics } from '../../../common/Layout/AnalyticsContext';
 import { DataExplorerGridContainer } from './components/DataExplorerGridContainer';
 import { getAuthenticatedRequest } from '../../../../utils/apiRequests/api';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
-import { APIError, handleError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
-import { MapProject } from '../../../common/types/ProjectPropsContextInterface';
 import { useTenant } from '../../../common/Layout/TenantContext';
 import NoProjectsFound from './components/NoProjectsFound';
 

--- a/src/features/user/TreeMapper/Import/components/Map.tsx
+++ b/src/features/user/TreeMapper/Import/components/Map.tsx
@@ -1,12 +1,14 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { RequiredMapStyle } from '../../../../common/types/map';
+import type { ViewPort } from '../../../../common/types/project';
+
+import React from 'react';
 import styles from '../../TreeMapper.module.scss';
 import getMapStyle from '../../../../../utils/maps/getMapStyle';
 import MapGL, { NavigationControl } from 'react-map-gl';
 import LayerIcon from '../../../../../../public/assets/images/icons/LayerIcon';
 import LayerDisabled from '../../../../../../public/assets/images/icons/LayerDisabled';
 import SatelliteLayer from '../../../../projects/components/maps/SatelliteLayer';
-import { RequiredMapStyle } from '../../../../common/types/map';
-import { ViewPort } from '../../../../common/types/project';
 
 export default function MyTreesMap(): ReactElement {
   const [satellite, setSatellite] = React.useState(false);

--- a/src/features/user/TreeMapper/Import/components/MapComponent.tsx
+++ b/src/features/user/TreeMapper/Import/components/MapComponent.tsx
@@ -1,11 +1,13 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { GeoJSON } from 'geojson';
+import type { RequiredMapStyle } from '../../../../common/types/map';
+
+import React from 'react';
 import * as turf from '@turf/turf';
 import ReactMapboxGl, { ZoomControl, GeoJSONLayer } from 'react-mapbox-gl';
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
 import WebMercatorViewport from '@math.gl/web-mercator';
 import getMapStyle from '../../../../../utils/maps/getMapStyle';
-import { GeoJSON } from 'geojson';
-import { RequiredMapStyle } from '../../../../common/types/map';
 
 interface Props {
   geoJson: GeoJSON | null;

--- a/src/features/user/TreeMapper/Import/components/PlantingLocation.tsx
+++ b/src/features/user/TreeMapper/Import/components/PlantingLocation.tsx
@@ -1,12 +1,23 @@
-import React, { ReactElement } from 'react';
-import {
-  Controller,
-  useForm,
-  useFieldArray,
-  FieldErrors,
-  FieldArrayWithId,
-  Control,
-} from 'react-hook-form';
+import type { ReactElement } from 'react';
+import type { FieldErrors, FieldArrayWithId, Control } from 'react-hook-form';
+import type {
+  FeatureCollection,
+  GeoJsonProperties,
+  Geometry,
+  GeometryObject,
+} from 'geojson';
+import type {
+  Species,
+  PlantLocation as PlantLocationType,
+} from '../../../../common/types/plantLocation';
+import type { PlantingLocationFormData } from '../../Treemapper';
+import type { MapProject } from '../../../../common/types/ProjectPropsContextInterface';
+import type { SetState } from '../../../../common/types/common';
+import type { SxProps } from '@mui/material';
+import type { APIError } from '@planet-sdk/common';
+
+import React from 'react';
+import { Controller, useForm, useFieldArray } from 'react-hook-form';
 import styles from '../Import.module.scss';
 import { useTranslations } from 'next-intl';
 import { localeMapForDate } from '../../../../../utils/language/getLanguageName';
@@ -14,7 +25,7 @@ import { useDropzone } from 'react-dropzone';
 import DeleteIcon from '../../../../../../public/assets/images/icons/manageProjects/Delete';
 import JSONInput from 'react-json-editor-ajrm';
 import locale from 'react-json-editor-ajrm/locale/en';
-import { Button, MenuItem, SxProps, TextField } from '@mui/material';
+import { Button, MenuItem, TextField } from '@mui/material';
 import { useUserProps } from '../../../../common/Layout/UserPropsContext';
 import {
   getAuthenticatedRequest,
@@ -27,23 +38,11 @@ import { MobileDatePicker as MuiDatePicker } from '@mui/x-date-pickers/MobileDat
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import themeProperties from '../../../../../theme/themeProperties';
-import { handleError, APIError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { ErrorHandlingContext } from '../../../../common/Layout/ErrorHandlingContext';
-import { MapProject } from '../../../../common/types/ProjectPropsContextInterface';
 import { useTenant } from '../../../../common/Layout/TenantContext';
-import {
-  FeatureCollection,
-  GeoJsonProperties,
-  Geometry,
-  GeometryObject,
-} from 'geojson';
-import {
-  Species,
-  PlantLocation as PlantLocationType,
-} from '../../../../common/types/plantLocation';
-import { PlantingLocationFormData } from '../../Treemapper';
+
 // import { DevTool } from '@hookform/devtools';
-import { SetState } from '../../../../common/types/common';
 
 const dialogSx: SxProps = {
   '& .MuiButtonBase-root.MuiPickersDay-root.Mui-selected': {

--- a/src/features/user/TreeMapper/Import/components/ReviewSubmit.tsx
+++ b/src/features/user/TreeMapper/Import/components/ReviewSubmit.tsx
@@ -1,10 +1,12 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { PlantLocationMulti } from '../../../../common/types/plantLocation';
+
+import React from 'react';
 import styles from '../Import.module.scss';
 import { useTranslations } from 'next-intl';
 import formatDate from '../../../../../utils/countryCurrency/getFormattedDate';
 import { useRouter } from 'next/router';
 import { Button } from '@mui/material';
-import { PlantLocationMulti } from '../../../../common/types/plantLocation';
 
 interface Props {
   plantLocation: PlantLocationMulti;

--- a/src/features/user/TreeMapper/Import/components/SampleTreeCard.tsx
+++ b/src/features/user/TreeMapper/Import/components/SampleTreeCard.tsx
@@ -1,23 +1,20 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { SxProps } from '@mui/material';
+import type { PlantLocationMulti } from '../../../../common/types/plantLocation';
+import type { SampleTree } from '../../../../common/types/plantLocation';
+import type { Control, FieldArrayWithId, FieldErrors } from 'react-hook-form';
+
+import React from 'react';
 import { useTranslations } from 'next-intl';
 import styles from '../Import.module.scss';
 import DeleteIcon from '../../../../../../public/assets/images/icons/manageProjects/Delete';
-import {
-  Control,
-  Controller,
-  FieldArrayWithId,
-  FieldErrors,
-} from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import { localeMapForDate } from '../../../../../utils/language/getLanguageName';
-import { InputAdornment, MenuItem, SxProps, TextField } from '@mui/material';
-
+import { InputAdornment, MenuItem, TextField } from '@mui/material';
 import { MobileDatePicker as MuiDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import themeProperties from '../../../../../theme/themeProperties';
-import { PlantLocationMulti } from '../../../../common/types/plantLocation';
-
-import { SampleTree } from '../../../../common/types/plantLocation';
 
 const dialogSx: SxProps = {
   '& .MuiButtonBase-root.MuiPickersDay-root.Mui-selected': {

--- a/src/features/user/TreeMapper/Import/components/SampleTrees.tsx
+++ b/src/features/user/TreeMapper/Import/components/SampleTrees.tsx
@@ -1,4 +1,14 @@
-import React, { ReactElement, useState } from 'react';
+import type { ReactElement } from 'react';
+import type { APIError } from '@planet-sdk/common';
+import type { Geometry } from '@turf/turf';
+import type { FileImportError } from '../../../BulkCodes/BulkCodesTypes';
+import type {
+  Measurements,
+  PlantLocationMulti,
+  SampleTree,
+} from '../../../../common/types/plantLocation';
+
+import React, { useState } from 'react';
 import styles from '../Import.module.scss';
 import { useDropzone } from 'react-dropzone';
 import { postAuthenticatedRequest } from '../../../../../utils/apiRequests/api';
@@ -7,17 +17,10 @@ import { useTranslations } from 'next-intl';
 import { useForm, useFieldArray } from 'react-hook-form';
 import SampleTreeCard from './SampleTreeCard';
 import Papa from 'papaparse';
-import { handleError, APIError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { ErrorHandlingContext } from '../../../../common/Layout/ErrorHandlingContext';
 import { Button } from '@mui/material';
 import { useTenant } from '../../../../common/Layout/TenantContext';
-import {
-  Measurements,
-  PlantLocationMulti,
-  SampleTree,
-} from '../../../../common/types/plantLocation';
-import { Geometry } from '@turf/turf';
-import { FileImportError } from '../../../BulkCodes/BulkCodesTypes';
 
 interface Props {
   handleNext: Function;

--- a/src/features/user/TreeMapper/Import/index.tsx
+++ b/src/features/user/TreeMapper/Import/index.tsx
@@ -1,4 +1,8 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type { APIError } from '@planet-sdk/common';
+import { type PlantLocation as PlantLocationType } from '../../../common/types/plantLocation';
+
+import React from 'react';
 import { getAuthenticatedRequest } from '../../../../utils/apiRequests/api';
 import PlantingLocation from './components/PlantingLocation';
 import styles from './Import.module.scss';
@@ -15,10 +19,9 @@ import SampleTrees from './components/SampleTrees';
 import ReviewSubmit from './components/ReviewSubmit';
 import dynamic from 'next/dynamic';
 import theme from '../../../../theme/themeProperties';
-import { handleError, APIError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
 import { useTenant } from '../../../common/Layout/TenantContext';
-import { type PlantLocation as PlantLocationType } from '../../../common/types/plantLocation';
 
 const Stepper = styled(MuiStepper)({
   '&': {

--- a/src/features/user/TreeMapper/MySpecies/MySpeciesForm.tsx
+++ b/src/features/user/TreeMapper/MySpecies/MySpeciesForm.tsx
@@ -1,3 +1,9 @@
+import type { APIError } from '@planet-sdk/common';
+import type {
+  Species,
+  SpeciesSuggestionType,
+} from '../../../common/types/plantLocation';
+
 import React from 'react';
 import StyledForm from '../../../common/Layout/StyledForm';
 import TrashIcon from '../../../../../public/assets/images/icons/manageProjects/Trash';
@@ -12,13 +18,9 @@ import styles from './MySpecies.module.scss';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
-import { handleError, APIError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDisplayGroup';
 import { Button, TextField } from '@mui/material';
-import {
-  Species,
-  SpeciesSuggestionType,
-} from '../../../common/types/plantLocation';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 interface NewSpecies {

--- a/src/features/user/TreeMapper/MySpecies/SpeciesAutoComplete.tsx
+++ b/src/features/user/TreeMapper/MySpecies/SpeciesAutoComplete.tsx
@@ -1,13 +1,16 @@
 /* eslint-disable no-use-before-define */
+import type { Control, FieldValues, FieldPath } from 'react-hook-form';
+import type { APIError } from '@planet-sdk/common';
+import type { SpeciesSuggestionType } from '../../../common/types/plantLocation';
+
 import React from 'react';
 import { postRequest } from '../../../../utils/apiRequests/api';
-import { Controller, Control, FieldValues, FieldPath } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import { Autocomplete, TextField } from '@mui/material';
 
 import { useTranslations } from 'next-intl';
-import { handleError, APIError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
-import { SpeciesSuggestionType } from '../../../common/types/plantLocation';
 import { useTenant } from '../../../common/Layout/TenantContext';
 
 interface Props<

--- a/src/features/user/TreeMapper/MySpecies/index.tsx
+++ b/src/features/user/TreeMapper/MySpecies/index.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import DashboardView from '../../../common/Layout/DashboardView';
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
 import MySpeciesForm from './MySpeciesForm';

--- a/src/features/user/TreeMapper/Treemapper.d.ts
+++ b/src/features/user/TreeMapper/Treemapper.d.ts
@@ -1,4 +1,5 @@
-import { DateString } from '../../common/types/common';
+import type { DateString } from '../../common/types/common';
+
 export interface DeviceLocation {
   coordinates: number[];
   type: string;

--- a/src/features/user/TreeMapper/components/Map.tsx
+++ b/src/features/user/TreeMapper/components/Map.tsx
@@ -1,11 +1,20 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type {
+  PlantLocation,
+  PlantLocationMulti,
+  SamplePlantLocation,
+} from '../../../common/types/plantLocation';
+import type { RequiredMapStyle } from '../../../common/types/map';
+import type { ViewPort } from '../../../common/types/ProjectPropsContextInterface';
+import type { MapEvent } from 'react-map-gl';
+
+import React from 'react';
 import styles from '../TreeMapper.module.scss';
 import getMapStyle from '../../../../utils/maps/getMapStyle';
 import * as turf from '@turf/turf';
 import MapGL, {
   FlyToInterpolator,
   Layer,
-  MapEvent,
   Marker,
   NavigationControl,
   Source,
@@ -17,13 +26,6 @@ import { useProjectProps } from '../../../common/Layout/ProjectPropsContext';
 import * as d3 from 'd3-ease';
 import { useRouter } from 'next/router';
 import SatelliteLayer from '../../../projects/components/maps/SatelliteLayer';
-import {
-  PlantLocation,
-  PlantLocationMulti,
-  SamplePlantLocation,
-} from '../../../common/types/plantLocation';
-import { RequiredMapStyle } from '../../../common/types/map';
-import { ViewPort } from '../../../common/types/ProjectPropsContextInterface';
 
 interface Props {
   locations: PlantLocation[] | SamplePlantLocation[] | null;

--- a/src/features/user/TreeMapper/components/PlantLocation.tsx
+++ b/src/features/user/TreeMapper/components/PlantLocation.tsx
@@ -1,3 +1,11 @@
+import type {
+  PlantLocation as PlantLocationType,
+  PlantLocationBase,
+  PlantLocationMulti,
+  PlantLocationSingle,
+} from '../../../common/types/plantLocation';
+import type { SamplePlantLocation } from '../Treemapper';
+
 import React from 'react';
 import formatDate from '../../../../utils/countryCurrency/getFormattedDate';
 import styles from '../TreeMapper.module.scss';
@@ -6,13 +14,6 @@ import * as turf from '@turf/turf';
 import { localizedAbbreviatedNumber } from '../../../../utils/getFormattedNumber';
 import TreeIcon from '../../../../../public/assets/images/icons/TreeIcon';
 import { useRouter } from 'next/router';
-import {
-  PlantLocation as PlantLocationType,
-  PlantLocationBase,
-  PlantLocationMulti,
-  PlantLocationSingle,
-} from '../../../common/types/plantLocation';
-import { SamplePlantLocation } from '../Treemapper';
 
 interface Props {
   location: Object;

--- a/src/features/user/TreeMapper/components/PlantLocationPage.tsx
+++ b/src/features/user/TreeMapper/components/PlantLocationPage.tsx
@@ -1,4 +1,13 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import type {
+  PlantLocation,
+  PlantLocationMulti,
+  PlantLocationSingle,
+  SamplePlantLocation,
+} from '../../../common/types/plantLocation';
+import type { SetState } from '../../../common/types/common';
+
+import React from 'react';
 import formatDate from '../../../../utils/countryCurrency/getFormattedDate';
 import styles from '../TreeMapper.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
@@ -7,13 +16,6 @@ import { getFormattedNumber } from '../../../../utils/getFormattedNumber';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import CopyToClipboard from '../../../common/CopyToClipboard';
-import {
-  PlantLocation,
-  PlantLocationMulti,
-  PlantLocationSingle,
-  SamplePlantLocation,
-} from '../../../common/types/plantLocation';
-import { SetState } from '../../../common/types/common';
 
 const ImageSlider = dynamic(
   () => import('../../../projects/components/PlantLocation/ImageSlider'),

--- a/src/features/user/TreeMapper/components/TreeMapperList.tsx
+++ b/src/features/user/TreeMapper/components/TreeMapperList.tsx
@@ -1,16 +1,18 @@
-import React, { ReactElement } from 'react';
-import TransactionListLoader from '../../../../../public/assets/images/icons/TransactionListLoader';
-import TransactionsNotFound from '../../../../../public/assets/images/icons/TransactionsNotFound';
-import styles from '../TreeMapper.module.scss';
-import { useTranslations } from 'next-intl';
-import {
+import type { ReactElement } from 'react';
+import type { Links } from '../../../common/types/payments';
+import type { SetState } from '../../../common/types/common';
+import type {
   PlantLocation as PlantLocationType,
   PlantLocationSingle,
   PlantLocationMulti,
 } from '../../../common/types/plantLocation';
-import { Links } from '../../../common/types/payments';
+
+import React from 'react';
+import TransactionListLoader from '../../../../../public/assets/images/icons/TransactionListLoader';
+import TransactionsNotFound from '../../../../../public/assets/images/icons/TransactionsNotFound';
+import styles from '../TreeMapper.module.scss';
+import { useTranslations } from 'next-intl';
 import PlantLocation from './PlantLocation';
-import { SetState } from '../../../common/types/common';
 
 interface Props {
   selectedLocation: PlantLocationSingle | PlantLocationMulti | null;

--- a/src/features/user/TreeMapper/index.tsx
+++ b/src/features/user/TreeMapper/index.tsx
@@ -1,4 +1,15 @@
-import React, { ReactElement } from 'react';
+import type { APIError } from '@planet-sdk/common';
+import type {
+  ExtendedScopePlantLocations,
+  PlantLocation as PlantLocationType,
+  PlantLocationMulti,
+  PlantLocationSingle,
+  SamplePlantLocation,
+} from '../../common/types/plantLocation';
+import type { Links } from '../../common/types/payments';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import styles from './TreeMapper.module.scss';
 import dynamic from 'next/dynamic';
 import TreeMapperList from './components/TreeMapperList';
@@ -9,16 +20,8 @@ import TopProgressBar from '../../common/ContentLoaders/TopProgressBar';
 import { useRouter } from 'next/router';
 import { ErrorHandlingContext } from '../../common/Layout/ErrorHandlingContext';
 import { useTranslations } from 'next-intl';
-import { handleError, APIError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../common/Layout/TenantContext';
-import {
-  ExtendedScopePlantLocations,
-  PlantLocation as PlantLocationType,
-  PlantLocationMulti,
-  PlantLocationSingle,
-  SamplePlantLocation,
-} from '../../common/types/plantLocation';
-import { Links } from '../../common/types/payments';
 
 const PlantLocationMap = dynamic(() => import('./components/Map'), {
   loading: () => <p>loading</p>,

--- a/src/features/user/Widget/DonationLink/DonationLinkForm.tsx
+++ b/src/features/user/Widget/DonationLink/DonationLinkForm.tsx
@@ -1,4 +1,8 @@
-import { ReactElement, useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
+import type { ProjectOption } from '../../../common/types/project';
+import type { ExtendedCountryCode } from '../../../common/types/country';
+
+import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import { Button, Switch, TextField } from '@mui/material';
 import AutoCompleteCountry from '../../../common/InputTypes/AutoCompleteCountry';
@@ -14,12 +18,10 @@ import {
   MuiAutoComplete,
   StyledAutoCompleteOption,
 } from '../../../common/InputTypes/MuiAutoComplete';
-import { ProjectOption } from '../../../common/types/project';
 import { allCountries } from '../../../../utils/constants/countries';
 import CustomSnackbar from '../../../common/CustomSnackbar';
 import StyledForm from '../../../common/Layout/StyledForm';
 import QRCode from 'qrcode';
-import { ExtendedCountryCode } from '../../../common/types/country';
 
 interface DonationLinkFormProps {
   projectsList: ProjectOption[] | null;

--- a/src/features/user/Widget/DonationLink/index.tsx
+++ b/src/features/user/Widget/DonationLink/index.tsx
@@ -1,15 +1,18 @@
-import React, { ReactElement, useContext, useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
+import type { ProjectOption } from '../../../common/types/project';
+import type { APIError } from '@planet-sdk/common';
+import type { MapProject } from '../../../common/types/ProjectPropsContextInterface';
+
+import React, { useContext, useEffect, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import { getRequest } from '../../../../utils/apiRequests/api';
 import DashboardView from '../../../common/Layout/DashboardView';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
 import DonationLinkForm from './DonationLinkForm';
 import SingleColumnView from '../../../common/Layout/SingleColumnView';
-import { ProjectOption } from '../../../common/types/project';
 import { useTenant } from '../../../common/Layout/TenantContext';
-import { handleError, APIError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
-import { MapProject } from '../../../common/types/ProjectPropsContextInterface';
 
 export default function DonationLink(): ReactElement | null {
   const { setErrors } = useContext(ErrorHandlingContext);

--- a/src/features/user/Widget/EmbedModal.tsx
+++ b/src/features/user/Widget/EmbedModal.tsx
@@ -1,3 +1,6 @@
+import type { APIError, User } from '@planet-sdk/common';
+import type { AlertColor } from '@mui/lab';
+
 import React from 'react';
 import { Modal, Snackbar, styled } from '@mui/material';
 import MuiAlert from '@mui/material/Alert';
@@ -8,8 +11,7 @@ import { useRouter } from 'next/router';
 import { ThemeContext } from '../../../theme/themeContext';
 import { useUserProps } from '../../common/Layout/UserPropsContext';
 import { ErrorHandlingContext } from '../../common/Layout/ErrorHandlingContext';
-import { handleError, APIError, User } from '@planet-sdk/common';
-import { AlertColor } from '@mui/lab';
+import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../common/Layout/TenantContext';
 
 interface Props {

--- a/src/middlewares/rate-limiter.ts
+++ b/src/middlewares/rate-limiter.ts
@@ -1,4 +1,5 @@
-import { Request } from 'express';
+import type { Request } from 'express';
+
 import rateLimit from 'express-rate-limit';
 import slowDown from 'express-slow-down';
 

--- a/src/server/procedures/myForest/contributions.ts
+++ b/src/server/procedures/myForest/contributions.ts
@@ -1,9 +1,4 @@
-import { procedure } from '../../trpc';
-import prisma from '../../../../prisma/client';
-import { z } from 'zod';
-import { Prisma } from '@prisma/client';
-import { TRPCError } from '@trpc/server';
-import {
+import type {
   BriefProjectQueryResult,
   ContributionStats,
   MyContributionsMapItem,
@@ -16,6 +11,12 @@ import {
   SingleRegistration,
   MySingleContribution,
 } from '../../../features/common/types/myForest';
+
+import { procedure } from '../../trpc';
+import prisma from '../../../../prisma/client';
+import { z } from 'zod';
+import { Prisma } from '@prisma/client';
+import { TRPCError } from '@trpc/server';
 import getPointCoordinates from '../../../utils/getPointCoordinates';
 import { fetchProfile } from '../../utils/fetchProfile';
 import { fetchProfileGroupData } from '../../utils/fetchProfileGroupData';

--- a/src/server/procedures/myForest/leaderboard.ts
+++ b/src/server/procedures/myForest/leaderboard.ts
@@ -1,6 +1,7 @@
+import type { Leaderboard } from '../../../features/common/types/myForest';
+
 import { z } from 'zod';
 import { procedure } from '../../trpc';
-import { Leaderboard } from '../../../features/common/types/myForest';
 import prisma from '../../../../prisma/client';
 import { TRPCError } from '@trpc/server';
 import { Prisma } from '@prisma/client';

--- a/src/server/procedures/myForest/projectList.ts
+++ b/src/server/procedures/myForest/projectList.ts
@@ -1,9 +1,10 @@
-import { procedure } from '../../trpc';
-import prisma from '../../../../prisma/client';
-import {
+import type {
   MyForestProject,
   ProjectQueryResult,
 } from '../../../features/common/types/myForest';
+
+import { procedure } from '../../trpc';
+import prisma from '../../../../prisma/client';
 
 export const projectListsProcedure = procedure.query(async () => {
   // Get the list of projects

--- a/src/server/utils/fetchProfileGroupData.ts
+++ b/src/server/utils/fetchProfileGroupData.ts
@@ -1,5 +1,6 @@
+import type { ProfileGroupQueryResult } from '../../features/common/types/myForest';
+
 import prisma from '../../../prisma/client';
-import { ProfileGroupQueryResult } from '../../features/common/types/myForest';
 
 export async function fetchProfileGroupData(profileId: number) {
   const data = await prisma.$queryRaw<ProfileGroupQueryResult[]>`

--- a/src/temp/icons/CalendarIcon.tsx
+++ b/src/temp/icons/CalendarIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../features/common/types/common';
 
 const CalendarIcon = ({ width, color }: IconProps) => {
   return (

--- a/src/temp/icons/DropdownDownArrow.tsx
+++ b/src/temp/icons/DropdownDownArrow.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../features/common/types/common';
 
 const DropdownDownArrow = ({ width }: IconProps) => {
   return (

--- a/src/temp/icons/DropdownUpArrow.tsx
+++ b/src/temp/icons/DropdownUpArrow.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../features/common/types/common';
 
 const DropdownUpArrow = ({ width }: IconProps) => {
   return (

--- a/src/temp/icons/FieldDataIcon.tsx
+++ b/src/temp/icons/FieldDataIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../features/common/types/common';
 
 const FieldDataIcon = ({ color, width, height }: IconProps) => {
   return (

--- a/src/temp/icons/FireIcon.tsx
+++ b/src/temp/icons/FireIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../features/common/types/common';
 
 const FireIcon = ({ width }: IconProps) => {
   return (

--- a/src/temp/icons/FirePopupIcon.tsx
+++ b/src/temp/icons/FirePopupIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../features/common/types/common';
 
 const FirePopupIcon = ({ width }: IconProps) => {
   return (

--- a/src/temp/icons/SatelliteAnalysisIcon.tsx
+++ b/src/temp/icons/SatelliteAnalysisIcon.tsx
@@ -1,5 +1,6 @@
+import type { IconProps } from '../../features/common/types/common';
+
 import React from 'react';
-import { IconProps } from '../../features/common/types/common';
 
 const SatelliteAnalysisIcon = ({ color, width }: IconProps) => {
   return (

--- a/src/tenants/common/Home/index.tsx
+++ b/src/tenants/common/Home/index.tsx
@@ -1,3 +1,8 @@
+import type {
+  LeaderBoardList,
+  TenantScore,
+} from '../../../features/common/types/leaderboard';
+
 import styles from './Home.module.scss';
 import LandingSection from '../../../features/common/Layout/LandingSection';
 import LeaderBoard from '../LeaderBoard';
@@ -6,10 +11,6 @@ import Footer from '../../../features/common/Layout/Footer';
 import React from 'react';
 import { useTenant } from '../../../features/common/Layout/TenantContext';
 import { useTranslations } from 'next-intl';
-import {
-  LeaderBoardList,
-  TenantScore,
-} from '../../../features/common/types/leaderboard';
 
 interface Props {
   leaderboard: LeaderBoardList | null;

--- a/src/tenants/common/LeaderBoard/index.tsx
+++ b/src/tenants/common/LeaderBoard/index.tsx
@@ -1,8 +1,9 @@
+import type { LeaderBoardList } from '../../../features/common/types/leaderboard';
+
 import React from 'react';
 import styles from './LeaderBoard.module.scss';
 import { getFormattedNumber } from '../../../utils/getFormattedNumber';
 import { useLocale, useTranslations } from 'next-intl';
-import { LeaderBoardList } from '../../../features/common/types/leaderboard';
 
 interface Props {
   leaderboard: LeaderBoardList | null;

--- a/src/tenants/planet/LeaderBoard/components/Score.tsx
+++ b/src/tenants/planet/LeaderBoard/components/Score.tsx
@@ -1,3 +1,5 @@
+import type { APIError } from '@planet-sdk/common';
+
 import React from 'react';
 import styles from './LeaderBoard.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
@@ -7,11 +9,10 @@ import MaterialTextField from '../../../../features/common/InputTypes/MaterialTe
 import { postRequest } from '../../../../utils/apiRequests/api';
 import Link from 'next/link';
 import getImageUrl from '../../../../utils/getImageURL';
-
 import SearchIcon from '../../../../../public/assets/images/icons/SearchIcon';
 import getRandomImage from '../../../../utils/getRandomImage';
 import { ErrorHandlingContext } from '../../../../features/common/Layout/ErrorHandlingContext';
-import { handleError, APIError } from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import { MuiAutoComplete } from '../../../../features/common/InputTypes/MuiAutoComplete';
 import { useTenant } from '../../../../features/common/Layout/TenantContext';
 

--- a/src/tenants/planet/LeaderBoard/components/Stats.tsx
+++ b/src/tenants/planet/LeaderBoard/components/Stats.tsx
@@ -1,21 +1,26 @@
+import type { ReactElement } from 'react';
+import type {
+  TenantScore,
+  TreesDonated,
+} from '../../../../features/common/types/leaderboard';
+
 import { Modal } from '@mui/material';
-import React, { ReactElement } from 'react';
+import React from 'react';
 import InfoIcon from '../../../../../public/assets/images/icons/InfoIcon';
 import styles from './Stats.module.scss';
 import StatsInfoModal from './StatsInfoModal';
 import { useLocale, useTranslations } from 'next-intl';
 import { localizedAbbreviatedNumber } from '../../../../utils/getFormattedNumber';
 import { ThemeContext } from '../../../../theme/themeContext';
-import {
-  TenantScore,
-  TreesDonated,
-} from '../../../../features/common/types/leaderboard';
 
 interface Props {
   tenantScore: TenantScore;
   treesDonated: TreesDonated;
 }
-export default function Stats({ tenantScore, treesDonated }: Props): ReactElement {
+export default function Stats({
+  tenantScore,
+  treesDonated,
+}: Props): ReactElement {
   const [infoExpanded, setInfoExpanded] = React.useState<String | null>(null);
   const tPlanet = useTranslations('Planet');
   const locale = useLocale();
@@ -30,7 +35,11 @@ export default function Stats({ tenantScore, treesDonated }: Props): ReactElemen
       <div className={styles.container}>
         <div className={styles.statCard}>
           <h2 className={styles.statNumber}>
-            {localizedAbbreviatedNumber(locale, Number(treesDonated.trees_since_2019), 2)}
+            {localizedAbbreviatedNumber(
+              locale,
+              Number(treesDonated.trees_since_2019),
+              2
+            )}
           </h2>
           <h3 className={styles.statText}>{tPlanet('treesDonated')}</h3>
           <button

--- a/src/tenants/planet/LeaderBoard/components/StatsInfoModal.tsx
+++ b/src/tenants/planet/LeaderBoard/components/StatsInfoModal.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import styles from './Stats.module.scss';
 import { useTranslations } from 'next-intl';
 import OpenLink from '../../../../../public/assets/images/icons/OpenLink';

--- a/src/tenants/planet/LeaderBoard/components/Stories.tsx
+++ b/src/tenants/planet/LeaderBoard/components/Stories.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import styles from './Stories.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
 import { lang_path } from '../../../../utils/constants/wpLanguages';

--- a/src/tenants/planet/LeaderBoard/components/Video.tsx
+++ b/src/tenants/planet/LeaderBoard/components/Video.tsx
@@ -1,5 +1,7 @@
 // Not used currently. Left as a reference.
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import styles from './Video.module.scss';
 import { useTranslations } from 'next-intl';
 import ReactPlayer from 'react-player/lazy';

--- a/src/tenants/planet/LeaderBoard/index.tsx
+++ b/src/tenants/planet/LeaderBoard/index.tsx
@@ -1,13 +1,15 @@
-import React, { ReactElement } from 'react';
-import Footer from '../../../features/common/Layout/Footer';
-import Score from './components/Score';
-import Stats from './components/Stats';
-import Stories from './components/Stories';
-import {
+import type { ReactElement } from 'react';
+import type {
   LeaderBoardList,
   TenantScore,
   TreesDonated,
 } from '../../../features/common/types/leaderboard';
+
+import React from 'react';
+import Footer from '../../../features/common/Layout/Footer';
+import Score from './components/Score';
+import Stats from './components/Stats';
+import Stories from './components/Stories';
 
 interface Props {
   leaderboard: LeaderBoardList | null;
@@ -23,7 +25,9 @@ export default function index({
   return (
     <div>
       <Score leaderboard={leaderboard} />
-      {(tenantScore && treesDonated) && <Stats tenantScore={tenantScore} treesDonated={treesDonated}/>}
+      {tenantScore && treesDonated && (
+        <Stats tenantScore={tenantScore} treesDonated={treesDonated} />
+      )}
       <Stories />
       <Footer />
     </div>

--- a/src/tenants/salesforce/Home/index.tsx
+++ b/src/tenants/salesforce/Home/index.tsx
@@ -1,3 +1,8 @@
+import type {
+  LeaderBoardList,
+  TenantScore,
+} from '../../../features/common/types/leaderboard';
+
 import Head from 'next/head';
 import Footer from '../../../features/common/Layout/Footer';
 import Landing from './components/Landing';
@@ -9,10 +14,6 @@ import ClimateAction from './components/ClimateAction';
 import Social from './components/Social';
 import React from 'react';
 import { useTenant } from '../../../features/common/Layout/TenantContext';
-import {
-  LeaderBoardList,
-  TenantScore,
-} from '../../../features/common/types/leaderboard';
 
 interface Props {
   leaderboard: LeaderBoardList | null;

--- a/src/tenants/salesforce/Mangroves/components/ProjectGrid.tsx
+++ b/src/tenants/salesforce/Mangroves/components/ProjectGrid.tsx
@@ -1,3 +1,6 @@
+import type { MapProject } from '../../../../features/common/types/ProjectPropsContextInterface';
+import type { APIError } from '@planet-sdk/common/build/types/errors';
+
 import React, { useEffect, useState } from 'react';
 import { ErrorHandlingContext } from '../../../../features/common/Layout/ErrorHandlingContext';
 import { getRequest } from '../../../../utils/apiRequests/api';
@@ -5,9 +8,7 @@ import getStoredCurrency from '../../../../utils/countryCurrency/getStoredCurren
 import gridStyles from './../styles/Grid.module.scss';
 import styles from './../styles/ProjectGrid.module.scss';
 import ProjectSnippet from '../../../../features/projects/components/ProjectSnippet';
-import { MapProject } from '../../../../features/common/types/ProjectPropsContextInterface';
 import { handleError } from '@planet-sdk/common/build/utils/handleError';
-import { APIError } from '@planet-sdk/common/build/types/errors';
 import { useTenant } from '../../../../features/common/Layout/TenantContext';
 
 const MANGROVE_PROJECTS = [

--- a/src/tenants/salesforce/OceanforceCampaign/components/ContentSection.tsx
+++ b/src/tenants/salesforce/OceanforceCampaign/components/ContentSection.tsx
@@ -1,14 +1,15 @@
+import type {
+  APIError,
+  TreeProjectExtended,
+  ConservationProjectExtended,
+} from '@planet-sdk/common';
+
 import { useContext, useEffect, useState } from 'react';
 import gridStyles from './../styles/Grid.module.scss';
 import styles from './../styles/ContentSection.module.scss';
 import { ErrorHandlingContext } from '../../../../features/common/Layout/ErrorHandlingContext';
 import getStoredCurrency from '../../../../utils/countryCurrency/getStoredCurrency';
-import {
-  handleError,
-  APIError,
-  TreeProjectExtended,
-  ConservationProjectExtended,
-} from '@planet-sdk/common';
+import { handleError } from '@planet-sdk/common';
 import ProjectSnippet from '../../../../features/projects/components/ProjectSnippet';
 import { getRequest } from '../../../../utils/apiRequests/api';
 import { useTenant } from '../../../../features/common/Layout/TenantContext';

--- a/src/tenants/salesforce/VTOCampaign/components/ProjectGrid.tsx
+++ b/src/tenants/salesforce/VTOCampaign/components/ProjectGrid.tsx
@@ -1,3 +1,6 @@
+import type { MapProject } from '../../../../features/common/types/ProjectPropsContextInterface';
+import type { APIError } from '@planet-sdk/common/build/types/errors';
+
 import React, { useEffect, useState } from 'react';
 import { ErrorHandlingContext } from '../../../../features/common/Layout/ErrorHandlingContext';
 import { getRequest } from '../../../../utils/apiRequests/api';
@@ -5,9 +8,7 @@ import getStoredCurrency from '../../../../utils/countryCurrency/getStoredCurren
 import gridStyles from './../styles/Grid.module.scss';
 import styles from './../styles/ProjectGrid.module.scss';
 import ProjectSnippet from '../../../../features/projects/components/ProjectSnippet';
-import { MapProject } from '../../../../features/common/types/ProjectPropsContextInterface';
 import { handleError } from '@planet-sdk/common/build/utils/handleError';
-import { APIError } from '@planet-sdk/common/build/types/errors';
 import { useTenant } from '../../../../features/common/Layout/TenantContext';
 
 export default function ProjectGrid() {

--- a/src/tenants/salesforce/VTOCampaign2023/components/ProjectGrid.tsx
+++ b/src/tenants/salesforce/VTOCampaign2023/components/ProjectGrid.tsx
@@ -1,3 +1,6 @@
+import type { MapProject } from '../../../../features/common/types/ProjectPropsContextInterface';
+import type { APIError } from '@planet-sdk/common/build/types/errors';
+
 import React, { useEffect, useState } from 'react';
 import { ErrorHandlingContext } from '../../../../features/common/Layout/ErrorHandlingContext';
 import { getRequest } from '../../../../utils/apiRequests/api';
@@ -5,9 +8,7 @@ import getStoredCurrency from '../../../../utils/countryCurrency/getStoredCurren
 import gridStyles from './../styles/Grid.module.scss';
 import styles from './../styles/ProjectGrid.module.scss';
 import ProjectSnippet from '../../../../features/projects/components/ProjectSnippet';
-import { MapProject } from '../../../../features/common/types/ProjectPropsContextInterface';
 import { handleError } from '@planet-sdk/common/build/utils/handleError';
-import { APIError } from '@planet-sdk/common/build/types/errors';
 import { useTenant } from '../../../../features/common/Layout/TenantContext';
 
 export default function ProjectGrid() {

--- a/src/tenants/stern/Home/index.tsx
+++ b/src/tenants/stern/Home/index.tsx
@@ -1,13 +1,14 @@
+import type {
+  LeaderBoardList,
+  TenantScore,
+} from '../../../features/common/types/leaderboard';
+
 import styles from './Home.module.scss';
 import LandingSection from '../../../features/common/Layout/LandingSection';
 import LeaderBoard from '../../common/LeaderBoard';
 import TreeCounter from '../../../features/common/TreeCounter/TreeCounter';
 import Footer from '../../../features/common/Layout/Footer';
 import { useTenant } from '../../../features/common/Layout/TenantContext';
-import {
-  LeaderBoardList,
-  TenantScore,
-} from '../../../features/common/types/leaderboard';
 
 interface Props {
   leaderboard: LeaderBoardList | null;

--- a/src/theme/themeContext.tsx
+++ b/src/theme/themeContext.tsx
@@ -1,4 +1,6 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+
+import React from 'react';
 import { useTenant } from '../features/common/Layout/TenantContext';
 
 export const ThemeContext = React.createContext({

--- a/src/utils/apiRequests/api.ts
+++ b/src/utils/apiRequests/api.ts
@@ -1,8 +1,9 @@
+import type { ImpersonationData } from '../../features/user/Settings/ImpersonateUser/ImpersonateUserForm';
+
 import { getQueryString } from './getQueryString';
 import getsessionId from './getSessionId';
 import { APIError, ClientError } from '@planet-sdk/common';
 import { validateToken } from './validateToken';
-import { ImpersonationData } from '../../features/user/Settings/ImpersonateUser/ImpersonateUserForm';
 import { setHeaderForImpersonation } from './setHeader';
 
 const INVALID_TOKEN_STATUS_CODE = 498;

--- a/src/utils/apiRequests/isApiCustomError.ts
+++ b/src/utils/apiRequests/isApiCustomError.ts
@@ -1,4 +1,4 @@
-import { ApiCustomError } from '../../features/common/types/apiErrors';
+import type { ApiCustomError } from '../../features/common/types/apiErrors';
 
 /**
  * Checks if res contains an error_code property.

--- a/src/utils/apiRequests/setHeader.ts
+++ b/src/utils/apiRequests/setHeader.ts
@@ -1,4 +1,4 @@
-import { ImpersonationData } from '../../features/user/Settings/ImpersonateUser/ImpersonateUserForm';
+import type { ImpersonationData } from '../../features/user/Settings/ImpersonateUser/ImpersonateUserForm';
 /**
  * Sets keys for header in impersonation mode
  */

--- a/src/utils/apiRequests/validateToken.ts
+++ b/src/utils/apiRequests/validateToken.ts
@@ -1,4 +1,6 @@
-import jwt_decode, { JwtPayload } from 'jwt-decode';
+import type { JwtPayload } from 'jwt-decode';
+
+import jwt_decode from 'jwt-decode';
 
 export const validateToken = (token: string): boolean => {
   try {

--- a/src/utils/constants/countries.ts
+++ b/src/utils/constants/countries.ts
@@ -1,4 +1,4 @@
-import { CountryType } from '../../features/common/types/country';
+import type { CountryType } from '../../features/common/types/country';
 
 // From https://bitbucket.org/atlassian/atlaskit-mk-2/raw/4ad0e56649c3e6c973e226b7efaeb28cb240ccb0/packages/core/select/src/data/countries.js
 export const allCountries: CountryType[] = [

--- a/src/utils/getMetaTags/GetHomeMeta.tsx
+++ b/src/utils/getMetaTags/GetHomeMeta.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import { useTenant } from '../../features/common/Layout/TenantContext';
 import Head from 'next/head';
 

--- a/src/utils/getMetaTags/GetLeaderboardMeta.tsx
+++ b/src/utils/getMetaTags/GetLeaderboardMeta.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+
+import React from 'react';
 import { useTenant } from '../../features/common/Layout/TenantContext';
 import Head from 'next/head';
 

--- a/src/utils/getMetaTags/GetPublicUserProfileMeta.tsx
+++ b/src/utils/getMetaTags/GetPublicUserProfileMeta.tsx
@@ -1,7 +1,9 @@
-import React, { ReactElement } from 'react';
-import { useTenant } from '../../features/common/Layout/TenantContext';
+import type { UserPublicProfile } from '@planet-sdk/common';
+import type { ReactElement } from 'react';
+
 import Head from 'next/head';
-import { UserPublicProfile } from '@planet-sdk/common';
+import React from 'react';
+import { useTenant } from '../../features/common/Layout/TenantContext';
 
 interface Props {
   userprofile: UserPublicProfile | null;

--- a/src/utils/getPointCoordinates.ts
+++ b/src/utils/getPointCoordinates.ts
@@ -1,5 +1,6 @@
+import type { Point, Polygon, Position } from 'geojson';
+
 import { centerOfMass, multiPoint } from '@turf/turf';
-import { Point, Polygon, Position } from 'geojson';
 
 /**
  * Converts a GeoJSON Polygon or Point geometry to a Point geometry

--- a/src/utils/language/getLanguageName.ts
+++ b/src/utils/language/getLanguageName.ts
@@ -1,3 +1,5 @@
+import type Locale from '@date-io/date-fns';
+
 import supportedLanguages from './supportedLanguages.json';
 import enLocale from 'date-fns/locale/en-US';
 import deLocale from 'date-fns/locale/de';
@@ -6,7 +8,6 @@ import esLocale from 'date-fns/locale/es';
 import frLocale from 'date-fns/locale/fr';
 import itLocale from 'date-fns/locale/it';
 import ptBRLocale from 'date-fns/locale/pt-BR';
-import Locale from '@date-io/date-fns';
 
 /**
  * * Returns country details by searching country data json file and options

--- a/src/utils/language/getMessagesForPage.ts
+++ b/src/utils/language/getMessagesForPage.ts
@@ -1,5 +1,6 @@
+import type { AbstractIntlMessages } from 'next-intl';
+
 import deepmerge from 'deepmerge';
-import { AbstractIntlMessages } from 'next-intl';
 
 // Update this when a new file is added
 type TRANSLATION_FILE_NAMES =

--- a/src/utils/maps/plantLocations.ts
+++ b/src/utils/maps/plantLocations.ts
@@ -1,12 +1,14 @@
+import type { APIError, SerializedError } from '@planet-sdk/common';
+import type { SetState } from '../../features/common/types/common';
+import type { PlantLocation } from '../../features/common/types/plantLocation';
+import type { Position } from 'geojson';
+import type { ViewPort } from '../../features/common/types/ProjectPropsContextInterface';
+
 import { FlyToInterpolator, WebMercatorViewport } from 'react-map-gl';
 import * as d3 from 'd3-ease';
 import * as turf from '@turf/turf';
 import { getRequest } from '../apiRequests/api';
-import { handleError, APIError, SerializedError } from '@planet-sdk/common';
-import { SetState } from '../../features/common/types/common';
-import { PlantLocation } from '../../features/common/types/plantLocation';
-import { Position } from 'geojson';
-import { ViewPort } from '../../features/common/types/ProjectPropsContextInterface';
+import { handleError } from '@planet-sdk/common';
 /**
  * Zooms the map to a multiple tree plant location
  * @param {Position} coordinates

--- a/src/utils/maps/zoomToLocation.ts
+++ b/src/utils/maps/zoomToLocation.ts
@@ -1,7 +1,8 @@
+import type { ViewPort } from '../../features/common/types/ProjectPropsContextInterface';
+import type { SetState } from '../../features/common/types/common';
+
 import { FlyToInterpolator } from 'react-map-gl';
 import * as d3 from 'd3-ease';
-import { ViewPort } from '../../features/common/types/ProjectPropsContextInterface';
-import { SetState } from '../../features/common/types/common';
 
 export default function zoomToLocation(
   viewport: ViewPort,

--- a/src/utils/maps/zoomToProjectSite.ts
+++ b/src/utils/maps/zoomToProjectSite.ts
@@ -1,12 +1,13 @@
-import { FlyToInterpolator, WebMercatorViewport } from 'react-map-gl';
-import * as d3 from 'd3-ease';
-import * as turf from '@turf/turf';
-import {
+import type {
   SiteViewPort,
   SitesGeoJSON,
   ViewPort,
 } from '../../features/common/types/ProjectPropsContextInterface';
-import { SetState } from '../../features/common/types/common';
+import type { SetState } from '../../features/common/types/common';
+
+import { FlyToInterpolator, WebMercatorViewport } from 'react-map-gl';
+import * as d3 from 'd3-ease';
+import * as turf from '@turf/turf';
 
 export default function zoomToProjectSite(
   geoJson: SitesGeoJSON | null,

--- a/src/utils/multiTenancy/helpers.ts
+++ b/src/utils/multiTenancy/helpers.ts
@@ -1,4 +1,5 @@
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
 import redisClient from '../../redis-client';
 import { cacheKeyPrefix } from '../constants/cacheKeyPrefix';
 

--- a/src/utils/myForestUtils.ts
+++ b/src/utils/myForestUtils.ts
@@ -1,11 +1,11 @@
-import { ProjectPurposeTypes, UnitTypes } from '@planet-sdk/common';
-import { ExtractedProjectData } from '../features/user/Profile/ContributionsMap/Markers/DonationClusterMarker';
-import themeProperties from '../theme/themeProperties';
-import { PointFeature } from 'supercluster';
-import { DonationProperties } from '../features/common/types/myForest';
-import { ProgressDataType } from '../features/user/Profile/ForestProgress/ForestProgressItem';
-import { ContributionStats } from '../features/common/types/myForest';
+import type { ProjectPurposeTypes, UnitTypes } from '@planet-sdk/common';
+import type { ExtractedProjectData } from '../features/user/Profile/ContributionsMap/Markers/DonationClusterMarker';
+import type { PointFeature } from 'supercluster';
+import type { DonationProperties } from '../features/common/types/myForest';
+import type { ProgressDataType } from '../features/user/Profile/ForestProgress/ForestProgressItem';
+import type { ContributionStats } from '../features/common/types/myForest';
 
+import themeProperties from '../theme/themeProperties';
 export type Accumulator = {
   maxContributionCount: number;
   maxContributingObject: ExtractedProjectData | null;

--- a/src/utils/selectUserType.ts
+++ b/src/utils/selectUserType.ts
@@ -1,4 +1,4 @@
-import { UserType } from '@planet-sdk/common';
+import type { UserType } from '@planet-sdk/common';
 
 /**
  * Returns translated value of `type`

--- a/src/utils/storeConfig.ts
+++ b/src/utils/storeConfig.ts
@@ -1,6 +1,7 @@
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+
 import getsessionId from './apiRequests/getSessionId';
 import countriesData from '../utils/countryCurrency/countriesData.json';
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
 
 export async function storeConfig(tenantConfig: Tenant) {
   await fetch(`${process.env.CONFIG_URL}`, {

--- a/src/utils/superclusterConfig.ts
+++ b/src/utils/superclusterConfig.ts
@@ -1,12 +1,14 @@
-import { Bound } from '../features/common/types/map';
-import Supercluster, { ClusterProperties, PointFeature } from 'supercluster';
-import { RefObject } from 'react';
-import { MapRef } from 'react-map-gl';
-import {
+import type { Bound } from '../features/common/types/map';
+import type { ClusterProperties, PointFeature } from 'supercluster';
+import type { RefObject } from 'react';
+import type { MapRef } from 'react-map-gl';
+import type {
   DonationProperties,
   MyContributionsSingleRegistration,
 } from '../features/common/types/myForest';
-import { ViewState } from 'react-map-gl-v7/maplibre';
+import type { ViewState } from 'react-map-gl-v7/maplibre';
+
+import Supercluster from 'supercluster';
 
 const clusterConfig = {
   radius: 40,

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -1,6 +1,7 @@
+import type { AppRouter } from '../server/router/_app';
+
 import { httpBatchLink } from '@trpc/client';
 import { createTRPCNext } from '@trpc/next';
-import { AppRouter } from '../server/router/_app';
 import superjson from 'superjson';
 
 function getBaseUrl() {

--- a/src/utils/trpcHelpers.ts
+++ b/src/utils/trpcHelpers.ts
@@ -1,9 +1,10 @@
-import { SerializedError } from '@planet-sdk/common';
-import { SetState } from '../features/common/types/common';
-import {
+import type { SerializedError } from '@planet-sdk/common';
+import type { SetState } from '../features/common/types/common';
+import type {
   TrpcQueryResult,
   TrpcQueryResultError,
 } from '../features/common/types/trpc';
+
 import { handleError, APIError } from '@planet-sdk/common';
 
 export const updateStateWithTrpcData = <

--- a/tenant.config.ts
+++ b/tenant.config.ts
@@ -1,4 +1,4 @@
-import { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
 export const defaultTenant: Tenant = {
   id: 'ten_NxJq55pm',


### PR DESCRIPTION
This pull request updates the codebase to enforce the use of` import type `for type-only imports, aligning with the `@typescript-eslint/consistent-type-imports` ESLint rule. This change was applied automatically using ESLint's --fix functionality for efficiency and consistency.

Key Changes:

- Added import type to all type-only imports across the codebase.
- Ensured compliance with the TypeScript best practices for distinguishing type imports from value imports.
- Improved code clarity and alignment with project coding standards.