### PR TITLE
Update ESLint workflow to use Node.js setup action and specify versions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -8,14 +8,15 @@ on:
 jobs:
   ubuntu-job:
     name: 'ESLint on Ubuntu'
-    runs-on: ubuntu-latest  # Can be self-hosted runner also
+    runs-on: ubuntu-latest # Can be self-hosted runner also
     steps:
-
       - name: 'Checkout the repository'
         uses: actions/checkout@v2
 
-      - name: Upgrade npm to latest version
-        run: sudo npm i -g npm@latest
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
 
       - name: 'Install Node Modules'
         run: npm install --legacy-peer-deps


### PR DESCRIPTION
Fixes the issue causing failure of the ESLint error report workflow.

Revise the ESLint workflow to utilize the Node.js setup action, ensuring consistent Node.js and npm versions.

The long term fix would be to update the node engine (as specified in package.json) to 20.x, but that would need to be tested.