### PR TITLE
Address mgmt/remove billing address option

### DIFF
--- a/public/static/locales/en/editProfile.json
+++ b/public/static/locales/en/editProfile.json
@@ -80,6 +80,7 @@
         "delete": "Delete",
         "setAsPrimaryAddress": "Set as Primary Address",
         "setAsBillingAddress": "Set as Billing Address",
+        "unsetBillingAddress": "Unset Billing Address",
         "addAddress": "Add New Address"
       },
       "deleteAction": {
@@ -90,7 +91,8 @@
       "updateAddressType": {
         "setAddressConfirmation": "Are you sure you want to set this address as your {addressType}?",
         "replaceAddressWarning": "This will replace your current {addressType}.",
-        "confirmButton": "Confirm"
+        "confirmButton": "Confirm",
+        "unsetBillingAddressMessage": "Do you want to unset your billing address? Your primary address will be used as billing address."
       },
       "maxAddressesMessage": "You have reached the maximum number of addresses! Remove one to add a new address.",
       "addressForm": {

--- a/src/features/user/Settings/EditProfile/AddressManagment/UnsetBillingAddress.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagment/UnsetBillingAddress.tsx
@@ -12,6 +12,7 @@ import { ErrorHandlingContext } from '../../../../common/Layout/ErrorHandlingCon
 import { putAuthenticatedRequest } from '../../../../../utils/apiRequests/api';
 import { useUserProps } from '../../../../common/Layout/UserPropsContext';
 import { useTenant } from '../../../../common/Layout/TenantContext';
+import { ADDRESS_TYPE } from '../../../../../utils/addressManagement';
 
 interface Props {
   addressType: 'mailing';
@@ -39,7 +40,7 @@ const UnsetBillingAddress = ({
     if (!contextLoaded || !user || !token) return;
     setIsLoading(true);
     const bodyToSend = {
-      type: 'other',
+      type: ADDRESS_TYPE.OTHER,
     };
     try {
       const res = await putAuthenticatedRequest<Address>(

--- a/src/features/user/Settings/EditProfile/AddressManagment/UnsetBillingAddress.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagment/UnsetBillingAddress.tsx
@@ -1,0 +1,98 @@
+import type { Address, APIError } from '@planet-sdk/common';
+import type { SetState } from '../../../../common/types/common';
+import type { AddressAction } from '../../../../common/types/profile';
+
+import { useContext, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { CircularProgress } from '@mui/material';
+import { handleError } from '@planet-sdk/common';
+import styles from './AddressManagement.module.scss';
+import WebappButton from '../../../../common/WebappButton';
+import { ErrorHandlingContext } from '../../../../common/Layout/ErrorHandlingContext';
+import { putAuthenticatedRequest } from '../../../../../utils/apiRequests/api';
+import { useUserProps } from '../../../../common/Layout/UserPropsContext';
+import { useTenant } from '../../../../common/Layout/TenantContext';
+
+interface Props {
+  addressType: 'mailing';
+  setIsModalOpen: SetState<boolean>;
+  setAddressAction: SetState<AddressAction | null>;
+  updateUserAddresses: () => Promise<void>;
+  selectedAddressForAction: Address | null;
+}
+
+const UnsetBillingAddress = ({
+  addressType,
+  setIsModalOpen,
+  setAddressAction,
+  updateUserAddresses,
+  selectedAddressForAction,
+}: Props) => {
+  const tAddressManagement = useTranslations('EditProfile.addressManagement');
+  const tCommon = useTranslations('Common');
+  const { contextLoaded, user, token, logoutUser } = useUserProps();
+  const { setErrors } = useContext(ErrorHandlingContext);
+  const { tenantConfig } = useTenant();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const unsetAddress = async () => {
+    if (!contextLoaded || !user || !token) return;
+    setIsLoading(true);
+    const bodyToSend = {
+      type: 'other',
+    };
+    try {
+      const res = await putAuthenticatedRequest<Address>(
+        tenantConfig.id,
+        `/app/addresses/${selectedAddressForAction?.id}`,
+        bodyToSend,
+        token,
+        logoutUser
+      );
+      if (res) updateUserAddresses();
+    } catch (error) {
+      setErrors(handleError(error as APIError));
+    } finally {
+      setIsLoading(false);
+      setIsModalOpen(false);
+      setAddressAction(null);
+    }
+  };
+
+  const handleCancel = () => {
+    setIsModalOpen(false);
+    setAddressAction(null);
+  };
+  return (
+    <div className={styles.addressActionContainer}>
+      <h2 className={styles.header}>
+        {tAddressManagement(`addressType.${addressType}`)}
+      </h2>
+      <p>
+        {tAddressManagement('updateAddressType.unsetBillingAddressMessage')}
+      </p>
+      {!isLoading ? (
+        <div className={styles.buttonContainer}>
+          <WebappButton
+            text={tCommon('cancel')}
+            elementType="button"
+            variant="secondary"
+            onClick={handleCancel}
+          />
+          <WebappButton
+            text={tAddressManagement('updateAddressType.confirmButton')}
+            elementType="button"
+            variant="primary"
+            onClick={unsetAddress}
+          />
+        </div>
+      ) : (
+        <div className={styles.addressMgmtSpinner}>
+          <CircularProgress color="success" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default UnsetBillingAddress;

--- a/src/features/user/Settings/EditProfile/AddressManagment/index.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagment/index.tsx
@@ -24,6 +24,7 @@ import UpdateAddressType from './UpdateAddressType';
 import DeleteAddress from './DeleteAddress';
 import EditAddress from './EditAddress';
 import AddAddress from './AddAddress';
+import UnsetBillingAddress from './UnsetBillingAddress';
 
 const AddressManagement = () => {
   const { user, contextLoaded, token, logoutUser } = useUserProps();
@@ -124,6 +125,16 @@ const AddressManagement = () => {
             setIsModalOpen={setIsModalOpen}
             selectedAddressForAction={selectedAddressForAction}
             updateUserAddresses={updateUserAddresses}
+          />
+        );
+      case ADDRESS_ACTIONS.UNSET_BILLING:
+        return (
+          <UnsetBillingAddress
+            addressType={ADDRESS_TYPE.MAILING}
+            setIsModalOpen={setIsModalOpen}
+            setAddressAction={setAddressAction}
+            updateUserAddresses={updateUserAddresses}
+            selectedAddressForAction={selectedAddressForAction}
           />
         );
     }

--- a/src/features/user/Settings/EditProfile/AddressManagment/microComponents/AddressActionMenu.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagment/microComponents/AddressActionMenu.tsx
@@ -62,6 +62,11 @@ const AddressActionsMenu = ({
         type === ADDRESS_TYPE.MAILING || type === ADDRESS_TYPE.PRIMARY
       ),
     },
+    {
+      label: tAddressManagement('actions.unsetBillingAddress'),
+      action: ADDRESS_ACTIONS.UNSET_BILLING,
+      shouldRender: type === ADDRESS_TYPE.MAILING,
+    },
   ];
 
   const openPopover = (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/features/user/Settings/EditProfile/AddressManagment/microComponents/AddressActionMenu.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagment/microComponents/AddressActionMenu.tsx
@@ -46,7 +46,7 @@ const AddressActionsMenu = ({
     {
       label: tAddressManagement(`actions.delete`),
       action: ADDRESS_ACTIONS.DELETE,
-      shouldRender: addressCount > 1,
+      shouldRender: addressCount > 1 && type !== ADDRESS_TYPE.PRIMARY,
     },
     {
       label: tAddressManagement('actions.setAsPrimaryAddress'),

--- a/src/utils/addressManagement.ts
+++ b/src/utils/addressManagement.ts
@@ -20,6 +20,7 @@ export const ADDRESS_ACTIONS = {
   DELETE: 'delete',
   SET_PRIMARY: 'setPrimary',
   SET_BILLING: 'setBilling',
+  UNSET_BILLING: 'unsetBilling',
 } as const;
 
 export const ADDRESS_FORM_TYPE = {


### PR DESCRIPTION
This pull request introduces :

-  The `Unset Billing Address` functionality to the address action menu. Users can now remove the billing address tag conveniently through the existing menu options.
-  Hide the `delete option` for the primary address.

Changes :

- Added the `Unset Billing Address` option to the address action menu.
- Integrated a modal for confirmation, ensuring consistency with other address-related actions.
- Updated relevant components  to accommodate the new option.