### PR TITLE
Add caching for TRPC APIs in profile management

### DIFF
--- a/src/features/common/Layout/MyForestContext.tsx
+++ b/src/features/common/Layout/MyForestContext.tsx
@@ -41,6 +41,8 @@ interface MyForestContextInterface {
   userInfo: UserInfo | null;
   setUserInfo: SetState<UserInfo | null>;
   contributionStats: ContributionStats | undefined;
+  isPublicProfile: boolean;
+  setIsPublicProfile: SetState<boolean>;
 }
 
 const MyForestContext = createContext<MyForestContextInterface | null>(null);
@@ -66,6 +68,8 @@ export const MyForestProvider: FC = ({ children }) => {
     PointFeature<DonationProperties>[]
   >([]);
 
+  const [isPublicProfile, setIsPublicProfile] = useState(false);
+
   const _projectList = trpc.myForest.projectList.useQuery(undefined, {
     refetchOnWindowFocus: false,
     staleTime: 1000 * 60 * 5, // 5 minutes
@@ -74,6 +78,7 @@ export const MyForestProvider: FC = ({ children }) => {
   const _contributions = trpc.myForest.contributions.useQuery(
     {
       profileId: `${userInfo?.profileId}`,
+      isPublicProfile,
     },
     {
       enabled: !!userInfo?.profileId && !!userInfo?.slug,
@@ -85,6 +90,7 @@ export const MyForestProvider: FC = ({ children }) => {
   const _leaderboard = trpc.myForest.leaderboard.useQuery(
     {
       profileId: `${userInfo?.profileId}`,
+      isPublicProfile,
     },
     {
       enabled: !!userInfo?.profileId && !!userInfo?.slug,
@@ -196,6 +202,8 @@ export const MyForestProvider: FC = ({ children }) => {
       userInfo,
       setUserInfo,
       contributionStats,
+      isPublicProfile,
+      setIsPublicProfile,
     }),
     [
       projectListResult,
@@ -213,6 +221,7 @@ export const MyForestProvider: FC = ({ children }) => {
       userInfo,
       setUserInfo,
       contributionStats,
+      isPublicProfile,
     ]
   );
 

--- a/src/features/user/Profile/PublicProfileLayout/index.tsx
+++ b/src/features/user/Profile/PublicProfileLayout/index.tsx
@@ -27,10 +27,12 @@ const PublicProfileLayout = ({ profile, isProfileLoaded }: Props) => {
     isContributionsLoaded,
     isProjectsListLoaded,
     isLeaderboardLoaded,
+    setIsPublicProfile,
   } = useMyForest();
 
   useEffect(() => {
     if (profile) {
+      setIsPublicProfile(true);
       const _userInfo = {
         profileId: profile.id,
         slug: profile.slug,

--- a/src/server/procedures/myForest/leaderboard.ts
+++ b/src/server/procedures/myForest/leaderboard.ts
@@ -7,6 +7,8 @@ import { TRPCError } from '@trpc/server';
 import { Prisma } from '@prisma/client';
 import { fetchProfile } from '../../utils/fetchProfile';
 import { fetchProfileGroupData } from '../../utils/fetchProfileGroupData';
+import { getCachedData } from '../../utils/cache';
+import { cacheKeyPrefix } from '../../../utils/constants/cacheKeyPrefix';
 
 async function fetchMostRecentGifts(profileIds: number[]) {
   return await prisma.$queryRaw<
@@ -59,51 +61,63 @@ export const leaderboardProcedure = procedure
   .input(
     z.object({
       profileId: z.string(),
+      isPublicProfile: z.boolean().optional(),
     })
   )
-  .query(async ({ input: { profileId } }) => {
-    // Initialize return values
-    const leaderboard: Leaderboard = {
-      mostRecent: [],
-      mostTrees: [],
+  .query(async ({ input: { profileId, isPublicProfile } }) => {
+    const fetchLeaderboardData = async () => {
+      // Initialize return values
+      const leaderboard: Leaderboard = {
+        mostRecent: [],
+        mostTrees: [],
+      };
+
+      // Check that the profile actually exists
+      const profile = await fetchProfile(profileId);
+
+      if (!profile) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Profile not found',
+        });
+      }
+
+      // Check if the profile is associated with a profile group, and fetch all profile ids for that group (parent and children)
+      const profileGroupData = await fetchProfileGroupData(profile.id);
+      const profileIds =
+        profileGroupData.length > 0
+          ? profileGroupData.map(({ profileId }) => profileId)
+          : [profile.id];
+
+      // Fetch the most recent gifts for the profile(s)
+      const mostRecentGifts = await fetchMostRecentGifts(profileIds);
+
+      leaderboard.mostRecent = mostRecentGifts.map((gift) => ({
+        name: gift.giverName,
+        units: gift.quantity,
+        unitType: 'tree',
+        purpose: gift.purpose,
+      }));
+
+      // Fetch the top 10 gifters for the profile(s)
+      const topGifters = await fetchTopGifters(profileIds);
+
+      leaderboard.mostTrees = topGifters.map((gifter) => ({
+        name: gifter.giverName,
+        units: gifter.totalQuantity,
+        unitType: 'tree',
+        purpose: gifter.purpose,
+      }));
+
+      return leaderboard;
     };
 
-    // Check that the profile actually exists
-    const profile = await fetchProfile(profileId);
-
-    if (!profile) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: 'Profile not found',
-      });
+    if (isPublicProfile) {
+      return await getCachedData(
+        `${cacheKeyPrefix}_pp-leaderboard_${profileId}`,
+        fetchLeaderboardData
+      );
     }
 
-    // Check if the profile is associated with a profile group, and fetch all profile ids for that group (parent and children)
-    const profileGroupData = await fetchProfileGroupData(profile.id);
-    const profileIds =
-      profileGroupData.length > 0
-        ? profileGroupData.map(({ profileId }) => profileId)
-        : [profile.id];
-
-    // Fetch the most recent gifts for the profile(s)
-    const mostRecentGifts = await fetchMostRecentGifts(profileIds);
-
-    leaderboard.mostRecent = mostRecentGifts.map((gift) => ({
-      name: gift.giverName,
-      units: gift.quantity,
-      unitType: 'tree',
-      purpose: gift.purpose,
-    }));
-
-    // Fetch the top 10 gifters for the profile(s)
-    const topGifters = await fetchTopGifters(profileIds);
-
-    leaderboard.mostTrees = topGifters.map((gifter) => ({
-      name: gifter.giverName,
-      units: gifter.totalQuantity,
-      unitType: 'tree',
-      purpose: gifter.purpose,
-    }));
-
-    return leaderboard;
+    return await fetchLeaderboardData();
   });

--- a/src/server/utils/cache.ts
+++ b/src/server/utils/cache.ts
@@ -1,0 +1,95 @@
+import redisClient from '../../redis-client';
+
+const DEFAULT_CACHE_TTL = 5 * 60; // 5 minutes in seconds
+
+function deserializeComplexTypes(obj: any): any {
+  // Handle direct Map objects
+  if (obj && obj._type === 'Map') {
+    return new Map(obj.data);
+  }
+
+  // Handle Set objects
+  if (obj && obj._type === 'Set') {
+    return new Set(obj.data);
+  }
+
+  // Handle objects containing Maps and Sets
+  if (obj && typeof obj === 'object') {
+    // Create a new object/array to avoid modifying the original
+    const newObj = Array.isArray(obj) ? [...obj] : { ...obj };
+
+    // Process all properties
+    for (const key of Object.keys(newObj)) {
+      if (newObj[key]?._type === 'Map') {
+        newObj[key] = new Map(newObj[key].data);
+      } else if (newObj[key]?._type === 'Set') {
+        newObj[key] = new Set(newObj[key].data);
+      } else if (typeof newObj[key] === 'object' && newObj[key] !== null) {
+        newObj[key] = deserializeComplexTypes(newObj[key]);
+      }
+    }
+    return newObj;
+  }
+
+  return obj;
+}
+
+function serializeComplexTypes(obj: any): any {
+  if (obj instanceof Map) {
+    return {
+      _type: 'Map',
+      data: Array.from(obj.entries()),
+    };
+  }
+
+  if (obj instanceof Set) {
+    return {
+      _type: 'Set',
+      data: Array.from(obj),
+    };
+  }
+
+  if (obj && typeof obj === 'object') {
+    const newObj = { ...obj };
+    Object.keys(newObj).forEach((key) => {
+      if (newObj[key] instanceof Map || newObj[key] instanceof Set) {
+        newObj[key] = serializeComplexTypes(newObj[key]);
+      } else if (typeof newObj[key] === 'object') {
+        newObj[key] = serializeComplexTypes(newObj[key]);
+      }
+    });
+    return newObj;
+  }
+
+  return obj;
+}
+
+/**
+ *
+ * @param key key that will be used to store the data in the cache
+ * @param fetchFn function used to fetch fresh data if not found in cache
+ * @param ttl time (for the cache) to live in seconds
+ * @returns
+ */
+export async function getCachedData<T>(
+  key: string,
+  fetchFn: () => Promise<T>,
+  ttl: number = DEFAULT_CACHE_TTL
+): Promise<T> {
+  if (!redisClient) {
+    return await fetchFn();
+  }
+
+  // Try to get data from cache
+  const cachedData = await redisClient.get(key);
+  if (cachedData) {
+    // Parse the cached string and revive complex types
+    return deserializeComplexTypes(cachedData) as T;
+  }
+
+  // If no cached data, fetch and cache
+  const data = await fetchFn();
+  const preparedData = serializeComplexTypes(data);
+  await redisClient.set(key, preparedData, { ex: ttl });
+  return data;
+}


### PR DESCRIPTION
Implement caching for contributions, leaderboard, and project list API responses to enhance performance for both public and private profiles.

Caches contributions/leaderboard APIs for public profile (5 minutes) and project list API for all profiles for 15 minutes.

Sets up cache utility `getCachedData` to handle caching when needed, serialization and deserialization of data.