### PR TITLE
refactor: refactor satellite view logic in useEffect

### DIFF
--- a/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
+++ b/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
@@ -108,11 +108,11 @@ const SingleProjectView = ({ mapRef }: Props) => {
   ]);
 
   useEffect(() => {
-    setIsSatelliteView(
+    const isSatelliteView =
       singleProject.purpose === 'conservation' ||
-        (singleProject.purpose === 'trees' &&
-          (!plantLocations || plantLocations.length === 0))
-    );
+      (singleProject.purpose === 'trees' && plantLocations?.length === 0);
+
+    setIsSatelliteView(isSatelliteView);
   }, [plantLocations, singleProject.purpose]);
   return (
     <>

--- a/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
+++ b/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
@@ -108,15 +108,12 @@ const SingleProjectView = ({ mapRef }: Props) => {
   ]);
 
   useEffect(() => {
-    if (plantLocations === null) return;
-    const hasNoPlantLocations = !plantLocations?.length;
-    const isSingleProjectLocation = hasNoPlantLocations && hasNoSites;
-    // Satellite view will be:
-    // - false if there are no plant locations and no sites (i.e., a single project location only)
-    // - true if there are no plant locations but there are multiple sites
-    setIsSatelliteView(!isSingleProjectLocation && hasNoPlantLocations);
-  }, [plantLocations, hasNoSites]);
-
+    setIsSatelliteView(
+      singleProject.purpose === 'conservation' ||
+        (singleProject.purpose === 'trees' &&
+          (!plantLocations || plantLocations.length === 0))
+    );
+  }, [plantLocations, singleProject.purpose]);
   return (
     <>
       {hasNoSites ? (
@@ -131,7 +128,7 @@ const SingleProjectView = ({ mapRef }: Props) => {
             isSatelliteView={isSatelliteView}
             geoJson={sitesGeojson}
           />
-          {isSatelliteView && plantLocations !== null && <SatelliteLayer />}
+          {isSatelliteView && <SatelliteLayer />}
         </>
       )}
 

--- a/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
+++ b/src/features/projectsV2/ProjectsMap/SingleProjectView.tsx
@@ -107,6 +107,7 @@ const SingleProjectView = ({ mapRef }: Props) => {
     requestedSite,
   ]);
 
+  // Enable satellite view for 'conservation' projects or 'trees' projects without plant locations(tree mapper data).
   useEffect(() => {
     const isSatelliteView =
       singleProject.purpose === 'conservation' ||


### PR DESCRIPTION
This PR refactors the logic for setting the satellite view `based on the project purpose (conservation or trees)` and the `availability of plant locations(TreeMapper Data)`. The changes `simplify the useEffect hook` that previously handled these conditions and streamline the flow for determining whether the satellite view should be enabled or not.

`Changes:`
Replaced the previous if conditions and checks for plant locations with a simplified expression.
Satellite view is now set to true for conservation purposes and when there are no plant locations for tree purposes.
The logic for determining satellite view has been consolidated, making it more readable and maintainable.
`Impact:`
Improves readability and clarity of the logic determining when satellite view should be enabled.
Reduces redundant conditional checks, making the code easier to maintain in the future.