### PR TITLE
feat: add GetStaticPaths type to enforce type safety in getStaticPath…

### DIFF
--- a/pages/sites/[slug]/[locale]/[p].tsx
+++ b/pages/sites/[slug]/[locale]/[p].tsx
@@ -1,4 +1,5 @@
 import type {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -60,18 +61,19 @@ ProjectDetailsPage.getLayout = function getLayout(
 
 export default ProjectDetailsPage;
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths?.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        p: v4(),
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          p: v4(),
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/all.tsx
+++ b/pages/sites/[slug]/[locale]/all.tsx
@@ -17,6 +17,7 @@ import {
   getTenantConfig,
 } from '../../../../src/utils/multiTenancy/helpers';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -78,7 +79,6 @@ export default function Home({ pageProps }: Props) {
     loadTenantScore();
   }, []);
 
-
   const [treesDonated, setTreesDonated] = React.useState<TreesDonated | null>(
     null
   );
@@ -103,12 +103,20 @@ export default function Home({ pageProps }: Props) {
     switch (pageProps.tenantConfig.config.slug) {
       case 'planet':
         AllPage = (
-          <LeaderBoard leaderboard={leaderboard} tenantScore={tenantScore} treesDonated={treesDonated} />
+          <LeaderBoard
+            leaderboard={leaderboard}
+            tenantScore={tenantScore}
+            treesDonated={treesDonated}
+          />
         );
         return AllPage;
       case 'ttc':
         AllPage = (
-          <LeaderBoard leaderboard={leaderboard} tenantScore={tenantScore} treesDonated={treesDonated}/>
+          <LeaderBoard
+            leaderboard={leaderboard}
+            tenantScore={tenantScore}
+            treesDonated={treesDonated}
+          />
         );
         return AllPage;
       default:
@@ -127,17 +135,18 @@ export default function Home({ pageProps }: Props) {
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/claim/[type]/[code].tsx
+++ b/pages/sites/[slug]/[locale]/claim/[type]/[code].tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import type {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -185,19 +186,20 @@ function ClaimDonation({ pageProps }: Props): ReactElement {
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths?.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        type: v4(),
-        code: v4(),
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          type: v4(),
+          code: v4(),
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths: paths,

--- a/pages/sites/[slug]/[locale]/complete-signup.tsx
+++ b/pages/sites/[slug]/[locale]/complete-signup.tsx
@@ -9,6 +9,7 @@ import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useRouter } from 'next/router';
 import { useTenant } from '../../../../src/features/common/Layout/TenantContext';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -43,17 +44,18 @@ export default function UserProfile({ pageProps }: Props) {
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/home.tsx
+++ b/pages/sites/[slug]/[locale]/home.tsx
@@ -18,6 +18,7 @@ import {
   getTenantConfig,
 } from '../../../../src/utils/multiTenancy/helpers';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -129,17 +130,18 @@ export default function Home({ pageProps }: Props) {
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/index.tsx
+++ b/pages/sites/[slug]/[locale]/index.tsx
@@ -1,4 +1,5 @@
 import type {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -56,17 +57,18 @@ ProjectListPage.getLayout = function getLayout(
 
 export default ProjectListPage;
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths?.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/login.tsx
+++ b/pages/sites/[slug]/[locale]/login.tsx
@@ -9,6 +9,7 @@ import {
 import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useTenant } from '../../../../src/features/common/Layout/TenantContext';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -83,17 +84,18 @@ export default function Login({ pageProps }: Props): ReactElement {
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths?.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/mangrove-challenge.tsx
+++ b/pages/sites/[slug]/[locale]/mangrove-challenge.tsx
@@ -8,6 +8,7 @@ import {
 import { AbstractIntlMessages } from 'next-intl';
 import { Tenant } from '@planet-sdk/common';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -98,7 +99,7 @@ export default function MangroveChallenge({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   return {
     paths: [{ params: { slug: 'salesforce', locale: 'en' } }],
     fallback: 'blocking',

--- a/pages/sites/[slug]/[locale]/mangroves.tsx
+++ b/pages/sites/[slug]/[locale]/mangroves.tsx
@@ -4,6 +4,7 @@ import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
 import { AbstractIntlMessages } from 'next-intl';
 import { Tenant } from '@planet-sdk/common';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -50,7 +51,7 @@ export default function MangrovesLandingPage({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   return {
     paths: [{ params: { slug: 'salesforce', locale: 'en' } }],
     fallback: 'blocking',

--- a/pages/sites/[slug]/[locale]/mangroves.tsx
+++ b/pages/sites/[slug]/[locale]/mangroves.tsx
@@ -1,6 +1,7 @@
 import type { AbstractIntlMessages } from 'next-intl';
 import type { Tenant } from '@planet-sdk/common';
 import type {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,

--- a/pages/sites/[slug]/[locale]/profile/api-key.tsx
+++ b/pages/sites/[slug]/[locale]/profile/api-key.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement } from 'react';
 import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import ApiKey from '../../../../../src/features/user/Settings/ApiKey';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -47,17 +48,18 @@ function EditProfilePage({ pageProps: { tenantConfig } }: Props): ReactElement {
 
 export default EditProfilePage;
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/bulk-codes/[method]/[id].tsx
+++ b/pages/sites/[slug]/[locale]/profile/bulk-codes/[method]/[id].tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import type {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -135,19 +136,20 @@ export default function BulkCodeIssueCodesPage({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths?.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        method: v4(),
-        id: v4(),
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          method: v4(),
+          id: v4(),
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths: paths,

--- a/pages/sites/[slug]/[locale]/profile/bulk-codes/[method]/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/bulk-codes/[method]/index.tsx
@@ -9,6 +9,7 @@ import { useBulkCode } from '../../../../../../../src/features/common/Layout/Bul
 import { BulkCodeMethods } from '../../../../../../../src/utils/constants/bulkCodeConstants';
 import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -70,18 +71,19 @@ export default function BulkCodeSelectProjectPage({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        method: v4(),
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          method: v4(),
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths: paths,

--- a/pages/sites/[slug]/[locale]/profile/bulk-codes/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/bulk-codes/index.tsx
@@ -6,6 +6,7 @@ import BulkCodes, {
 import Head from 'next/head';
 import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -47,17 +48,18 @@ export default function BulkCodePage({ pageProps }: Props): ReactElement {
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/delete-account.tsx
+++ b/pages/sites/[slug]/[locale]/profile/delete-account.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
 import type { AbstractIntlMessages } from 'next-intl';
 import type {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,

--- a/pages/sites/[slug]/[locale]/profile/delete-account.tsx
+++ b/pages/sites/[slug]/[locale]/profile/delete-account.tsx
@@ -4,6 +4,7 @@ import UserLayout from '../../../../../src/features/common/Layout/UserLayout/Use
 import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import DeleteProfile from '../../../../../src/features/user/Settings/DeleteProfile';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -49,17 +50,18 @@ function DeleteProfilePage({
 
 export default DeleteProfilePage;
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/donation-link.tsx
+++ b/pages/sites/[slug]/[locale]/profile/donation-link.tsx
@@ -4,6 +4,7 @@ import DonationLink from '../../../../../src/features/user/Widget/DonationLink';
 import Head from 'next/head';
 import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -47,17 +48,18 @@ export default function DonationLinkPage({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/edit.tsx
+++ b/pages/sites/[slug]/[locale]/profile/edit.tsx
@@ -1,5 +1,6 @@
 import type { AbstractIntlMessages } from 'next-intl';
 import type {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -50,17 +51,18 @@ function EditProfilePage({ pageProps: { tenantConfig } }: Props): ReactElement {
 
 export default EditProfilePage;
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths?.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/giftfund/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/giftfund/index.tsx
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import GiftFunds from '../../../../../../src/features/user/GiftFunds';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -48,17 +49,18 @@ export default function Register({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/history.tsx
+++ b/pages/sites/[slug]/[locale]/profile/history.tsx
@@ -19,6 +19,7 @@ import { ErrorHandlingContext } from '../../../../../src/features/common/Layout/
 import { handleError } from '@planet-sdk/common';
 import DashboardView from '../../../../../src/features/common/Layout/DashboardView';
 import type {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -177,17 +178,18 @@ function AccountHistory({ pageProps }: Props): ReactElement {
 
 export default AccountHistory;
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths?.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/impersonate-user.tsx
+++ b/pages/sites/[slug]/[locale]/profile/impersonate-user.tsx
@@ -6,6 +6,7 @@ import { useUserProps } from '../../../../../src/features/common/Layout/UserProp
 import { ReactElement, useEffect } from 'react';
 import AccessDeniedLoader from '../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -56,17 +57,18 @@ const ImpersonateUserPage = ({
 
 export default ImpersonateUserPage;
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/index.tsx
@@ -1,6 +1,7 @@
 import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { MyForestProvider } from '../../../../../src/features/common/Layout/MyForestContext';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -42,17 +43,18 @@ const MyForestPage = ({ pageProps: { tenantConfig } }: Props) => {
 
 export default MyForestPage;
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/payouts/add-bank-details.tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/add-bank-details.tsx
@@ -8,6 +8,7 @@ import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
 import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -56,17 +57,18 @@ export default function AddBankDetailsPage({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/payouts/edit-bank-details/[id].tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/edit-bank-details/[id].tsx
@@ -6,6 +6,7 @@ import ManagePayouts, {
 } from '../../../../../../../src/features/user/ManagePayouts';
 import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -50,18 +51,19 @@ export default function EditBankDetailsPage({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        id: v4(),
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          id: v4(),
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths: paths,

--- a/pages/sites/[slug]/[locale]/profile/payouts/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/index.tsx
@@ -9,6 +9,7 @@ import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
 import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -68,17 +69,18 @@ export default function OverviewPage({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/payouts/schedule.tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/schedule.tsx
@@ -8,6 +8,7 @@ import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
 import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -57,17 +58,18 @@ export default function PayoutSchedulePage({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/planetcash/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/planetcash/index.tsx
@@ -7,6 +7,7 @@ import PlanetCash, {
 } from '../../../../../../src/features/user/PlanetCash';
 import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -65,17 +66,18 @@ export default function PlanetCashPage({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/planetcash/new.tsx
+++ b/pages/sites/[slug]/[locale]/profile/planetcash/new.tsx
@@ -7,6 +7,7 @@ import PlanetCash, {
 } from '../../../../../../src/features/user/PlanetCash';
 import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -69,17 +70,18 @@ export default function PlanetCashCreatePage({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/planetcash/transactions.tsx
+++ b/pages/sites/[slug]/[locale]/profile/planetcash/transactions.tsx
@@ -7,6 +7,7 @@ import PlanetCash, {
 } from '../../../../../../src/features/user/PlanetCash';
 import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -69,17 +70,18 @@ export default function PlanetCashTransactionsPage({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/projects/[id].tsx
+++ b/pages/sites/[slug]/[locale]/profile/projects/[id].tsx
@@ -11,6 +11,7 @@ import Head from 'next/head';
 import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import { ErrorHandlingContext } from '../../../../../../src/features/common/Layout/ErrorHandlingContext';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -124,18 +125,19 @@ function ManageSingleProject({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        id: v4(),
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          id: v4(),
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths: paths,

--- a/pages/sites/[slug]/[locale]/profile/projects/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/projects/index.tsx
@@ -1,11 +1,7 @@
-import { AbstractIntlMessages, useTranslations } from 'next-intl';
-import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
-import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
-import {
-  GetStaticPaths,
 import type { ReactElement } from 'react';
 import type { AbstractIntlMessages } from 'next-intl';
 import type {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,

--- a/pages/sites/[slug]/[locale]/profile/projects/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/projects/index.tsx
@@ -6,6 +6,7 @@ import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
 import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -50,17 +51,18 @@ export default function Register({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths?.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/projects/new-project.tsx
+++ b/pages/sites/[slug]/[locale]/profile/projects/new-project.tsx
@@ -7,6 +7,7 @@ import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoa
 import Footer from '../../../../../../src/features/common/Layout/Footer';
 import Head from 'next/head';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -96,17 +97,18 @@ export default function AddProjectType({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/recurrency.tsx
+++ b/pages/sites/[slug]/[locale]/profile/recurrency.tsx
@@ -10,6 +10,7 @@ import { handleError, APIError } from '@planet-sdk/common';
 import { Subscription } from '../../../../../src/features/common/types/payments';
 import RecurrentPayments from '../../../../../src/features/user/Account/RecurrentPayments';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -117,17 +118,18 @@ function RecurrentDonations({
 
 export default RecurrentDonations;
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/redeem/[code].tsx
+++ b/pages/sites/[slug]/[locale]/profile/redeem/[code].tsx
@@ -1,4 +1,5 @@
 import type {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -195,18 +196,19 @@ const RedeemCode = ({ pageProps: { tenantConfig } }: Props) => {
   );
 };
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths?.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        code: v4(),
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          code: v4(),
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths: paths,

--- a/pages/sites/[slug]/[locale]/profile/register-trees.tsx
+++ b/pages/sites/[slug]/[locale]/profile/register-trees.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
 import type { AbstractIntlMessages } from 'next-intl';
 import type {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,

--- a/pages/sites/[slug]/[locale]/profile/register-trees.tsx
+++ b/pages/sites/[slug]/[locale]/profile/register-trees.tsx
@@ -4,6 +4,7 @@ import UserLayout from '../../../../../src/features/common/Layout/UserLayout/Use
 import Head from 'next/head';
 import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -50,17 +51,18 @@ export default function Register({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/treemapper/data-explorer.tsx
+++ b/pages/sites/[slug]/[locale]/profile/treemapper/data-explorer.tsx
@@ -6,6 +6,7 @@ import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
 import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -62,17 +63,18 @@ function TreeMapperAnalytics({
 
 export default TreeMapperAnalytics;
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/treemapper/import.tsx
+++ b/pages/sites/[slug]/[locale]/profile/treemapper/import.tsx
@@ -6,6 +6,7 @@ import ImportData from '../../../../../../src/features/user/TreeMapper/Import';
 import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
 import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -50,17 +51,18 @@ export default function Import({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/treemapper/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/treemapper/index.tsx
@@ -4,6 +4,7 @@ import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/
 import TreeMapper from '../../../../../../src/features/user/TreeMapper';
 import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -51,17 +52,18 @@ function TreeMapperPage({ pageProps: { tenantConfig } }: Props): ReactElement {
 
 export default TreeMapperPage;
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/treemapper/my-species.tsx
+++ b/pages/sites/[slug]/[locale]/profile/treemapper/my-species.tsx
@@ -6,6 +6,7 @@ import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
 import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -50,17 +51,18 @@ export default function MySpeciesPage({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/profile/widgets.tsx
+++ b/pages/sites/[slug]/[locale]/profile/widgets.tsx
@@ -6,6 +6,7 @@ import styles from '../../../../../src/features/common/Layout/UserLayout/UserLay
 import Head from 'next/head';
 import { AbstractIntlMessages, useTranslations } from 'next-intl';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -68,17 +69,18 @@ function ProfilePage({ pageProps: { tenantConfig } }: Props): ReactElement {
 
 export default ProfilePage;
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/projects-archive/[p].tsx
+++ b/pages/sites/[slug]/[locale]/projects-archive/[p].tsx
@@ -27,6 +27,7 @@ import {
 import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { v4 } from 'uuid';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -220,18 +221,19 @@ export default function Donate({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths?.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        p: v4(),
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          p: v4(),
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths: paths,

--- a/pages/sites/[slug]/[locale]/projects-archive/index.tsx
+++ b/pages/sites/[slug]/[locale]/projects-archive/index.tsx
@@ -22,6 +22,7 @@ import {
 import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import { useTenant } from '../../../../../src/features/common/Layout/TenantContext';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -174,17 +175,18 @@ export default function Donate({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/s/[id].tsx
+++ b/pages/sites/[slug]/[locale]/s/[id].tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { getRequest } from '../../../../../src/utils/apiRequests/api';
 import { ErrorHandlingContext } from '../../../../../src/features/common/Layout/ErrorHandlingContext';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -69,18 +70,19 @@ export default function DirectGift({
   return tenantConfig ? <div></div> : <></>;
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        id: v4(),
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          id: v4(),
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths: paths,

--- a/pages/sites/[slug]/[locale]/t/[profile].tsx
+++ b/pages/sites/[slug]/[locale]/t/[profile].tsx
@@ -1,6 +1,7 @@
 // This page will be moved to a different place in the future, as it is not a part of the user dashboard
 import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -83,18 +84,19 @@ const PublicProfilePage = ({ pageProps: { tenantConfig } }: Props) => {
 
 export default PublicProfilePage;
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths?.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-        profile: v4(),
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+          profile: v4(),
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/verify-email.tsx
+++ b/pages/sites/[slug]/[locale]/verify-email.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/router';
 import { useTenant } from '../../../../src/features/common/Layout/TenantContext';
 import { Tenant } from '@planet-sdk/common/build/types/tenant';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -44,17 +45,18 @@ export default function VerifyEmail({ pageProps }: Props): ReactElement {
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   const subDomainPaths = await constructPathsForTenantSlug();
 
-  const paths = subDomainPaths.map((path) => {
-    return {
-      params: {
-        slug: path.params.slug,
-        locale: 'en',
-      },
-    };
-  });
+  const paths =
+    subDomainPaths?.map((path) => {
+      return {
+        params: {
+          slug: path.params.slug,
+          locale: 'en',
+        },
+      };
+    }) ?? [];
 
   return {
     paths,

--- a/pages/sites/[slug]/[locale]/vto-fitness-challenge-2023.tsx
+++ b/pages/sites/[slug]/[locale]/vto-fitness-challenge-2023.tsx
@@ -8,6 +8,7 @@ import {
 import { AbstractIntlMessages } from 'next-intl';
 import { Tenant } from '@planet-sdk/common';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -101,7 +102,7 @@ export default function VTOFitnessChallenge({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   return {
     paths: [{ params: { slug: 'salesforce', locale: 'en' } }],
     fallback: 'blocking',

--- a/pages/sites/[slug]/[locale]/vto-fitness-challenge-2023.tsx
+++ b/pages/sites/[slug]/[locale]/vto-fitness-challenge-2023.tsx
@@ -5,6 +5,7 @@ import type {
 import type { AbstractIntlMessages } from 'next-intl';
 import type { Tenant } from '@planet-sdk/common';
 import type {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,

--- a/pages/sites/[slug]/[locale]/vto-fitness-challenge.tsx
+++ b/pages/sites/[slug]/[locale]/vto-fitness-challenge.tsx
@@ -8,6 +8,7 @@ import {
 import { AbstractIntlMessages } from 'next-intl';
 import { Tenant } from '@planet-sdk/common';
 import {
+  GetStaticPaths,
   GetStaticProps,
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -101,7 +102,7 @@ export default function VTOFitnessChallenge({
   );
 }
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   return {
     paths: [{ params: { slug: 'salesforce', locale: 'en' } }],
     fallback: 'blocking',


### PR DESCRIPTION
This update enhances the type safety of the getStaticPaths function  by explicitly applying the `GetStaticPaths` type from Next.js. By doing so, the function now adheres strictly to the expected return structure, and any discrepancies in the returned value will trigger TypeScript warnings or errors.

Key changes include:
- Updated `getStaticPaths` to use the `GetStaticPaths` type