### PR TITLE
Migrate database connection from MySQL to PostgreSQL (Data explorer)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
         "read-more-react": "^1.0.10",
         "sass": "^1.62.1",
         "serverless-mysql": "^1.5.4",
+        "serverless-postgres": "^2.1.1",
         "slick-carousel": "^1.8.1",
         "styled-jsx": "^5.0.0",
         "supercluster": "^8.0.1",
@@ -5316,7 +5317,7 @@
       "version": "4.16.2",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.16.2.tgz",
       "integrity": "sha512-vx1nxVvN4QeT/cepQce68deh/Turxy5Mr+4L4zClFuK1GlxN3+ivxfuv+ej/gvidWn1cE1uAhW7ALLNlYbRUAw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
@@ -14198,7 +14199,7 @@
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.7",
@@ -19784,13 +19785,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -25225,6 +25219,87 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
+    "node_modules/pg": {
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.13.1.tgz",
+      "integrity": "sha512-OUir1A0rPNZlX//c7ksiu7crsGZTKSOXJPgtNiHGIlC9H0lO+NC6ZDYksSgBYY/thSWhnSRBv8w1lieNNGATNQ==",
+      "dependencies": {
+        "pg-connection-string": "^2.7.0",
+        "pg-pool": "^3.7.0",
+        "pg-protocol": "^1.7.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.7.0.tgz",
+      "integrity": "sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA=="
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.7.0.tgz",
+      "integrity": "sha512-ZOBQForurqh4zZWjrgSwwAtzJ7QiRX0ovFkZr2klsen3Nm0aoh33Ls0fzfv3imeH/nw/O27cjdz5kzYJfeGp/g==",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.7.0.tgz",
+      "integrity": "sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ=="
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -25563,6 +25638,41 @@
         "node": ">=6.14.4"
       }
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/potpack": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
@@ -25894,7 +26004,7 @@
       "version": "4.16.2",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.16.2.tgz",
       "integrity": "sha512-SYCsBvDf0/7XSJyf2cHTLjLeTLVXYfqp7pG5eEVafFLeT0u/hLFz/9W196nDRGUOo1JfPatAEb+uEnTQImQC1g==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/engines": "4.16.2"
@@ -28007,6 +28117,14 @@
         "@types/mysql": "^2.15.6"
       }
     },
+    "node_modules/serverless-postgres": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/serverless-postgres/-/serverless-postgres-2.1.1.tgz",
+      "integrity": "sha512-ctkK/XL0iVXBXWUZrKp6vLibxgpUmy7EnmXowSzMazO4bTwNC11WPOsfRTa42RdthtvQWgtT14CyVFzyQ+pUdQ==",
+      "dependencies": {
+        "pg": "^8.11.5"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -28447,6 +28565,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,6 @@
         "react-slick": "^0.30.2",
         "read-more-react": "^1.0.10",
         "sass": "^1.62.1",
-        "serverless-mysql": "^1.5.4",
         "serverless-postgres": "^2.1.1",
         "slick-carousel": "^1.8.1",
         "styled-jsx": "^5.0.0",
@@ -10117,15 +10116,6 @@
       "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
       "dev": true
     },
-    "node_modules/@types/mysql": {
-      "version": "2.15.26",
-      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
-      "integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@types/negotiator/-/negotiator-0.6.3.tgz",
@@ -12240,14 +12230,6 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
       "engines": {
         "node": "*"
       }
@@ -21256,52 +21238,6 @@
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
       "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
     },
-    "node_modules/mysql": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
-      "integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
-      "dependencies": {
-        "bignumber.js": "9.0.0",
-        "readable-stream": "2.3.7",
-        "safe-buffer": "5.1.2",
-        "sqlstring": "2.3.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mysql/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-    },
-    "node_modules/mysql/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/mysql/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/mysql/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
@@ -28106,17 +28042,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/serverless-mysql": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/serverless-mysql/-/serverless-mysql-1.5.5.tgz",
-      "integrity": "sha512-QwaCtswn3GKCnqyVA0whwDFMIw91iKTeTvf6F++HoGiunfyvfJ2MdU8d3MKMQdKGNOXIvmUlLq/JVjxuPQxkrw==",
-      "dependencies": {
-        "mysql": "^2.18.1"
-      },
-      "optionalDependencies": {
-        "@types/mysql": "^2.15.6"
-      }
-    },
     "node_modules/serverless-postgres": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/serverless-postgres/-/serverless-postgres-2.1.1.tgz",
@@ -28580,14 +28505,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
-    },
-    "node_modules/sqlstring": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
-      "integrity": "sha512-ooAzh/7dxIG5+uDik1z/Rd1vli0+38izZhGzSa34FwR7IbelPWCCKSNIl8jlL/F7ERvy8CB2jNeM1E9i9mXMAQ==",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/ssf": {
       "version": "0.11.2",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "read-more-react": "^1.0.10",
     "sass": "^1.62.1",
     "serverless-mysql": "^1.5.4",
+    "serverless-postgres": "^2.1.1",
     "slick-carousel": "^1.8.1",
     "styled-jsx": "^5.0.0",
     "supercluster": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "react-slick": "^0.30.2",
     "read-more-react": "^1.0.10",
     "sass": "^1.62.1",
-    "serverless-mysql": "^1.5.4",
     "serverless-postgres": "^2.1.1",
     "slick-carousel": "^1.8.1",
     "styled-jsx": "^5.0.0",

--- a/pages/api/data-explorer/export.ts
+++ b/pages/api/data-explorer/export.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { IExportData } from '../../../src/features/common/types/dataExplorer';
 
-import db from '../../../src/utils/connectDB';
+import { query } from '../../../src/utils/connectDB';
 import nc from 'next-connect';
 import {
   rateLimiter,
@@ -16,46 +16,47 @@ handler.use(speedLimiter);
 handler.post(async (req, response) => {
   const { projectId, startDate, endDate } = req.body;
   try {
-    const query = `
+    const queryText = `
 			SELECT 
-          iv.hid, 
-          iv.intervention_start_date, 
-          COALESCE(ss.name, ps.other_species, iv.other_species, 'Unknown') AS species, 
-          CASE WHEN iv.type='single-tree-registration' THEN 1 ELSE ps.tree_count END AS tree_count, 
-          iv.geometry, 
-          iv.type, 
-          iv.trees_allocated, 
-          iv.trees_planted, 
-          iv.metadata, 
-          iv.description, 
-          iv.plant_project_id, 
-          iv.sample_tree_count, 
-          iv.capture_status, 
-          iv.created 
-				FROM intervention iv 
-				LEFT JOIN planted_species ps ON ps.intervention_id = iv.id 
-				LEFT JOIN scientific_species ss ON COALESCE(iv.scientific_species_id, ps.scientific_species_id) = ss.id 
-				JOIN project pp ON iv.plant_project_id = pp.id 
-				WHERE 
-						pp.guid=? AND 
-						iv.type IN ('multi-tree-registration','single-tree-registration') AND 
-						iv.deleted_at IS NULL AND 
-						iv.intervention_start_date BETWEEN ? AND ?
-			`;
+				iv.hid, 
+				iv.intervention_start_date, 
+				COALESCE(ss.name, ps.other_species, iv.other_species, 'Unknown') AS species, 
+				CASE WHEN iv.type='single-tree-registration' THEN 1 ELSE ps.tree_count END AS tree_count, 
+				iv.geometry, 
+				iv.type, 
+				iv.trees_allocated, 
+				iv.trees_planted, 
+				iv.metadata, 
+				iv.description, 
+				iv.plant_project_id, 
+				iv.sample_tree_count, 
+				iv.capture_status, 
+				iv.created 
+			FROM intervention iv 
+			LEFT JOIN planted_species ps ON ps.intervention_id = iv.id 
+			LEFT JOIN scientific_species ss ON COALESCE(iv.scientific_species_id, ps.scientific_species_id) = ss.id 
+			JOIN project pp ON iv.plant_project_id = pp.id 
+			WHERE 
+					pp.guid = $1 AND 
+					iv.type IN ('multi-tree-registration','single-tree-registration') AND 
+					iv.deleted_at IS NULL AND 
+					iv.intervention_start_date BETWEEN $2 AND $3
+		`;
 
-    const res = await db.query<IExportData[]>(query, [
+    // Set the end date to the end of the day
+    const endDateTime = new Date(endDate);
+    endDateTime.setHours(23, 59, 59, 999);
+
+    const res = await query<IExportData>(queryText, [
       projectId,
       startDate,
-      `${endDate} 23:59:59.999`,
+      endDateTime,
     ]);
-
-    await db.end();
 
     response.status(200).json({ data: res });
   } catch (err) {
     console.error('Error fetching export data:', err);
-  } finally {
-    await db.quit();
+    response.status(500).json({ error: 'Failed to fetch export data' });
   }
 });
 

--- a/pages/api/data-explorer/map/distinct-species/[projectId].ts
+++ b/pages/api/data-explorer/map/distinct-species/[projectId].ts
@@ -4,7 +4,7 @@ import type {
   UncleanDistinctSpecies,
 } from '../../../../../src/features/common/types/dataExplorer';
 
-import db from '../../../../../src/utils/connectDB';
+import { query } from '../../../../../src/utils/connectDB';
 import nc from 'next-connect';
 import {
   rateLimiter,
@@ -43,20 +43,20 @@ handler.get(async (req, response) => {
   let distinctSpecies: DistinctSpecies;
 
   try {
-    const query = `
-			SELECT 
-        	DISTINCT COALESCE(ss.name, ps.other_species, iv.other_species, 'Unknown') AS name 
-        FROM intervention iv
-				LEFT JOIN planted_species ps ON iv.id = ps.intervention_id
-        LEFT JOIN scientific_species ss ON COALESCE(iv.scientific_species_id, ps.scientific_species_id) = ss.id
-        JOIN project pp ON iv.plant_project_id = pp.id 
-        WHERE 
-						pp.guid = ?
-						AND iv.deleted_at IS NULL
-						AND iv.type IN ('single-tree-registration', 'multi-tree-registration')
-			`;
+    const queryText = `
+      SELECT 
+        DISTINCT COALESCE(ss.name, ps.other_species, iv.other_species, 'Unknown') AS "name" 
+      FROM intervention iv
+      LEFT JOIN planted_species ps ON iv.id = ps.intervention_id
+      LEFT JOIN scientific_species ss ON COALESCE(iv.scientific_species_id, ps.scientific_species_id) = ss.id
+      JOIN project pp ON iv.plant_project_id = pp.id 
+      WHERE 
+        pp.guid = $1
+        AND iv.deleted_at IS NULL
+        AND iv.type IN ('single-tree-registration', 'multi-tree-registration')
+    `;
 
-    const res = await db.query<UncleanDistinctSpecies[]>(query, [projectId]);
+    const res = await query<UncleanDistinctSpecies>(queryText, [projectId]);
 
     distinctSpecies = res.map((species) => species.name);
 
@@ -69,8 +69,7 @@ handler.get(async (req, response) => {
     response.status(200).json({ data: distinctSpecies });
   } catch (err) {
     console.error(`Error fetching distinct species for ${projectId}`, err);
-  } finally {
-    db.quit();
+    response.status(500).json({ error: 'Failed to fetch distinct species' });
   }
 });
 

--- a/pages/api/data-explorer/map/plant-location/[plantLocationId].ts
+++ b/pages/api/data-explorer/map/plant-location/[plantLocationId].ts
@@ -5,93 +5,88 @@ import type {
 } from '../../../../../src/features/common/types/dataExplorer';
 
 import nc from 'next-connect';
-import db from '../../../../../src/utils/connectDB';
+import { query } from '../../../../../src/utils/connectDB';
 
 const handler = nc<NextApiRequest, NextApiResponse>();
 
 handler.get(async (req, response) => {
   const { plantLocationId } = req.query;
 
-  const query = `
-    SELECT
-    JSON_OBJECT(
-						'properties', (
-								SELECT JSON_OBJECT(
-										'type', iv.type,
-										'hid', iv.hid
-								)
-								FROM intervention iv
-								WHERE iv.guid = ?
-						),
-            'plantedSpecies', (
-                SELECT JSON_ARRAYAGG(
-                    JSON_OBJECT(
-                        'scientificName', COALESCE(ss.name, ps.other_species, iv.other_species),
-                        'treeCount', COALESCE(ps.tree_count, iv.trees_planted, 0)
-                    )
-                )
-                FROM intervention iv
-                LEFT JOIN planted_species ps ON iv.id = ps.intervention_id
-                LEFT JOIN scientific_species ss ON COALESCE(iv.scientific_species_id, ps.scientific_species_id) = ss.id
-                WHERE iv.guid = ?
-                GROUP BY iv.id
-            ),
-            'totalPlantedTrees', (
-              SELECT SUM(COALESCE(ps.tree_count, iv.trees_planted, 0))
-              FROM intervention iv
-              LEFT JOIN planted_species ps ON iv.id = ps.intervention_id
-              LEFT JOIN scientific_species ss ON COALESCE(iv.scientific_species_id, ps.scientific_species_id) = ss.id
-              WHERE iv.guid = ?
-              GROUP BY iv.id
-          ),
-            'samplePlantLocations', (
-                SELECT JSON_ARRAYAGG(
-                    JSON_OBJECT(
-                        'measurements', JSON_OBJECT(
-                          'height', JSON_UNQUOTE(JSON_EXTRACT(siv.measurements, '$.height')),
-                          'width', JSON_UNQUOTE(JSON_EXTRACT(siv.measurements, '$.width'))
-                      ),
-                        'tag', siv.tag,
-                        'guid', siv.guid,
-                        'species', (
-                          SELECT ss.name 
-                          FROM intervention pl_inner 
-                          JOIN scientific_species ss ON pl_inner.scientific_species_id = ss.id 
-                          WHERE pl_inner.guid = siv.guid
-                          LIMIT 1
-                      ),
-                        'geometry', JSON_OBJECT(
-                          'type', JSON_UNQUOTE(JSON_EXTRACT(siv.geometry, '$.type')),
-                          'coordinates', JSON_EXTRACT(siv.geometry, '$.coordinates')
-                      )
-                    )
-                )
-                FROM intervention iv
-                INNER JOIN intervention siv ON iv.id = siv.parent_id
-                LEFT JOIN scientific_species ss ON iv.scientific_species_id = ss.id
-                WHERE iv.guid = ?
-                GROUP BY iv.parent_id
-            ),
-            'totalSamplePlantLocations', (
-                SELECT COUNT(*) 
-                FROM intervention iv
-                INNER JOIN intervention siv ON iv.id = siv.parent_id
-                WHERE iv.guid = ?
-                GROUP BY iv.parent_id
-            )
-        )
-     AS result;
- `;
+  const queryText = `
+    SELECT 
+			JSON_BUILD_OBJECT(
+				'properties', (
+					SELECT JSON_BUILD_OBJECT(
+						'type', iv.type,
+						'hid', iv.hid
+					)
+					FROM intervention iv
+					WHERE iv.guid = $1
+				),
+				'plantedSpecies', (
+					SELECT COALESCE(JSON_AGG(
+						JSON_BUILD_OBJECT(
+							'scientificName', COALESCE(ss.name, ps.other_species, iv.other_species),
+							'treeCount', COALESCE(ps.tree_count, iv.trees_planted, 0)
+						)
+					), '[]'::json)
+					FROM intervention iv
+					LEFT JOIN planted_species ps ON iv.id = ps.intervention_id
+					LEFT JOIN scientific_species ss ON COALESCE(iv.scientific_species_id, ps.scientific_species_id) = ss.id
+					WHERE iv.guid = $1
+					GROUP BY iv.id
+				),
+				'totalPlantedTrees', (
+					SELECT SUM(COALESCE(ps.tree_count, iv.trees_planted, 0))
+					FROM intervention iv
+					LEFT JOIN planted_species ps ON iv.id = ps.intervention_id
+					LEFT JOIN scientific_species ss ON COALESCE(iv.scientific_species_id, ps.scientific_species_id) = ss.id
+					WHERE iv.guid = $1
+					GROUP BY iv.id
+				),
+				'samplePlantLocations', (
+					SELECT COALESCE(JSON_AGG(
+						JSON_BUILD_OBJECT(
+							'measurements', JSON_BUILD_OBJECT(
+								'height', (siv.measurements->>'height')::text,
+								'width', (siv.measurements->>'width')::text
+							),
+							'tag', siv.tag,
+							'guid', siv.guid,
+							'species', (
+								SELECT ss.name 
+								FROM intervention pl_inner 
+								JOIN scientific_species ss ON pl_inner.scientific_species_id = ss.id 
+								WHERE pl_inner.guid = siv.guid
+								LIMIT 1
+							),
+							'geometry', JSON_BUILD_OBJECT(
+								'type', (siv.geometry->>'type')::text,
+								'coordinates', siv.geometry->'coordinates'
+							)
+						)
+					), '[]'::json)
+					FROM intervention iv
+					INNER JOIN intervention siv ON iv.id = siv.parent_id
+					LEFT JOIN scientific_species ss ON iv.scientific_species_id = ss.id
+					WHERE iv.guid = $1
+					GROUP BY iv.parent_id
+				),
+				'totalSamplePlantLocations', (
+					SELECT COUNT(*) 
+					FROM intervention iv
+					INNER JOIN intervention siv ON iv.id = siv.parent_id
+					WHERE iv.guid = $1
+					GROUP BY iv.parent_id
+				)
+			) as result
+  `;
 
-  const res = await db.query<PlantLocationDetailsQueryRes[]>(query, [
-    plantLocationId,
-    plantLocationId,
-    plantLocationId,
-    plantLocationId,
+  const res = await query<PlantLocationDetailsQueryRes>(queryText, [
     plantLocationId,
   ]);
 
-  const plantLocationDetails: PlantLocationDetails = JSON.parse(res[0].result);
+  const plantLocationDetails: PlantLocationDetails = res[0]?.result || null;
 
   response.status(200).json({
     res: plantLocationDetails,

--- a/pages/api/data-explorer/map/plant-location/index.ts
+++ b/pages/api/data-explorer/map/plant-location/index.ts
@@ -1,15 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import type { Geometry } from '@turf/turf';
+import type { Point, Polygon } from 'geojson';
 import type { SinglePlantLocationApiResponse } from '../../../../../src/features/common/types/dataExplorer';
 
+import { query } from '../../../../../src/utils/connectDB';
 import nc from 'next-connect';
-import db from '../../../../../src/utils/connectDB';
 import { QueryType } from '../../../../../src/features/user/TreeMapper/Analytics/constants';
 
 const handler = nc<NextApiRequest, NextApiResponse>();
 
 interface UncleanPlantLocations {
-  geometry: string;
+  geometry: Point | Polygon;
   guid: string;
   treeCount: number;
   name: string;
@@ -20,49 +20,57 @@ handler.post(async (req, response) => {
     req.body;
 
   try {
-    let query = `
+    let queryText = `
 			SELECT 
-					iv.guid,
-					iv.trees_planted as treeCount,
-					iv.geometry,
-					COALESCE(ss.name, ps.other_species, iv.other_species, 'Unknown') AS name
-        FROM intervention iv
-        LEFT JOIN planted_species ps ON iv.id = ps.intervention_id
-        LEFT JOIN scientific_species ss ON COALESCE(iv.scientific_species_id, ps.scientific_species_id) = ss.id
-        JOIN project pp ON iv.plant_project_id = pp.id
-        WHERE 
-						pp.guid = ? AND 
-						iv.deleted_at IS NULL AND 
-						iv.type in ('multi-tree-registration', 'single-tree-registration')
+				iv.guid,
+				CAST(iv.trees_planted AS INTEGER) as "treeCount",
+				iv.geometry,
+				COALESCE(ss.name, ps.other_species, iv.other_species, 'Unknown') AS "name"
+			FROM intervention iv
+			LEFT JOIN planted_species ps ON iv.id = ps.intervention_id
+			LEFT JOIN scientific_species ss ON COALESCE(iv.scientific_species_id, ps.scientific_species_id) = ss.id
+			JOIN project pp ON iv.plant_project_id = pp.id
+			WHERE 
+				pp.guid = $1 AND 
+				iv.deleted_at IS NULL AND 
+				iv.type in ('multi-tree-registration', 'single-tree-registration')
 			`;
 
     const values = [projectId];
+    let paramIndex = 2;
 
     if (queryType !== QueryType.DATE) {
-      query += ' AND DATE(iv.intervention_start_date) BETWEEN ? AND ?';
+      queryText += ` AND DATE(iv.intervention_start_date) BETWEEN $${paramIndex} AND $${
+        paramIndex + 1
+      }`;
       values.push(fromDate, toDate);
+      paramIndex += 2;
     }
 
     if (queryType) {
       if (queryType === QueryType.DATE) {
         // Filter by date
-        query += ' AND DATE(iv.intervention_start_date) = ?';
+        queryText += ` AND DATE(iv.intervention_start_date) = $${paramIndex}`;
         values.push(searchQuery);
+        paramIndex++;
       } else if (queryType === QueryType.HID) {
         // Filter by HID
-        query += ' AND iv.hid = ?';
+        queryText += ` AND iv.hid = $${paramIndex}`;
         values.push(searchQuery);
+        paramIndex++;
       }
     }
 
     if (species !== 'All') {
       // Filter by species name
-      query +=
-        ' AND (ss.name = ? OR ps.other_species = ? OR iv.other_species = ?)';
+      queryText += ` AND (ss.name = $${paramIndex} OR ps.other_species = $${
+        paramIndex + 1
+      } OR iv.other_species = $${paramIndex + 2})`;
       values.push(species, species, species);
+      paramIndex += 3;
     }
 
-    const qRes = await db.query<UncleanPlantLocations[]>(query, values);
+    const qRes = await query<UncleanPlantLocations>(queryText, values);
 
     const plantLocations: SinglePlantLocationApiResponse[] = qRes.map(
       (plantLocation) => ({
@@ -71,11 +79,9 @@ handler.post(async (req, response) => {
           guid: plantLocation.guid,
           treeCount: plantLocation.treeCount,
         },
-        geometry: JSON.parse(plantLocation.geometry) as Geometry,
+        geometry: plantLocation.geometry,
       })
     );
-
-    await db.end();
 
     response.setHeader(
       'Cache-Control',
@@ -86,8 +92,6 @@ handler.post(async (req, response) => {
   } catch (err) {
     console.error('Error fetching plant location data:', err);
     response.status(500).json({ error: 'Internal Server Error' });
-  } finally {
-    db.quit();
   }
 });
 

--- a/pages/api/data-explorer/species-planted.ts
+++ b/pages/api/data-explorer/species-planted.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { ISpeciesPlanted } from '../../../src/features/common/types/dataExplorer';
 
-import db from '../../../src/utils/connectDB';
+import { query } from '../../../src/utils/connectDB';
 import nc from 'next-connect';
 import {
   rateLimiter,
@@ -41,33 +41,38 @@ handler.post(async (req, response) => {
   }
 
   try {
-    const query = `
-			SELECT 
-					ps.other_species,
-					COALESCE(iv.scientific_species_id,
-									ps.scientific_species_id) AS scientific_species_id,
-					COALESCE(ss.name,
-									ps.other_species,
-									iv.other_species, 'Unknown') AS name,
-					SUM(COALESCE(ps.tree_count, iv.trees_planted, 0)) AS total_tree_count
-				FROM intervention iv
-				LEFT JOIN planted_species ps ON iv.id = ps.intervention_id
-				LEFT JOIN scientific_species ss ON COALESCE(iv.scientific_species_id, ps.scientific_species_id) = ss.id
-				JOIN project pp ON iv.plant_project_id = pp.id
-				WHERE
-						iv.deleted_at IS NULL
-						AND iv.type IN ('single-tree-registration', 'multi-tree-registration')
-						AND pp.guid = ? 
-						AND iv.intervention_start_date BETWEEN ? AND ?
-				GROUP BY 
-						COALESCE(iv.scientific_species_id, ps.scientific_species_id), 
-						COALESCE(ss.name, ps.other_species, iv.other_species, 'Unknown')
-				ORDER BY total_tree_count DESC`;
+    const queryText = `
+      SELECT 
+        ps.other_species,
+        COALESCE(iv.scientific_species_id,
+                ps.scientific_species_id) AS scientific_species_id,
+        COALESCE(ss.name,
+                ps.other_species,
+                iv.other_species, 'Unknown') AS name,
+        SUM(COALESCE(ps.tree_count, iv.trees_planted, 0))::integer AS total_tree_count
+      FROM intervention iv
+      LEFT JOIN planted_species ps ON iv.id = ps.intervention_id
+      LEFT JOIN scientific_species ss ON COALESCE(iv.scientific_species_id, ps.scientific_species_id) = ss.id
+      JOIN project pp ON iv.plant_project_id = pp.id
+      WHERE
+        iv.deleted_at IS NULL
+        AND iv.type IN ('single-tree-registration', 'multi-tree-registration')
+        AND pp.guid = $1 
+        AND iv.intervention_start_date BETWEEN $2 AND $3
+      GROUP BY 
+        ps.other_species,
+        COALESCE(iv.scientific_species_id, ps.scientific_species_id), 
+        COALESCE(ss.name, ps.other_species, iv.other_species, 'Unknown')
+      ORDER BY total_tree_count DESC`;
 
-    const res = await db.query<ISpeciesPlanted[]>(query, [
+    // Ensure endDate includes time
+    const endDateTime = new Date(endDate);
+    endDateTime.setHours(23, 59, 59, 999);
+
+    const res = await query<ISpeciesPlanted>(queryText, [
       projectId,
       startDate,
-      `${endDate} 23:59:59.999`,
+      endDateTime,
     ]);
 
     await redisClient.set(CACHE_KEY, JSON.stringify(res), {
@@ -77,8 +82,9 @@ handler.post(async (req, response) => {
     response.status(200).json({ data: res });
   } catch (err) {
     console.error('Error fetching species planted:', err);
-  } finally {
-    await db.quit();
+    response
+      .status(500)
+      .json({ error: 'Failed to fetch species planted data' });
   }
 });
 

--- a/pages/api/data-explorer/total-trees-planted.ts
+++ b/pages/api/data-explorer/total-trees-planted.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { TotalTreesPlanted } from '../../../src/features/common/types/dataExplorer';
 
-import db from '../../../src/utils/connectDB';
+import { query } from '../../../src/utils/connectDB';
 import nc from 'next-connect';
 import {
   rateLimiter,
@@ -42,21 +42,25 @@ handler.post(async (req, response) => {
   }
 
   try {
-    const query = `
+    const queryText = `
 			SELECT
-					COALESCE(SUM(iv.trees_planted), 0) AS totalTreesPlanted
-				FROM intervention iv
-				JOIN project pp ON iv.plant_project_id = pp.id
-				WHERE 
-						iv.deleted_at IS NULL
-						AND iv.type IN ('single-tree-registration', 'multi-tree-registration')
-						AND pp.guid = ? 
-						AND iv.intervention_start_date BETWEEN ? AND ?`;
+				COALESCE(SUM(iv.trees_planted), 0)::integer AS "totalTreesPlanted"
+			FROM intervention iv
+			JOIN project pp ON iv.plant_project_id = pp.id
+			WHERE 
+				iv.deleted_at IS NULL
+				AND iv.type IN ('single-tree-registration', 'multi-tree-registration')
+				AND pp.guid = $1
+				AND iv.intervention_start_date BETWEEN $2 AND $3`;
 
-    const res = await db.query<TotalTreesPlanted[]>(query, [
+    // Ensure endDate includes time
+    const endDateTime = new Date(endDate);
+    endDateTime.setHours(23, 59, 59, 999);
+
+    const res = await query<TotalTreesPlanted>(queryText, [
       projectId,
       startDate,
-      `${endDate} 23:59:59.999`,
+      endDateTime,
     ]);
 
     await redisClient.set(CACHE_KEY, JSON.stringify(res[0]), {
@@ -66,8 +70,7 @@ handler.post(async (req, response) => {
     response.status(200).json({ data: res[0] });
   } catch (err) {
     console.error('Error fetching total trees planted:', err);
-  } finally {
-    await db.quit();
+    response.status(500).json({ error: 'Failed to fetch total trees planted' });
   }
 });
 

--- a/pages/api/data-explorer/trees-planted.ts
+++ b/pages/api/data-explorer/trees-planted.ts
@@ -6,7 +6,7 @@ import type {
   IYearlyFrame,
 } from '../../../src/features/common/types/dataExplorer';
 
-import db from '../../../src/utils/connectDB';
+import { query } from '../../../src/utils/connectDB';
 import { TIME_FRAME } from '../../../src/features/user/TreeMapper/Analytics/components/TreePlanted/TimeFrameSelector';
 import nc from 'next-connect';
 import {
@@ -49,103 +49,116 @@ handler.post(async (req, response) => {
     return;
   }
 
-  let query: string;
+  let queryText: string;
 
   switch (timeFrame) {
     case TIME_FRAME.DAYS:
-      query = `
-				SELECT
-						iv.intervention_start_date AS plantedDate,
-						SUM(iv.trees_planted) AS treesPlanted
-					FROM intervention iv
-					JOIN project pp ON iv.plant_project_id = pp.id
-					WHERE
-							iv.deleted_at IS NULL AND
-							iv.type IN ('single-tree-registration', 'multi-tree-registration') AND
-							pp.guid = ? AND 
-							iv.intervention_start_date BETWEEN ? AND ?
-					GROUP BY iv.intervention_start_date
-					ORDER BY iv.intervention_start_date
-			`;
+      queryText = `
+        SELECT
+          iv.intervention_start_date AS "plantedDate",
+          SUM(iv.trees_planted) AS "treesPlanted"
+        FROM intervention iv
+        JOIN project pp ON iv.plant_project_id = pp.id
+        WHERE
+          iv.deleted_at IS NULL AND
+          iv.type IN ('single-tree-registration', 'multi-tree-registration') AND
+          pp.guid = $1 AND 
+          iv.intervention_start_date BETWEEN $2 AND $3
+        GROUP BY iv.intervention_start_date
+        ORDER BY iv.intervention_start_date
+      `;
       break;
 
     case TIME_FRAME.WEEKS:
-      query = `
-				SELECT
-						DATE_SUB(iv.intervention_start_date, INTERVAL WEEKDAY(iv.intervention_start_date) DAY) AS weekStartDate,
-						DATE_ADD(DATE_SUB(iv.intervention_start_date, INTERVAL WEEKDAY(iv.intervention_start_date) DAY), INTERVAL 6 DAY) AS weekEndDate,
-						WEEK(iv.intervention_start_date, 1) AS weekNum,
-						LEFT(MONTHNAME(iv.intervention_start_date), 3) AS month,
-						YEAR(iv.intervention_start_date) AS year,
-						SUM(iv.trees_planted) AS treesPlanted
-					FROM intervention iv
-					JOIN project pp ON iv.plant_project_id = pp.id
-					WHERE
-							iv.deleted_at IS NULL AND
-							iv.type IN ('single-tree-registration', 'multi-tree-registration') AND 
-							pp.guid = ? AND 
-							iv.intervention_start_date BETWEEN ? AND ?
-					GROUP BY weekNum, weekStartDate, weekEndDate, month, year
-					ORDER BY iv.intervention_start_date
-				`;
-      break;
-
-    case TIME_FRAME.MONTHS:
-      query = `
-				SELECT 
-						LEFT(MONTHNAME(iv.intervention_start_date), 3) AS month,
-						YEAR(iv.intervention_start_date) AS year,
-						SUM(iv.trees_planted) AS treesPlanted
-					FROM intervention iv
-					JOIN project pp ON iv.plant_project_id = pp.id 
-					WHERE
-							iv.deleted_at IS NULL AND
-							iv.type IN ('single-tree-registration', 'multi-tree-registration') AND 
-							pp.guid = ? AND 
-							iv.intervention_start_date BETWEEN ? AND ? 
-					GROUP BY month, year 
-					ORDER BY iv.intervention_start_date
-				`;
-      break;
-
-    case TIME_FRAME.YEARS:
-      query = `
-				SELECT 
-						YEAR(iv.intervention_start_date) AS year, 
-						SUM(iv.trees_planted) AS treesPlanted 
-					FROM intervention iv 
-					JOIN project pp ON iv.plant_project_id = pp.id 
-					WHERE
-							iv.deleted_at IS NULL AND
-							iv.type IN ('single-tree-registration', 'multi-tree-registration') AND
-							pp.guid = ? AND 
-							iv.intervention_start_date BETWEEN ? AND ? 
-					GROUP BY year 
-					ORDER BY iv.intervention_start_date
-				`;
-      break;
-
-    default:
-      query = `
-				SELECT
-            YEAR(iv.intervention_start_date) AS year,
-            SUM(iv.trees_planted) AS treesPlanted
+      queryText = `
+         WITH week_ranges AS (
+          SELECT
+            DATE_TRUNC('week', iv.intervention_start_date)::timestamptz AS week_start,
+            EXTRACT(WEEK FROM iv.intervention_start_date)::integer AS week_num,
+            SUM(iv.trees_planted) AS trees
           FROM intervention iv
           JOIN project pp ON iv.plant_project_id = pp.id
           WHERE
-							iv.deleted_at IS NULL AND
-							iv.type IN ('single-tree-registration', 'multi-tree-registration') AND 
-							pp.guid = ? AND 
-							iv.intervention_start_date BETWEEN ? AND ?
-          GROUP BY year
-          ORDER BY iv.intervention_start_date
-				`;
+            iv.deleted_at IS NULL AND
+            iv.type IN ('single-tree-registration', 'multi-tree-registration') AND 
+            pp.guid = $1 AND 
+            iv.intervention_start_date BETWEEN $2 AND $3
+          GROUP BY 
+            week_start,
+            week_num
+        )
+        SELECT
+          week_start AS "weekStartDate",
+          (week_start + INTERVAL '6 days')::timestamptz AS "weekEndDate",
+          week_num AS "weekNum",
+          TO_CHAR(week_start, 'Mon') AS month,
+          EXTRACT(YEAR FROM week_start)::integer AS year,
+          trees::integer AS "treesPlanted"
+        FROM week_ranges
+        ORDER BY week_start
+      `;
+      break;
+
+    case TIME_FRAME.MONTHS:
+      queryText = `
+        SELECT 
+          TO_CHAR(iv.intervention_start_date, 'Mon') AS month,
+          EXTRACT(YEAR FROM iv.intervention_start_date) AS year,
+          SUM(iv.trees_planted) AS "treesPlanted"
+        FROM intervention iv
+        JOIN project pp ON iv.plant_project_id = pp.id 
+        WHERE
+          iv.deleted_at IS NULL AND
+          iv.type IN ('single-tree-registration', 'multi-tree-registration') AND 
+          pp.guid = $1 AND 
+          iv.intervention_start_date BETWEEN $2 AND $3
+        GROUP BY month, year, DATE_TRUNC('month', iv.intervention_start_date)
+        ORDER BY DATE_TRUNC('month', iv.intervention_start_date)
+      `;
+      break;
+
+    case TIME_FRAME.YEARS:
+      queryText = `
+        SELECT 
+          EXTRACT(YEAR FROM iv.intervention_start_date) AS year,
+          SUM(iv.trees_planted) AS "treesPlanted"
+        FROM intervention iv 
+        JOIN project pp ON iv.plant_project_id = pp.id 
+        WHERE
+          iv.deleted_at IS NULL AND
+          iv.type IN ('single-tree-registration', 'multi-tree-registration') AND
+          pp.guid = $1 AND 
+          iv.intervention_start_date BETWEEN $2 AND $3
+        GROUP BY year 
+        ORDER BY year
+      `;
+      break;
+
+    default:
+      queryText = `
+        SELECT
+          EXTRACT(YEAR FROM iv.intervention_start_date) AS year,
+          SUM(iv.trees_planted) AS "treesPlanted"
+        FROM intervention iv
+        JOIN project pp ON iv.plant_project_id = pp.id
+        WHERE
+          iv.deleted_at IS NULL AND
+          iv.type IN ('single-tree-registration', 'multi-tree-registration') AND 
+          pp.guid = $1 AND 
+          iv.intervention_start_date BETWEEN $2 AND $3
+        GROUP BY year
+        ORDER BY year
+      `;
   }
 
   try {
-    const res = await db.query<
-      IDailyFrame[] | IWeeklyFrame[] | IMonthlyFrame[] | IYearlyFrame[]
-    >(query, [projectId, startDate, `${endDate} 23:59:59.999`]);
+    // Ensure endDate includes time up to the last millisecond of the day
+    const endDateTime = new Date(endDate);
+    endDateTime.setHours(23, 59, 59, 999);
+
+    const res = await query<
+      IDailyFrame | IWeeklyFrame | IMonthlyFrame | IYearlyFrame
+    >(queryText, [projectId, startDate, endDateTime]);
 
     await redisClient.set(CACHE_KEY, JSON.stringify(res), {
       ex: TWO_HOURS,
@@ -154,8 +167,7 @@ handler.post(async (req, response) => {
     response.status(200).json({ data: res });
   } catch (err) {
     console.error('Error fetching trees planted:', err);
-  } finally {
-    await db.quit();
+    response.status(500).json({ error: 'Failed to fetch trees planted data' });
   }
 });
 

--- a/src/features/common/types/dataExplorer.d.ts
+++ b/src/features/common/types/dataExplorer.d.ts
@@ -1,4 +1,4 @@
-import type { Geometry } from '@turf/turf';
+import type { Point, Polygon } from 'geojson';
 
 export interface IDailyFrame {
   plantedDate: string;
@@ -58,7 +58,7 @@ export interface TotalSpeciesPlanted {
 }
 
 export interface Feature {
-  geometry: Geometry;
+  geometry: Point | Polygon;
   properties: {
     name: string;
   };
@@ -72,7 +72,7 @@ export type FeatureCollection = {
 
 export interface UncleanSite {
   name: string;
-  geometry: string;
+  geometry: Point | Polygon;
 }
 
 export interface UncleanDistinctSpecies {
@@ -87,7 +87,7 @@ export interface UncleanPlantLocations {
 }
 
 export interface PlantLocation {
-  geometry: Geometry;
+  geometry: Point | Polygon;
   properties: {
     guid: string;
     treeCount: number;
@@ -111,7 +111,7 @@ export interface Measurements {
 export interface SamplePlantLocation {
   tag: string | null;
   guid: string;
-  geometry: Geometry;
+  geometry: Point;
   measurements: Measurements;
 }
 
@@ -121,7 +121,7 @@ export interface PlantedSpecies {
 }
 
 export interface PlantLocationDetailsQueryRes {
-  result: string;
+  result: PlantLocationDetails;
 }
 
 export interface PlantLocationProperties {
@@ -167,7 +167,7 @@ export interface PlantLocationDetailsApiResponse {
 }
 
 export interface SinglePlantLocationApiResponse {
-  geometry: Geometry;
+  geometry: Point | Polygon;
   properties: {
     guid: string;
     treeCount: number;

--- a/src/features/user/TreeMapper/Analytics/components/TreePlanted/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/TreePlanted/index.tsx
@@ -508,6 +508,10 @@ export const TreePlanted = () => {
           xaxis: {
             ...options.xaxis,
             categories: categories,
+            labels: {
+              ...options.xaxis?.labels,
+              rotateAlways: data.length > 15,
+            },
           },
           tooltip: {
             custom: function ({ series: s, dataPointIndex }) {

--- a/src/utils/connectDB.ts
+++ b/src/utils/connectDB.ts
@@ -9,6 +9,8 @@ interface DatabaseConfig {
   user?: string;
   password?: string;
   debug?: boolean;
+  ssl: { rejectUnauthorized: boolean };
+  maxConnections?: number;
 }
 
 interface Field {
@@ -46,6 +48,8 @@ const config: DatabaseConfig = {
   user,
   password,
   debug: process.env.NODE_ENV === 'development',
+  ssl: { rejectUnauthorized: false },
+  maxConnections: 20,
 };
 
 const db = new postgres(config);

--- a/src/utils/connectDB.ts
+++ b/src/utils/connectDB.ts
@@ -1,20 +1,73 @@
-import mysql from 'serverless-mysql';
+import postgres from 'serverless-postgres';
 import { ConnectionString } from 'connection-string';
 
-const { user, password, path, hostname: host, port } = new ConnectionString(
-  process.env.DB_CONN_URL
-);
+// Types for database configuration
+interface DatabaseConfig {
+  host?: string;
+  port?: number;
+  database?: string;
+  user?: string;
+  password?: string;
+  debug?: boolean;
+}
+
+interface Field {
+  name: string;
+  tableID: number;
+  columnID: number;
+  dataTypeID: number;
+  dataTypeSize: number;
+  dataTypeModifier: number;
+  format: string;
+}
+
+// Type for query response from serverless-postgres
+interface QueryResult<T> {
+  command: 'SELECT' | 'UPDATE' | 'INSERT' | 'DELETE';
+  rowCount: number;
+  rows: T[];
+  fields: Field[];
+}
+
+const {
+  user,
+  password,
+  path,
+  hostname: host,
+  port,
+} = new ConnectionString(process.env.DB_CONN_URL);
 
 const database = path?.[0];
 
-const db = mysql({
-  config: {
-    host,
-    port,
-    database,
-    user,
-    password,
-  },
-});
+const config: DatabaseConfig = {
+  host,
+  port: port,
+  database,
+  user,
+  password,
+  debug: process.env.NODE_ENV === 'development',
+};
+
+const db = new postgres(config);
+
+/**
+ * Executes a SQL query with proper connection handling
+ * @param queryText - The SQL query text with $1, $2, etc. for parameters
+ * @param values - Array of parameter values [$1, $2 etc.]
+ * @returns Promise resolving to an array of query results
+ * @throws Error if query fails
+ */
+export async function query<T>(
+  queryText: string,
+  values: unknown[] = []
+): Promise<T[]> {
+  try {
+    await db.connect();
+    const result: QueryResult<T> = await db.query(queryText, values);
+    return result.rows;
+  } finally {
+    await db.clean(); // This is better than quit() for serverless environments
+  }
+}
 
 export default db;


### PR DESCRIPTION
Replace MySQL with PostgreSQL for database connections for data explorer APIS + implement a new query helper function, and adapt data explorer APIs accordingly. 

Also rotates the labels of Trees Planted graph when more than 15 columns are to be shown (or when space is less, whichever is earlier).

Pending

- [x] Uninstall serverless-mysql