### PR TITLE
Fix bug preventing tab switching in project list

### DIFF
--- a/src/features/projectsV2/ProjectListControls/index.tsx
+++ b/src/features/projectsV2/ProjectListControls/index.tsx
@@ -87,7 +87,7 @@ const ProjectListControls = ({
     }
 
     return <ProjectListTabLargeScreen {...projectListTabProps} />;
-  }, [hasFilterApplied, shouldHideProjectTabs, filteredProjects]);
+  }, [hasFilterApplied, shouldHideProjectTabs, filteredProjects, tabSelected]);
 
   return (
     <>


### PR DESCRIPTION
Resolve an issue that prevented users from switching between project list tabs (on large screens) by updating the dependencies in the `renderTabContent` memo within `ProjectListControls`.

Earlier, the following issues were faced:
1. On switching from top projects to all projects, the project list was updated, but the selected tab still appeared to be top projects.
2. The user could not switch back to top projects once the All Projects tab was clicked on. The project list did not get updated, nor did the tab selected appear to change.

https://www.loom.com/share/1cecfd1f69154d70858bb487f945eb12?sid=c33961fd-49e0-4d29-a00c-1c460b48a08a