### PR TITLE
fix: trigger contributions refetch after redeeming code

### DIFF
--- a/src/features/common/Layout/MyForestContext.tsx
+++ b/src/features/common/Layout/MyForestContext.tsx
@@ -32,6 +32,10 @@ type ContributionsQueryRefetchType = ReturnType<
   typeof trpc.myForest.contributions.useQuery
 >['refetch'];
 
+type LeaderboardQueryRefetchType = ReturnType<
+  typeof trpc.myForest.leaderboard.useQuery
+>['refetch'];
+
 interface MyForestContextInterface {
   projectListResult: ProjectListResponse | undefined;
   contributionsResult: ContributionsResponse | undefined;
@@ -46,6 +50,7 @@ interface MyForestContextInterface {
   setUserInfo: SetState<UserInfo | null>;
   contributionStats: ContributionStats | undefined;
   refetchContributions: ContributionsQueryRefetchType;
+  refetchLeaderboard: LeaderboardQueryRefetchType;
 }
 
 const MyForestContext = createContext<MyForestContextInterface | null>(null);
@@ -202,6 +207,7 @@ export const MyForestProvider: FC = ({ children }) => {
       setUserInfo,
       contributionStats,
       refetchContributions: _contributions.refetch,
+      refetchLeaderboard: _leaderboard.refetch,
     }),
     [
       projectListResult,
@@ -220,6 +226,7 @@ export const MyForestProvider: FC = ({ children }) => {
       setUserInfo,
       contributionStats,
       _contributions.refetch,
+      _leaderboard.refetch,
     ]
   );
 

--- a/src/features/common/Layout/MyForestContext.tsx
+++ b/src/features/common/Layout/MyForestContext.tsx
@@ -1,14 +1,4 @@
-import {
-  FC,
-  createContext,
-  useContext,
-  useMemo,
-  useState,
-  useEffect,
-} from 'react';
-import { trpc } from '../../../utils/trpc';
-import { ErrorHandlingContext } from './ErrorHandlingContext';
-import {
+import type {
   ProjectListResponse,
   MyForestProject,
   ContributionsResponse,
@@ -20,9 +10,16 @@ import {
   DonationProperties,
   ContributionStats,
 } from '../types/myForest';
+import type { SetState } from '../types/common';
+import type { PointFeature } from 'supercluster';
+import type { QueryObserverResult } from '@tanstack/react-query';
+import type { TRPCClientErrorBase } from '@trpc/client';
+import type { FC } from 'react';
+
+import { createContext, useContext, useMemo, useState, useEffect } from 'react';
+import { trpc } from '../../../utils/trpc';
+import { ErrorHandlingContext } from './ErrorHandlingContext';
 import { updateStateWithTrpcData } from '../../../utils/trpcHelpers';
-import { SetState } from '../types/common';
-import { PointFeature } from 'supercluster';
 
 interface UserInfo {
   profileId: string;
@@ -33,6 +30,17 @@ interface UserInfo {
     areaConserved: number;
   };
 }
+type RefetchContributions = () => Promise<
+  QueryObserverResult<
+    {
+      stats: ContributionStats;
+      myContributionsMap: Map<string, MyContributionsMapItem>;
+      registrationLocationsMap: Map<string, MapLocation>;
+      projectLocationsMap: Map<string, MapLocation>;
+    },
+    TRPCClientErrorBase<any>
+  >
+>;
 interface MyForestContextInterface {
   projectListResult: ProjectListResponse | undefined;
   contributionsResult: ContributionsResponse | undefined;
@@ -46,6 +54,7 @@ interface MyForestContextInterface {
   userInfo: UserInfo | null;
   setUserInfo: SetState<UserInfo | null>;
   contributionStats: ContributionStats | undefined;
+  refetchContributions: RefetchContributions;
 }
 
 const MyForestContext = createContext<MyForestContextInterface | null>(null);
@@ -201,6 +210,7 @@ export const MyForestProvider: FC = ({ children }) => {
       userInfo,
       setUserInfo,
       contributionStats,
+      refetchContributions: _contributions.refetch,
     }),
     [
       projectListResult,
@@ -218,6 +228,7 @@ export const MyForestProvider: FC = ({ children }) => {
       userInfo,
       setUserInfo,
       contributionStats,
+      _contributions.refetch,
     ]
   );
 

--- a/src/features/common/Layout/MyForestContext.tsx
+++ b/src/features/common/Layout/MyForestContext.tsx
@@ -13,8 +13,6 @@ import type {
 } from '../types/myForest';
 import type { SetState } from '../types/common';
 import type { PointFeature } from 'supercluster';
-import type { QueryObserverResult } from '@tanstack/react-query';
-import type { TRPCClientErrorBase } from '@trpc/client';
 
 import { createContext, useContext, useMemo, useState, useEffect } from 'react';
 import { trpc } from '../../../utils/trpc';
@@ -30,17 +28,10 @@ interface UserInfo {
     areaConserved: number;
   };
 }
-type RefetchContributions = () => Promise<
-  QueryObserverResult<
-    {
-      stats: ContributionStats;
-      myContributionsMap: Map<string, MyContributionsMapItem>;
-      registrationLocationsMap: Map<string, MapLocation>;
-      projectLocationsMap: Map<string, MapLocation>;
-    },
-    TRPCClientErrorBase<any>
-  >
->;
+type ContributionsQueryRefetchType = ReturnType<
+  typeof trpc.myForest.contributions.useQuery
+>['refetch'];
+
 interface MyForestContextInterface {
   projectListResult: ProjectListResponse | undefined;
   contributionsResult: ContributionsResponse | undefined;
@@ -54,7 +45,7 @@ interface MyForestContextInterface {
   userInfo: UserInfo | null;
   setUserInfo: SetState<UserInfo | null>;
   contributionStats: ContributionStats | undefined;
-  refetchContributions: RefetchContributions;
+  refetchContributions: ContributionsQueryRefetchType;
 }
 
 const MyForestContext = createContext<MyForestContextInterface | null>(null);

--- a/src/features/user/Profile/ProfileCard/RedeemModal/index.tsx
+++ b/src/features/user/Profile/ProfileCard/RedeemModal/index.tsx
@@ -39,7 +39,7 @@ export default function RedeemModal({
   } = useUserProps();
   const { setErrors, errors: apiErrors } =
     React.useContext(ErrorHandlingContext);
-  const { refetchContributions } = useMyForest();
+  const { refetchContributions, refetchLeaderboard } = useMyForest();
   const [inputCode, setInputCode] = React.useState<string | undefined>('');
   const [redeemedCodeData, setRedeemedCodeData] = React.useState<
     RedeemedCodeData | undefined
@@ -67,6 +67,7 @@ export default function RedeemModal({
           cloneUser.score.received = cloneUser.score.received + res.units;
           setUser(cloneUser);
           refetchContributions();
+          refetchLeaderboard();
         }
       } catch (err) {
         const serializedErrors = handleError(err as APIError);

--- a/src/features/user/Profile/ProfileCard/RedeemModal/index.tsx
+++ b/src/features/user/Profile/ProfileCard/RedeemModal/index.tsx
@@ -17,6 +17,7 @@ import {
   EnterRedeemCode,
 } from '../../../../common/RedeemCode';
 import { useTenant } from '../../../../common/Layout/TenantContext';
+import { useMyForest } from '../../../../common/Layout/MyForestContext';
 interface RedeemModal {
   redeemModalOpen: boolean;
   handleRedeemModalClose: () => void;
@@ -38,6 +39,7 @@ export default function RedeemModal({
   } = useUserProps();
   const { setErrors, errors: apiErrors } =
     React.useContext(ErrorHandlingContext);
+  const { refetchContributions } = useMyForest();
   const [inputCode, setInputCode] = React.useState<string | undefined>('');
   const [redeemedCodeData, setRedeemedCodeData] = React.useState<
     RedeemedCodeData | undefined
@@ -64,6 +66,7 @@ export default function RedeemModal({
           const cloneUser = { ...user };
           cloneUser.score.received = cloneUser.score.received + res.units;
           setUser(cloneUser);
+          refetchContributions();
         }
       } catch (err) {
         const serializedErrors = handleError(err as APIError);


### PR DESCRIPTION
Fixes #
This fix ensures that the contributions data is `refetched` after a redeem code is successfully processed. Previously, the contributions might not have been updated in real time, leading to stale or inconsistent data in the application.