### PR TITLE
Bug: direct link to plant location does not work (first time)

### DIFF
--- a/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
@@ -41,9 +41,7 @@ const ImageSection = (props: ImageSectionProps) => {
   const isEmbed = embed === 'true';
 
   const handleBackButton = () => {
-    if (setPreventShallowPush) {
-      setPreventShallowPush(true);
-    }
+    if (setPreventShallowPush) setPreventShallowPush(true);
 
     const previousPageRoute = sessionStorage.getItem('backNavigationUrl');
     const defaultRoute = `/${locale}`;

--- a/src/features/projectsV2/ProjectsContext.tsx
+++ b/src/features/projectsV2/ProjectsContext.tsx
@@ -314,7 +314,8 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
       page !== 'project-details' ||
       singleProject === null ||
       selectedSite !== null ||
-      (requestedPlantLocation && requestedSite)
+      (requestedPlantLocation && requestedSite) ||
+      plantLocations === null
     )
       return;
 
@@ -353,6 +354,7 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
     selectedPlantLocation,
     selectedSite,
     hasNoSites,
+    plantLocations,
   ]);
   useEffect(() => {
     if (
@@ -360,7 +362,8 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
       page !== 'project-details' ||
       singleProject === null ||
       selectedPlantLocation !== null ||
-      preventShallowPush
+      preventShallowPush ||
+      plantLocations === null
     )
       return;
     // Handle the case where a direct link requests a specific site (via URL query)
@@ -398,6 +401,7 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
     requestedSite,
     router.isReady,
     selectedPlantLocation,
+    plantLocations,
     preventShallowPush,
     hasNoSites,
   ]);

--- a/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
+++ b/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
@@ -61,7 +61,12 @@ const SingleProjectView = ({ mapRef }: Props) => {
 
   // Zoom to project site
   useEffect(() => {
-    if (!router.isReady || selectedPlantLocation !== null) return;
+    if (
+      !router.isReady ||
+      selectedPlantLocation !== null ||
+      plantLocations === null
+    )
+      return;
     if (sitesGeojson.features.length > 0 && selectedSite !== null) {
       zoomInToProjectSite(
         mapRef,
@@ -85,7 +90,13 @@ const SingleProjectView = ({ mapRef }: Props) => {
         );
       }
     }
-  }, [selectedSite, sitesGeojson, router.isReady, selectedPlantLocation]);
+  }, [
+    selectedSite,
+    sitesGeojson,
+    router.isReady,
+    selectedPlantLocation,
+    plantLocations,
+  ]);
 
   useEffect(() => {
     const hasNoPlantLocations = !plantLocations?.length;


### PR DESCRIPTION

Fix :
Previously, visiting a `plant location via a direct link` in an incognito tab (e.g., https://dev.pp.eco/en/yucatan?ploc=JOCK9R) redirected to the default site instead of the specified plant location. This fix ensures the correct plant location is resolved and displayed when accessing such links, even in incognito mode.
