### PR TITLE
Improve user widget rendering and handle null cases

### DIFF
--- a/pages/sites/[slug]/[locale]/profile/widgets.tsx
+++ b/pages/sites/[slug]/[locale]/profile/widgets.tsx
@@ -54,15 +54,19 @@ function ProfilePage({ pageProps: { tenantConfig } }: Props): ReactElement {
       <Head>
         <title>{t('widgets')}</title>
       </Head>
-      {user?.isPrivate === false ? (
-        <div className={styles.widgetsContainer}>
-          <iframe
-            src={`${process.env.WIDGET_URL}?user=${user?.id}&tenantkey=${tenantConfig.id}`}
-            className={styles.widgetIFrame}
-          />
-        </div>
-      ) : (
-        <EmbedModal {...embedModalProps} />
+      {user !== null && (
+        <>
+          {user.isPrivate === false ? (
+            <div className={styles.widgetsContainer}>
+              <iframe
+                src={`${process.env.WIDGET_URL}?user=${user.slug}&tenantkey=${tenantConfig.id}`}
+                className={styles.widgetIFrame}
+              />
+            </div>
+          ) : (
+            <EmbedModal {...embedModalProps} />
+          )}
+        </>
       )}
     </UserLayout>
   ) : (


### PR DESCRIPTION
Enhance the rendering logic for user widgets by passing the user slug for a more recognizable URL and preventing `user=undefined` in the iframe URL when the user is null.