### PR TITLE
intervention condition added

### DIFF
--- a/src/features/projectsV2/ProjectsMap/microComponents/PlantLocations.tsx
+++ b/src/features/projectsV2/ProjectsMap/microComponents/PlantLocations.tsx
@@ -220,6 +220,7 @@ export default function PlantLocations(): React.ReactElement {
         />
         {selectedPlantLocation &&
         selectedPlantLocation.type !== 'single-tree-registration' &&
+        (selectedInterventionType === 'multi-tree-registration' || selectedInterventionType === 'enrichment-planting' ||  selectedInterventionType ==='all' ||  selectedInterventionType === 'default') &&
         viewState.zoom > 14 &&
         selectedPlantLocation.sampleInterventions
           ? selectedPlantLocation.sampleInterventions.map((spl) => {


### PR DESCRIPTION
Changes in this pull request:
In this PR  intervention filter condition has been added to the PlantLocation component to ensure that sample trees are hidden on the map when an intervention without sample trees is selected.

@sunil-sabat 