### PR TITLE
LatLng convention fixed.

### DIFF
--- a/src/features/projectsV2/ProjectsMap/FirePopup/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/FirePopup/index.tsx
@@ -90,6 +90,13 @@ export default function FirePopup({ isOpen, feature }: Props) {
     return { amount: `${days}`, unit: 'd' }; // 24 hours or more
   }, [feature.properties.eventDate]);
 
+  const alertCoordinates = useMemo(() => {
+    const [lng, lat] = feature.geometry.coordinates;
+    const latString = lat >= 0 ? `${Math.abs(lat)}°N` : `${Math.abs(lat)}°S`;
+    const lngString = lng >= 0 ? `${Math.abs(lng)}°E` : `${Math.abs(lng)}°W`;
+    return `${latString}, ${lngString}`;
+  }, [feature.geometry.coordinates]);
+
   const alertConfidence = useMemo(() => {
     const confidenceMap: Record<string, string> = {
       high: 'highAlertConfidenceText',
@@ -155,10 +162,7 @@ export default function FirePopup({ isOpen, feature }: Props) {
             </p>
           </header>
           <div className={styles.popupText}>
-            <p className={styles.coordinates}>
-              {feature.geometry.coordinates[0]},{' '}
-              {feature.geometry.coordinates[1]}
-            </p>
+            <p className={styles.coordinates}>{alertCoordinates}</p>
             <p>
               {tProjectDetails.rich(alertConfidence, {
                 important: (chunks) => <span>{chunks}</span>,


### PR DESCRIPTION
Fixes #
Previously In the Fire Popup it shows the coordinates in following manner
[longitude], [latitude]
This PR fixes that & displays it corrected manner [latitude][°N/S], [longitude][°E/W].
Following are few Screenshots.

![Screenshot 2025-01-29 at 18 47 03](https://github.com/user-attachments/assets/eee19fff-de01-4b6d-a685-6d55de7f4dad)
![Screenshot 2025-01-29 at 18 48 32](https://github.com/user-attachments/assets/04fe324e-046a-4b9a-8068-0333dac61ff8)
