### PR TITLE
Hotfix/map zoom out

### DIFF
--- a/src/features/projectsV2/ProjectsMap/MultipleProjectsView.tsx
+++ b/src/features/projectsV2/ProjectsMap/MultipleProjectsView.tsx
@@ -1,42 +1,19 @@
 import type { CategorizedProjects } from './ProjectMarkers';
 import type { MapRef } from '../../common/types/projectv2';
 
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import ProjectMarkers from './ProjectMarkers';
 import { useProjects } from '../ProjectsContext';
-import { useProjectsMap } from '../ProjectsMapContext'; // Add this import
 import { getProjectCategory } from '../../../utils/projectV2';
-import { zoomOutMap } from '../../../utils/mapsV2/zoomToProjectSite';
 
 interface MultipleProjectsViewProps {
   mapRef: MapRef;
   page: 'project-list' | 'project-details';
 }
 
-const MultipleProjectsView = ({ mapRef, page }: MultipleProjectsViewProps) => {
+const MultipleProjectsView = ({ page }: MultipleProjectsViewProps) => {
   const { projects, isLoading, isError, filteredProjects } = useProjects();
-  const { handleViewStateChange } = useProjectsMap();
-  if (isLoading || isError || !projects) {
-    return null;
-  }
-
-  useEffect(() => {
-    //Wrapping the logic in Promise.resolve().then() defers the map-related code until after synchronous tasks finish,
-    //Giving the map time to initialize fully. This ensures mapRef.current is ready for interaction.
-    Promise.resolve().then(() => {
-      if (mapRef.current) {
-        const map = mapRef.current.getMap
-          ? mapRef.current.getMap()
-          : mapRef.current;
-        zoomOutMap(map, () => {
-          handleViewStateChange({
-            ...map.getCenter(),
-            zoom: map.getZoom(),
-          });
-        });
-      }
-    });
-  }, []);
+  if (isLoading || isError || !projects) return null;
 
   const categorizedProjects = useMemo(() => {
     return filteredProjects?.reduce<CategorizedProjects>(

--- a/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
+++ b/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
@@ -11,6 +11,7 @@ import PlantLocations from './microComponents/PlantLocations';
 import { zoomToPolygonPlantLocation } from '../../../utils/mapsV2/zoomToPolygonPlantLocation';
 import zoomToLocation from '../../../utils/mapsV2/zoomToLocation';
 import ProjectLocation from './microComponents/ProjectLocation';
+import { MAIN_MAP_ANIMATION_DURATIONS } from '../../../utils/projectV2';
 
 interface Props {
   mapRef: MapRef;
@@ -49,12 +50,19 @@ const SingleProjectView = ({ mapRef }: Props) => {
         polygonCoordinates,
         mapRef,
         handleViewStateChange,
-        4000
+        MAIN_MAP_ANIMATION_DURATIONS.ZOOM_IN
       );
     } else if (isPointLocation) {
       const [lon, lat] = coordinates;
       if (typeof lon === 'number' && typeof lat === 'number') {
-        zoomToLocation(handleViewStateChange, lon, lat, 20, 4000, mapRef);
+        zoomToLocation(
+          handleViewStateChange,
+          lon,
+          lat,
+          20,
+          MAIN_MAP_ANIMATION_DURATIONS.ZOOM_IN,
+          mapRef
+        );
       }
     }
   }, [selectedPlantLocation, router.isReady]);
@@ -73,7 +81,7 @@ const SingleProjectView = ({ mapRef }: Props) => {
         sitesGeojson,
         selectedSite,
         handleViewStateChange,
-        4000
+        MAIN_MAP_ANIMATION_DURATIONS.ZOOM_IN
       );
     } else {
       const { lat: latitude, lon: longitude } = singleProject.coordinates;

--- a/src/utils/mapsV2/zoomToProjectSite.ts
+++ b/src/utils/mapsV2/zoomToProjectSite.ts
@@ -9,13 +9,11 @@ import { DEFAULT_VIEW_STATE } from '../../features/projectsV2/ProjectsMapContext
 export function zoomOutMap(map: Map, callback: () => void) {
   map.flyTo({
     center: [DEFAULT_VIEW_STATE.longitude, DEFAULT_VIEW_STATE.latitude],
-    zoom: 2,
+    zoom: DEFAULT_VIEW_STATE.zoom,
     duration: 1600,
   });
 
-  map.once('moveend', () => {
-    callback();
-  });
+  map.once('moveend', () => callback());
 }
 export function zoomInToProjectSite(
   mapRef: MapRef,

--- a/src/utils/mapsV2/zoomToProjectSite.ts
+++ b/src/utils/mapsV2/zoomToProjectSite.ts
@@ -5,12 +5,13 @@ import type { MapRef } from '../../features/common/types/projectv2';
 
 import * as turf from '@turf/turf';
 import { DEFAULT_VIEW_STATE } from '../../features/projectsV2/ProjectsMapContext';
+import { MAIN_MAP_ANIMATION_DURATIONS } from '../projectV2';
 
 export function zoomOutMap(map: Map, callback: () => void) {
   map.flyTo({
     center: [DEFAULT_VIEW_STATE.longitude, DEFAULT_VIEW_STATE.latitude],
     zoom: DEFAULT_VIEW_STATE.zoom,
-    duration: 1600,
+    duration: MAIN_MAP_ANIMATION_DURATIONS.ZOOM_OUT,
   });
 
   map.once('moveend', () => callback());

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -20,6 +20,11 @@ export type MobileOs = 'android' | 'ios' | undefined;
 
 const paramsToDelete = ['ploc', 'backNavigationUrl', 'site'];
 
+export const MAIN_MAP_ANIMATION_DURATIONS = {
+  ZOOM_OUT: 1600,
+  ZOOM_IN: 4000,
+};
+
 type RouteParams = {
   siteId?: string | null;
   plocId?: string | null;


### PR DESCRIPTION
Issue: When visiting a specific plant location via a direct link (e.g., [link](https://dev.pp.eco/en/yucatan?ploc=JOCK9R)), and then using the back button to return to the landing page, the map becomes stuck at an incorrect zoom level and latitude/longitude coordinates. This behavior contradicts the expected behavior set by the flyTo() function, which is responsible for zooming the map out.

Fix: This PR fixes the issue by ensuring that the map zoom level and coordinates reset correctly when navigating back from the plant location. 