### PR TITLE
Adds functionality to show soil bulk density + other available layers in the map

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -123,6 +123,8 @@ const nextConfig = {
     REDIS_URL: process.env.REDIS_URL,
     REDIS_TOKEN: process.env.REDIS_TOKEN,
     WEBHOOK_URL: process.env.WEBHOOK_URL,
+    LAYERS_API_KEY: process.env.LAYERS_API_KEY,
+    LAYERS_API_ENDPOINT: process.env.LAYERS_API_ENDPOINT,
   },
   trailingSlash: false,
   reactStrictMode: true,

--- a/public/static/locales/en/maps.json
+++ b/public/static/locales/en/maps.json
@@ -62,7 +62,7 @@
         "projects": "Projects",
         "forestCover": "Forest Cover",
         "forestBiomass": "Forest Biomass",
-        "potentialForestBiomass": "Potential Additional Forest Biomass",
+        "biomassPotential": "Potential Additional Forest Biomass",
         "deforestation": "Deforestation",
         "canopyHeight": "Canopy Height",
         "soilNitrogen": "Soil Nitrogen",

--- a/src/features/projectsV2/ProjectsMap/ExploreLayers.tsx
+++ b/src/features/projectsV2/ProjectsMap/ExploreLayers.tsx
@@ -33,12 +33,7 @@ export default function ExploreLayers(): ReactElement | null {
           return null;
         }
 
-        const tiles = [
-          layerData.tileUrl.replace(
-            'https://storage.googleapis.com/planet-layers',
-            'https://layers-t.plant-for-the-planet.org'
-          ),
-        ];
+        const tiles = [layerData.tileUrl];
 
         return (
           <Source

--- a/src/features/projectsV2/ProjectsMap/ExploreLayers.tsx
+++ b/src/features/projectsV2/ProjectsMap/ExploreLayers.tsx
@@ -1,0 +1,50 @@
+import type { ReactElement } from 'react';
+import type { MapOptions } from '../ProjectsMapContext';
+import type { MapLayerOptionsType } from '../../../utils/mapsV2/mapSettings.config';
+
+import { Layer, Source } from 'react-map-gl-v7/maplibre';
+import { useProjectsMap } from '../ProjectsMapContext';
+
+const getEnabledLayers = (mapOptions: MapOptions): MapLayerOptionsType[] => {
+  const enabledLayers: MapLayerOptionsType[] = [];
+  Object.entries(mapOptions).forEach(([key, value]) => {
+    if (key !== 'projects' && value === true) {
+      enabledLayers.push(key as MapLayerOptionsType);
+    }
+  });
+  return enabledLayers;
+};
+
+export default function ExploreLayers(): ReactElement | null {
+  const { exploreLayersData, mapOptions } = useProjectsMap();
+  if (!exploreLayersData) return null;
+
+  const enabledLayers = getEnabledLayers(mapOptions);
+  if (enabledLayers.length === 0) return null;
+
+  return (
+    <>
+      {enabledLayers.map((layerKey) => {
+        const layerData = exploreLayersData[layerKey];
+
+        if (!layerData || !layerData.tileUrl) {
+          return null;
+        }
+
+        const tiles = [layerData.tileUrl];
+
+        return (
+          <Source
+            key={layerKey}
+            id={layerKey}
+            type="raster"
+            tiles={tiles}
+            tileSize={128}
+          >
+            <Layer id={`${layerKey}-layer`} source={layerKey} type="raster" />
+          </Source>
+        );
+      })}
+    </>
+  );
+}

--- a/src/features/projectsV2/ProjectsMap/ExploreLayers.tsx
+++ b/src/features/projectsV2/ProjectsMap/ExploreLayers.tsx
@@ -31,7 +31,12 @@ export default function ExploreLayers(): ReactElement | null {
           return null;
         }
 
-        const tiles = [layerData.tileUrl];
+        const tiles = [
+          layerData.tileUrl.replace(
+            'https://storage.googleapis.com/planet-layers',
+            'https://layers-t.plant-for-the-planet.org'
+          ),
+        ];
 
         return (
           <Source

--- a/src/features/projectsV2/ProjectsMap/ExploreLayers.tsx
+++ b/src/features/projectsV2/ProjectsMap/ExploreLayers.tsx
@@ -5,26 +5,28 @@ import type { MapLayerOptionsType } from '../../../utils/mapsV2/mapSettings.conf
 import { Layer, Source } from 'react-map-gl-v7/maplibre';
 import { useProjectsMap } from '../ProjectsMapContext';
 
-const getEnabledLayers = (mapOptions: MapOptions): MapLayerOptionsType[] => {
-  const enabledLayers: MapLayerOptionsType[] = [];
+const getSelectedLayerKeys = (
+  mapOptions: MapOptions
+): MapLayerOptionsType[] => {
+  const selectedLayers: MapLayerOptionsType[] = [];
   Object.entries(mapOptions).forEach(([key, value]) => {
     if (key !== 'projects' && value === true) {
-      enabledLayers.push(key as MapLayerOptionsType);
+      selectedLayers.push(key as MapLayerOptionsType);
     }
   });
-  return enabledLayers;
+  return selectedLayers;
 };
 
 export default function ExploreLayers(): ReactElement | null {
   const { exploreLayersData, mapOptions } = useProjectsMap();
   if (!exploreLayersData) return null;
 
-  const enabledLayers = getEnabledLayers(mapOptions);
-  if (enabledLayers.length === 0) return null;
+  const selectedLayers = getSelectedLayerKeys(mapOptions);
+  if (selectedLayers.length === 0) return null;
 
   return (
     <>
-      {enabledLayers.map((layerKey) => {
+      {selectedLayers.map((layerKey) => {
         const layerData = exploreLayersData[layerKey];
 
         if (!layerData || !layerData.tileUrl) {

--- a/src/features/projectsV2/ProjectsMap/ExploreLayers.tsx
+++ b/src/features/projectsV2/ProjectsMap/ExploreLayers.tsx
@@ -8,6 +8,8 @@ import type { MapLayerOptionsType } from '../../../utils/mapsV2/mapSettings.conf
 import { Layer, Source } from 'react-map-gl-v7/maplibre';
 import { useProjectsMap } from '../ProjectsMapContext';
 
+const TILE_SIZE = 128;
+
 const getSelectedLayerKeys = (
   mapOptions: MapOptions
 ): MapLayerOptionsType[] => {
@@ -47,7 +49,7 @@ export default function ExploreLayers(): ReactElement | null {
             id={layerKey}
             type="raster"
             tiles={tiles}
-            tileSize={128}
+            tileSize={TILE_SIZE}
             minzoom={layerData.zoomConfig.minZoom}
             maxzoom={layerData.zoomConfig.maxZoom}
           >

--- a/src/features/projectsV2/ProjectsMap/ExploreLayers.tsx
+++ b/src/features/projectsV2/ProjectsMap/ExploreLayers.tsx
@@ -47,6 +47,8 @@ export default function ExploreLayers(): ReactElement | null {
             type="raster"
             tiles={tiles}
             tileSize={128}
+            minzoom={layerData.zoomConfig.minZoom}
+            maxzoom={layerData.zoomConfig.maxZoom}
           >
             <Layer id={`${layerKey}-layer`} source={layerKey} type="raster" />
           </Source>

--- a/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/microComponents/MapSettingsSection.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/microComponents/MapSettingsSection.tsx
@@ -18,7 +18,8 @@ type Props = BaseProps &
   );
 
 const isValidGroup = (config: LayerConfig[]): boolean =>
-  config.length > 0 && config.some((layerConfig) => layerConfig.isAvailable);
+  config.length > 0 &&
+  config.some((layerConfig) => layerConfig.isAvailable && layerConfig.canShow);
 
 const GroupedLayers = ({
   config,
@@ -26,7 +27,7 @@ const GroupedLayers = ({
   updateMapOption,
 }: { config: LayerConfig[] } & BaseProps) => {
   const availableLayersConfig = config.filter(
-    (layerConfig) => layerConfig.isAvailable
+    (layerConfig) => layerConfig.isAvailable && layerConfig.canShow
   );
 
   return (

--- a/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/microComponents/MapSettingsSection.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/microComponents/MapSettingsSection.tsx
@@ -25,13 +25,13 @@ const GroupedLayers = ({
   mapOptions,
   updateMapOption,
 }: { config: LayerConfig[] } & BaseProps) => {
-  const availableLayers = config.filter(
+  const availableLayersConfig = config.filter(
     (layerConfig) => layerConfig.isAvailable
   );
 
   return (
     <div>
-      {availableLayers.map((layerConfig) => (
+      {availableLayersConfig.map((layerConfig) => (
         <SingleLayerOption
           key={layerConfig.key}
           layerConfig={layerConfig}

--- a/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/microComponents/MapSettingsSection.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/microComponents/MapSettingsSection.tsx
@@ -1,5 +1,7 @@
 import type { LayerConfig } from '../../../../../utils/mapsV2/mapSettings.config';
 import type { MapOptions } from '../../../ProjectsMapContext';
+
+import { useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import SingleLayerOption from './SingleLayerOption';
 import styles from '../MapFeatureExplorer.module.scss';
@@ -26,8 +28,12 @@ const GroupedLayers = ({
   mapOptions,
   updateMapOption,
 }: { config: LayerConfig[] } & BaseProps) => {
-  const availableLayersConfig = config.filter(
-    (layerConfig) => layerConfig.isAvailable && layerConfig.canShow
+  const availableLayersConfig = useMemo(
+    () =>
+      config.filter(
+        (layerConfig) => layerConfig.isAvailable && layerConfig.canShow
+      ),
+    [config]
   );
 
   return (

--- a/src/features/projectsV2/ProjectsMap/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/index.tsx
@@ -10,6 +10,7 @@ import dynamic from 'next/dynamic';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import Map, { NavigationControl } from 'react-map-gl-v7/maplibre';
 import { useProjectsMap } from '../ProjectsMapContext';
+import { useFetchLayers } from '../../../utils/mapsV2/useFetchLayers';
 import MultipleProjectsView from './MultipleProjectsView';
 import SingleProjectView from './SingleProjectView';
 import {
@@ -48,7 +49,9 @@ export type ProjectsMapMobileProps = {
 export type ProjectsMapProps = ProjectsMapMobileProps | ProjectsMapDesktopProps;
 
 function ProjectsMap(props: ProjectsMapProps) {
-  // const [mobileOS, setMobileOS] = useState<MobileOs>(null);
+  // Fetch layers data
+  useFetchLayers();
+
   const mapRef: MapRef = useRef<ExtendedMapLibreMap | null>(null);
   const {
     viewState,
@@ -203,18 +206,15 @@ function ProjectsMap(props: ProjectsMapProps) {
         selectedPlantLocation?.type === 'single-tree-registration';
       const isMultiTree =
         selectedPlantLocation?.type === 'multi-tree-registration';
-      // const isOther = selectedPlantLocation?.type !== 'single-tree-registration' && selectedPlantLocation?.type !== 'multi-tree-registration';
-      // Clear sample plant location on clicking outside.
-      // Clicks on sample plant location will not propagate on the map
+
       setSelectedSamplePlantLocation(null);
-      // Clear plant location info if clicked twice (single or multi tree) // point plant location
+
       if (isSamePlantLocation && (isSingleTree || isMultiTree)) {
         setSelectedPlantLocation(null);
         setSelectedSite(hasNoSites ? null : 0);
         return;
       }
 
-      // Set selected plant location if a result is found
       if (result) {
         setSelectedSite(null);
         setSelectedPlantLocation(result);
@@ -227,17 +227,21 @@ function ProjectsMap(props: ProjectsMapProps) {
     mapRef,
     selectedTab,
   };
+
   const multipleProjectsViewProps = {
     mapRef,
     page: props.page,
   };
+
   const mapContainerClass = `${styles.mapContainer} ${
     styles[mobileOS !== undefined ? mobileOS : '']
   }`;
+
   const shouldShowOtherIntervention =
     props.isMobile &&
     selectedPlantLocation !== null &&
     !PLANTATION_TYPES.includes(selectedPlantLocation.type);
+
   return (
     <>
       <MapControls {...mapControlProps} />

--- a/src/features/projectsV2/ProjectsMap/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/index.tsx
@@ -30,6 +30,7 @@ import styles from './ProjectsMap.module.scss';
 import { useDebouncedEffect } from '../../../utils/useDebouncedEffect';
 import OtherInterventionInfo from '../ProjectDetails/components/OtherInterventionInfo';
 import { PLANTATION_TYPES } from '../../../utils/constants/intervention';
+import ExploreLayers from './ExploreLayers';
 
 const TimeTravel = dynamic(() => import('./TimeTravel'), {
   ssr: false,
@@ -60,6 +61,7 @@ function ProjectsMap(props: ProjectsMapProps) {
     mapOptions,
     timeTravelConfig,
     setTimeTravelConfig,
+    isExploreMode,
   } = useProjectsMap();
   const {
     plantLocations,
@@ -156,6 +158,8 @@ function ProjectsMap(props: ProjectsMapProps) {
     isTimeTravelEnabled &&
     (selectedTab === 'timeTravel' || wasTimeTravelMounted);
   const shouldShowMapTabs = selectedTab !== null;
+  const shouldShowExploreLayers =
+    props.page === 'project-list' && isExploreMode;
 
   const mobileOS = useMemo(() => getDeviceType(), [props.isMobile]);
   const mapControlProps = {
@@ -206,15 +210,18 @@ function ProjectsMap(props: ProjectsMapProps) {
         selectedPlantLocation?.type === 'single-tree-registration';
       const isMultiTree =
         selectedPlantLocation?.type === 'multi-tree-registration';
-
+      // const isOther = selectedPlantLocation?.type !== 'single-tree-registration' && selectedPlantLocation?.type !== 'multi-tree-registration';
+      // Clear sample plant location on clicking outside.
+      // Clicks on sample plant location will not propagate on the map
       setSelectedSamplePlantLocation(null);
-
+      // Clear plant location info if clicked twice (single or multi tree) // point plant location
       if (isSamePlantLocation && (isSingleTree || isMultiTree)) {
         setSelectedPlantLocation(null);
         setSelectedSite(hasNoSites ? null : 0);
         return;
       }
 
+      // Set selected plant location if a result is found
       if (result) {
         setSelectedSite(null);
         setSelectedPlantLocation(result);
@@ -277,6 +284,7 @@ function ProjectsMap(props: ProjectsMapProps) {
               : undefined
           }
         >
+          {shouldShowExploreLayers && <ExploreLayers />}
           {shouldShowSingleProjectsView && (
             <SingleProjectView {...singleProjectViewProps} />
           )}

--- a/src/features/projectsV2/ProjectsMapContext.tsx
+++ b/src/features/projectsV2/ProjectsMapContext.tsx
@@ -54,21 +54,23 @@ export type MapOptions = {
   [key in MapLayerOptionsType]?: boolean;
 };
 
+export type SingleExploreLayerConfig = {
+  uuid: string;
+  name: string;
+  description: string;
+  earthEngineAssetId: string;
+  visParams: VisParams;
+  zoomConfig: LayerZoomConfig;
+  tileUrl: string;
+  googleEarthUrl: string;
+  metadata: Record<never, never>;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export type ExploreLayersData = {
-  [key in MapLayerOptionsType]: {
-    uuid: string;
-    name: string;
-    description: string;
-    earthEngineAssetId: string;
-    visParams: VisParams;
-    zoomConfig: LayerZoomConfig;
-    tileUrl: string;
-    googleEarthUrl: string;
-    metadata: Record<never, never>;
-    enabled: boolean;
-    createdAt: string;
-    updatedAt: string;
-  };
+  [key in MapLayerOptionsType]?: SingleExploreLayerConfig;
 };
 
 type VisParams = {

--- a/src/features/projectsV2/ProjectsMapContext.tsx
+++ b/src/features/projectsV2/ProjectsMapContext.tsx
@@ -54,6 +54,10 @@ export type MapOptions = {
   [key in MapLayerOptionsType]?: boolean;
 };
 
+export type ExploreLayersData = {
+  [key in MapLayerOptionsType]?: SingleExploreLayerConfig;
+};
+
 export type SingleExploreLayerConfig = {
   uuid: string;
   name: string;
@@ -67,10 +71,6 @@ export type SingleExploreLayerConfig = {
   enabled: boolean;
   createdAt: string;
   updatedAt: string;
-};
-
-export type ExploreLayersData = {
-  [key in MapLayerOptionsType]?: SingleExploreLayerConfig;
 };
 
 type VisParams = {
@@ -102,6 +102,7 @@ interface ProjectsMapState {
   setTimeTravelConfig: SetState<ProjectTimeTravelConfig | null>;
   exploreLayersData: ExploreLayersData | null;
   setExploreLayersData: SetState<ExploreLayersData | null>;
+  isExploreMode: boolean;
 }
 
 const ProjectsMapContext = createContext<ProjectsMapState | null>(null);
@@ -116,6 +117,15 @@ export const ProjectsMapProvider: FC = ({ children }) => {
     useState<ProjectTimeTravelConfig | null>(null);
   const [exploreLayersData, setExploreLayersData] =
     useState<ExploreLayersData | null>(null);
+  const [isExploreMode, setIsExploreMode] = useState(false);
+
+  // Set isExploreMode to true if mapOptions has keys other than 'projects' set to true
+  useEffect(() => {
+    const enabledLayers = Object.entries(mapOptions).filter(
+      ([key, value]) => key !== 'projects' && value === true
+    );
+    setIsExploreMode(enabledLayers.length > 0);
+  }, [mapOptions]);
 
   const handleViewStateChange = (newViewState: Partial<ExtendedViewState>) => {
     setViewState((prev) => ({
@@ -152,12 +162,21 @@ export const ProjectsMapProvider: FC = ({ children }) => {
       setIsSatelliteView,
       mapOptions,
       updateMapOption,
-      timeTravelConfig,
-      setTimeTravelConfig,
       exploreLayersData,
       setExploreLayersData,
+      isExploreMode,
+      timeTravelConfig,
+      setTimeTravelConfig,
     }),
-    [mapState, viewState, mapOptions, isSatelliteView, timeTravelConfig]
+    [
+      mapState,
+      viewState,
+      mapOptions,
+      isSatelliteView,
+      exploreLayersData,
+      isExploreMode,
+      timeTravelConfig,
+    ]
   );
 
   return (

--- a/src/features/projectsV2/ProjectsMapContext.tsx
+++ b/src/features/projectsV2/ProjectsMapContext.tsx
@@ -54,6 +54,34 @@ export type MapOptions = {
   [key in MapLayerOptionsType]?: boolean;
 };
 
+export type ExploreLayersData = {
+  [key in MapLayerOptionsType]: {
+    uuid: string;
+    name: string;
+    description: string;
+    earthEngineAssetId: string;
+    visParams: VisParams;
+    zoomConfig: LayerZoomConfig;
+    tileUrl: string;
+    googleEarthUrl: string;
+    metadata: Record<never, never>;
+    enabled: boolean;
+    createdAt: string;
+    updatedAt: string;
+  };
+};
+
+type VisParams = {
+  max: number;
+  min: number;
+  palette: string[];
+};
+
+type LayerZoomConfig = {
+  minZoom: number;
+  maxZoom: number;
+};
+
 interface ProjectsMapState {
   viewState: ViewState;
   handleViewStateChange: (newViewState: Partial<ExtendedViewState>) => void;
@@ -70,6 +98,8 @@ interface ProjectsMapState {
   updateMapOption: (option: keyof MapOptions, value: boolean) => void;
   timeTravelConfig: ProjectTimeTravelConfig | null;
   setTimeTravelConfig: SetState<ProjectTimeTravelConfig | null>;
+  exploreLayersData: ExploreLayersData | null;
+  setExploreLayersData: SetState<ExploreLayersData | null>;
 }
 
 const ProjectsMapContext = createContext<ProjectsMapState | null>(null);
@@ -82,6 +112,8 @@ export const ProjectsMapProvider: FC = ({ children }) => {
   });
   const [timeTravelConfig, setTimeTravelConfig] =
     useState<ProjectTimeTravelConfig | null>(null);
+  const [exploreLayersData, setExploreLayersData] =
+    useState<ExploreLayersData | null>(null);
 
   const handleViewStateChange = (newViewState: Partial<ExtendedViewState>) => {
     setViewState((prev) => ({
@@ -120,6 +152,8 @@ export const ProjectsMapProvider: FC = ({ children }) => {
       updateMapOption,
       timeTravelConfig,
       setTimeTravelConfig,
+      exploreLayersData,
+      setExploreLayersData,
     }),
     [mapState, viewState, mapOptions, isSatelliteView, timeTravelConfig]
   );

--- a/src/utils/mapsV2/mapSettings.config.ts
+++ b/src/utils/mapsV2/mapSettings.config.ts
@@ -30,7 +30,10 @@ export interface AdditionalInfo {
 
 export interface LayerConfig {
   key: MapLayerOptionsType;
-  isAvailable: boolean | null; // null means the availability is not yet determined
+  /** Indicates whether the layer should be enabled in the UI */
+  canShow: boolean;
+  /** Indicates whether layer data is available from API. null indicates unknown status */
+  isAvailable: boolean | null;
   additionalInfo?: AdditionalInfo;
   color?: string;
 }
@@ -48,11 +51,13 @@ export interface MapSettingsConfig {
 export const mapSettingsConfig: MapSettingsConfig = {
   projects: {
     key: 'projects',
+    canShow: true,
     isAvailable: true,
   },
   forests: [
     {
       key: 'forestCover',
+      canShow: true,
       isAvailable: null,
       additionalInfo: {
         resolution: '~500m (Downscaled)',
@@ -68,6 +73,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'forestBiomass',
+      canShow: false,
       isAvailable: null,
       color: '#27AE60',
       additionalInfo: {
@@ -84,6 +90,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'biomassPotential',
+      canShow: true,
       isAvailable: null,
       additionalInfo: {
         resolution: '~500km',
@@ -100,6 +107,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'deforestation',
+      canShow: false,
       isAvailable: null,
       color: '#EB5757',
       additionalInfo: {
@@ -115,6 +123,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'canopyHeight',
+      canShow: false,
       isAvailable: null,
       color: '#2F80ED',
       additionalInfo: {
@@ -133,6 +142,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
   soil: [
     {
       key: 'soilNitrogen',
+      canShow: false,
       isAvailable: null,
       additionalInfo: {
         resolution: '~250m',
@@ -149,6 +159,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'soilPH',
+      canShow: false,
       isAvailable: null,
       additionalInfo: {
         resolution: '~250m',
@@ -164,6 +175,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'soilOrganicCarbon',
+      canShow: false,
       isAvailable: null,
       additionalInfo: {
         resolution: '~250m',
@@ -180,6 +192,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'soilBulkDensity',
+      canShow: true,
       isAvailable: null,
       additionalInfo: {
         resolution: '~250m',
@@ -198,6 +211,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
   biodiversity: [
     {
       key: 'treeSpeciesDensity',
+      canShow: false,
       isAvailable: null,
       additionalInfo: {
         resolution: '~3km',
@@ -214,6 +228,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'birdsDensity',
+      canShow: false,
       isAvailable: null,
       additionalInfo: {
         resolution: '~10km',
@@ -230,6 +245,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'mammalsDensity',
+      canShow: false,
       isAvailable: null,
       additionalInfo: {
         resolution: '~10km',
@@ -245,6 +261,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'amphibiansDensity',
+      canShow: false,
       isAvailable: null,
       additionalInfo: {
         resolution: '~10km',
@@ -262,6 +279,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
   risks: [
     {
       key: 'fireRisk',
+      canShow: false,
       isAvailable: null,
       additionalInfo: {
         resolution: '~55km',
@@ -276,6 +294,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'deforestationRisk',
+      canShow: false,
       isAvailable: null,
       additionalInfo: {
         resolution: '~30m',

--- a/src/utils/mapsV2/mapSettings.config.ts
+++ b/src/utils/mapsV2/mapSettings.config.ts
@@ -52,7 +52,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
   forests: [
     {
       key: 'forestCover',
-      isAvailable: false,
+      isAvailable: true,
       additionalInfo: {
         resolution: '~500m (Downscaled)',
         dataYears: '2023',
@@ -83,7 +83,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'biomassPotential',
-      isAvailable: false,
+      isAvailable: true,
       additionalInfo: {
         resolution: '~500km',
         dataYears: '2016',

--- a/src/utils/mapsV2/mapSettings.config.ts
+++ b/src/utils/mapsV2/mapSettings.config.ts
@@ -30,7 +30,7 @@ export interface AdditionalInfo {
 
 export interface LayerConfig {
   key: MapLayerOptionsType;
-  isAvailable: boolean;
+  isAvailable: boolean | null; // null means the availability is not yet determined
   additionalInfo?: AdditionalInfo;
   color?: string;
 }
@@ -44,6 +44,7 @@ export interface MapSettingsConfig {
 }
 
 // Configuration object
+// isAvailable is set to null initially, and will be updated based on the API response (except for projects which are always available)
 export const mapSettingsConfig: MapSettingsConfig = {
   projects: {
     key: 'projects',
@@ -52,7 +53,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
   forests: [
     {
       key: 'forestCover',
-      isAvailable: true,
+      isAvailable: null,
       additionalInfo: {
         resolution: '~500m (Downscaled)',
         dataYears: '2023',
@@ -67,7 +68,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'forestBiomass',
-      isAvailable: false,
+      isAvailable: null,
       color: '#27AE60',
       additionalInfo: {
         resolution: '~500km',
@@ -83,12 +84,12 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'biomassPotential',
-      isAvailable: true,
+      isAvailable: null,
       additionalInfo: {
         resolution: '~500km',
         dataYears: '2016',
         description:
-          'Global additional potential biomass with and without considering agricultural and human settelements.',
+          'Global additional potential biomass with and without considering agricultural and human settlements.',
         underlyingData:
           'Remote sensing (MODIS, LiDAR) based Machine Learning models',
         source: {
@@ -99,7 +100,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'deforestation',
-      isAvailable: false,
+      isAvailable: null,
       color: '#EB5757',
       additionalInfo: {
         resolution: '~30m',
@@ -114,7 +115,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'canopyHeight',
-      isAvailable: false,
+      isAvailable: null,
       color: '#2F80ED',
       additionalInfo: {
         resolution: '~1m',
@@ -132,12 +133,12 @@ export const mapSettingsConfig: MapSettingsConfig = {
   soil: [
     {
       key: 'soilNitrogen',
-      isAvailable: false,
+      isAvailable: null,
       additionalInfo: {
         resolution: '~250m',
         dataYears: '2016',
         description:
-          'cg/kg; 0-30 cm horrizon (A weighted average for all depths)',
+          'cg/kg; 0-30 cm horizon (A weighted average for all depths)',
         underlyingData:
           '150,000 soil profiles and 158 remote sensing-based soil covariates (soilgrids.org)',
         source: {
@@ -148,11 +149,11 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'soilPH',
-      isAvailable: false,
+      isAvailable: null,
       additionalInfo: {
         resolution: '~250m',
         dataYears: '2016',
-        description: '0-30 cm horrizon (A weighted average for all depths)',
+        description: '0-30 cm horizon (A weighted average for all depths)',
         underlyingData:
           '150,000 soil profiles and 158 remote sensing-based soil covariates (soilgrids.org)',
         source: {
@@ -163,12 +164,12 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'soilOrganicCarbon',
-      isAvailable: false,
+      isAvailable: null,
       additionalInfo: {
         resolution: '~250m',
         dataYears: '2016',
         description:
-          'dg/kg; 0-30 cm horrizon (A weighted average for all depths)',
+          'dg/kg; 0-30 cm horizon (A weighted average for all depths)',
         underlyingData:
           '150,000 soil profiles and 158 remote sensing-based soil covariates (soilgrids.org)',
         source: {
@@ -179,12 +180,12 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'soilBulkDensity',
-      isAvailable: true,
+      isAvailable: null,
       additionalInfo: {
         resolution: '~250m',
         dataYears: '2016',
         description:
-          'cg/cm3; cg/kg; 0-30 cm horrizon (A weighted average for all depths)',
+          'cg/cm3; cg/kg; 0-30 cm horizon (A weighted average for all depths)',
         underlyingData:
           '150,000 soil profiles and 158 remote sensing-based soil covariates (soilgrids.org)',
         source: {
@@ -197,7 +198,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
   biodiversity: [
     {
       key: 'treeSpeciesDensity',
-      isAvailable: false,
+      isAvailable: null,
       additionalInfo: {
         resolution: '~3km',
         dataYears: '2005-2015',
@@ -213,7 +214,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'birdsDensity',
-      isAvailable: false,
+      isAvailable: null,
       additionalInfo: {
         resolution: '~10km',
         dataYears: '2013-2018',
@@ -229,7 +230,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'mammalsDensity',
-      isAvailable: false,
+      isAvailable: null,
       additionalInfo: {
         resolution: '~10km',
         dataYears: '2013-2018',
@@ -244,7 +245,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'amphibiansDensity',
-      isAvailable: false,
+      isAvailable: null,
       additionalInfo: {
         resolution: '~10km',
         dataYears: '2013-2018',
@@ -261,7 +262,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
   risks: [
     {
       key: 'fireRisk',
-      isAvailable: false,
+      isAvailable: null,
       additionalInfo: {
         resolution: '~55km',
         dataYears: '1980-2023',
@@ -275,7 +276,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'deforestationRisk',
-      isAvailable: false,
+      isAvailable: null,
       additionalInfo: {
         resolution: '~30m',
         dataYears: '2023',

--- a/src/utils/mapsV2/mapSettings.config.ts
+++ b/src/utils/mapsV2/mapSettings.config.ts
@@ -52,7 +52,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
   forests: [
     {
       key: 'forestCover',
-      isAvailable: true,
+      isAvailable: false,
       additionalInfo: {
         resolution: '~500m (Downscaled)',
         dataYears: '2023',
@@ -67,7 +67,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'forestBiomass',
-      isAvailable: true,
+      isAvailable: false,
       color: '#27AE60',
       additionalInfo: {
         resolution: '~500km',
@@ -83,7 +83,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'potentialForestBiomass',
-      isAvailable: true,
+      isAvailable: false,
       additionalInfo: {
         resolution: '~500km',
         dataYears: '2016',
@@ -99,7 +99,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'deforestation',
-      isAvailable: true,
+      isAvailable: false,
       color: '#EB5757',
       additionalInfo: {
         resolution: '~30m',
@@ -114,7 +114,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'canopyHeight',
-      isAvailable: true,
+      isAvailable: false,
       color: '#2F80ED',
       additionalInfo: {
         resolution: '~1m',
@@ -132,7 +132,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
   soil: [
     {
       key: 'soilNitrogen',
-      isAvailable: true,
+      isAvailable: false,
       additionalInfo: {
         resolution: '~250m',
         dataYears: '2016',
@@ -148,7 +148,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'soilPH',
-      isAvailable: true,
+      isAvailable: false,
       additionalInfo: {
         resolution: '~250m',
         dataYears: '2016',
@@ -163,7 +163,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'soilOrganicCarbon',
-      isAvailable: true,
+      isAvailable: false,
       additionalInfo: {
         resolution: '~250m',
         dataYears: '2016',
@@ -197,7 +197,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
   biodiversity: [
     {
       key: 'treeSpeciesDensity',
-      isAvailable: true,
+      isAvailable: false,
       additionalInfo: {
         resolution: '~3km',
         dataYears: '2005-2015',
@@ -213,7 +213,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'birdsDensity',
-      isAvailable: true,
+      isAvailable: false,
       additionalInfo: {
         resolution: '~10km',
         dataYears: '2013-2018',
@@ -229,7 +229,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'mammalsDensity',
-      isAvailable: true,
+      isAvailable: false,
       additionalInfo: {
         resolution: '~10km',
         dataYears: '2013-2018',
@@ -244,7 +244,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'amphibiansDensity',
-      isAvailable: true,
+      isAvailable: false,
       additionalInfo: {
         resolution: '~10km',
         dataYears: '2013-2018',
@@ -261,7 +261,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
   risks: [
     {
       key: 'fireRisk',
-      isAvailable: true,
+      isAvailable: false,
       additionalInfo: {
         resolution: '~55km',
         dataYears: '1980-2023',
@@ -275,7 +275,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'deforestationRisk',
-      isAvailable: true,
+      isAvailable: false,
       additionalInfo: {
         resolution: '~30m',
         dataYears: '2023',

--- a/src/utils/mapsV2/mapSettings.config.ts
+++ b/src/utils/mapsV2/mapSettings.config.ts
@@ -3,7 +3,7 @@ export type MapLayerOptionsType =
   | 'projects'
   | 'forestCover'
   | 'forestBiomass'
-  | 'potentialForestBiomass'
+  | 'biomassPotential'
   | 'deforestation'
   | 'canopyHeight'
   | 'soilNitrogen'
@@ -82,7 +82,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
       },
     },
     {
-      key: 'potentialForestBiomass',
+      key: 'biomassPotential',
       isAvailable: false,
       additionalInfo: {
         resolution: '~500km',

--- a/src/utils/mapsV2/useFetchLayers.ts
+++ b/src/utils/mapsV2/useFetchLayers.ts
@@ -6,6 +6,7 @@ import type { MapLayerOptionsType } from './mapSettings.config';
 
 import { useEffect, useRef } from 'react';
 import { useProjectsMap } from '../../features/projectsV2/ProjectsMapContext';
+
 const toCamelCase = (str: string): string => {
   return str
     .toLowerCase()

--- a/src/utils/mapsV2/useFetchLayers.ts
+++ b/src/utils/mapsV2/useFetchLayers.ts
@@ -5,6 +5,7 @@ import type {
 import type { MapLayerOptionsType } from './mapSettings.config';
 
 import { useEffect, useRef } from 'react';
+import { mapSettingsConfig } from './mapSettings.config';
 import { useProjectsMap } from '../../features/projectsV2/ProjectsMapContext';
 
 const toCamelCase = (str: string): string => {
@@ -51,6 +52,26 @@ export const useFetchLayers = () => {
           setExploreLayersData(null);
           return;
         }
+
+        const availableLayers = new Set(
+          layers
+            .filter((layer) => layer.enabled)
+            .map((layer) => toCamelCase(layer.name))
+        );
+
+        // Update isAvailable in mapSettingsConfig based on API response
+        Object.entries(mapSettingsConfig).forEach(([key, section]) => {
+          if (key === 'projects') {
+            // projects is always available
+            return;
+          }
+
+          if (Array.isArray(section)) {
+            section.forEach((layer) => {
+              layer.isAvailable = availableLayers.has(layer.key);
+            });
+          }
+        });
 
         const layersData = layers.reduce((tempLayersData, layer) => {
           const key = toCamelCase(layer.name) as MapLayerOptionsType;

--- a/src/utils/mapsV2/useFetchLayers.ts
+++ b/src/utils/mapsV2/useFetchLayers.ts
@@ -1,11 +1,16 @@
-import type { ExploreLayersData } from '../../features/projectsV2/ProjectsMapContext';
+import type {
+  ExploreLayersData,
+  SingleExploreLayerConfig,
+} from '../../features/projectsV2/ProjectsMapContext';
 import type { MapLayerOptionsType } from './mapSettings.config';
 
 import { useEffect, useRef } from 'react';
 import { useProjectsMap } from '../../features/projectsV2/ProjectsMapContext';
-
-// Get the type of a single layer from ExploreLayersData
-type APILayer = ExploreLayersData[MapLayerOptionsType];
+const toCamelCase = (str: string): string => {
+  return str
+    .toLowerCase()
+    .replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase());
+};
 
 export const useFetchLayers = () => {
   const { exploreLayersData, setExploreLayersData } = useProjectsMap();
@@ -39,7 +44,7 @@ export const useFetchLayers = () => {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
 
-        const layers = (await response.json()) as APILayer[];
+        const layers = (await response.json()) as SingleExploreLayerConfig[];
 
         if (!Array.isArray(layers) || layers.length === 0) {
           setExploreLayersData(null);
@@ -47,9 +52,7 @@ export const useFetchLayers = () => {
         }
 
         const layersData = layers.reduce((tempLayersData, layer) => {
-          const key = layer.name
-            .toLowerCase()
-            .replace(/\s+/g, '_') as MapLayerOptionsType;
+          const key = toCamelCase(layer.name) as MapLayerOptionsType;
           tempLayersData[key] = layer;
           return tempLayersData;
         }, {} as ExploreLayersData);

--- a/src/utils/mapsV2/useFetchLayers.ts
+++ b/src/utils/mapsV2/useFetchLayers.ts
@@ -1,0 +1,66 @@
+import type { ExploreLayersData } from '../../features/projectsV2/ProjectsMapContext';
+import type { MapLayerOptionsType } from './mapSettings.config';
+
+import { useEffect, useRef } from 'react';
+import { useProjectsMap } from '../../features/projectsV2/ProjectsMapContext';
+
+// Get the type of a single layer from ExploreLayersData
+type APILayer = ExploreLayersData[MapLayerOptionsType];
+
+export const useFetchLayers = () => {
+  const { exploreLayersData, setExploreLayersData } = useProjectsMap();
+  const hasAttemptedFetch = useRef(false);
+
+  useEffect(() => {
+    const fetchLayers = async () => {
+      if (exploreLayersData !== null || hasAttemptedFetch.current) {
+        return;
+      }
+
+      if (!process.env.LAYERS_API_ENDPOINT || !process.env.LAYERS_API_KEY) {
+        console.error('Invalid environment setup for layers API');
+        return;
+      }
+
+      hasAttemptedFetch.current = true;
+
+      try {
+        const response = await fetch(
+          `${process.env.LAYERS_API_ENDPOINT}/layers`,
+          {
+            method: 'GET',
+            headers: {
+              'x-api-key': process.env.LAYERS_API_KEY,
+            },
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const layers = (await response.json()) as APILayer[];
+
+        if (!Array.isArray(layers) || layers.length === 0) {
+          setExploreLayersData(null);
+          return;
+        }
+
+        const layersData = layers.reduce((tempLayersData, layer) => {
+          const key = layer.name
+            .toLowerCase()
+            .replace(/\s+/g, '_') as MapLayerOptionsType;
+          tempLayersData[key] = layer;
+          return tempLayersData;
+        }, {} as ExploreLayersData);
+
+        setExploreLayersData(layersData);
+      } catch (error) {
+        console.error('Error fetching layers:', error);
+        setExploreLayersData(null);
+      }
+    };
+
+    fetchLayers();
+  }, [exploreLayersData]);
+};


### PR DESCRIPTION
1. Links up the layers API to the webapp, using the new `useFetchLayers` hook.
2. Shows layer toggles in Explore menu based on layer availability in the API response, and new `canShow` key in mapSettings config. `canShow` can be used to disable options in the Explore menu even if the API supports those options (layers)
3. Adds functionality to show/hide the Explore layers using the Explore menu toggles
 