### PR TITLE
hide filter option condition added

### DIFF
--- a/src/features/projectsV2/ProjectsMap/InterventionDropDown/InterventionList.tsx
+++ b/src/features/projectsV2/ProjectsMap/InterventionDropDown/InterventionList.tsx
@@ -31,30 +31,35 @@ const InterventionList = ({
     setSelectedInterventionType(key);
   };
 
+  const shouldRenderIntervention = (interventionValue: string) => {
+    const showAllIntervention = interventionValue === 'all';
+    const showExisitingIntervention = existingIntervention.includes(interventionValue);
+    if (showAllIntervention && existingIntervention.length === 1) {
+      return false;
+    }
+    return showExisitingIntervention || showAllIntervention;
+  };
+
 
 
   return (
-    <ul className={`${styles.interventionListOptions} ${!hasProjectSites ? styles.interventionListOptionsAbove : styles.interventionListOptionsBelow}`}>
-      {interventionList.map((intervention, index) => {
-        const exists = existingIntervention.includes(intervention.value);
-        if (!exists && intervention.value !== 'all') {
+    <ul
+      className={`${styles.interventionListOptions} ${!hasProjectSites ? styles.interventionListOptionsAbove : styles.interventionListOptionsBelow
+        }`}
+    >
+      {interventionList.map((intervention) => {
+        if (!shouldRenderIntervention(intervention.value)) {
           return null;
         }
-        if (intervention.value == 'all' && existingIntervention.length === 1) {
-          return
-        }
+
         return (
           <li
-            className={`${styles.listItem} ${intervention.value === selectedInterventionData?.value
-              ? styles.selectedItem
-              : ''
+            className={`${styles.listItem} ${intervention.value === selectedInterventionData?.value ? styles.selectedItem : ''
               }`}
             onClick={() => handleFilterSelection(intervention.value)}
-            key={index}
+            key={intervention.value} // Use unique value as key
           >
-            <p>
-              {tProjectDetails(intervention.value)}
-            </p>
+            <p>{tProjectDetails(intervention.value)}</p>
           </li>
         );
       })}

--- a/src/features/projectsV2/ProjectsMap/InterventionDropDown/InterventionList.tsx
+++ b/src/features/projectsV2/ProjectsMap/InterventionDropDown/InterventionList.tsx
@@ -15,13 +15,15 @@ interface InterventionListProps {
   setIsMenuOpen: SetState<boolean>;
   selectedInterventionData: InterventionData | undefined;
   hasProjectSites?: boolean
+  existingIntervention: string[]
 }
 const InterventionList = ({
   interventionList,
   setSelectedInterventionType,
   setIsMenuOpen,
   selectedInterventionData,
-  hasProjectSites
+  hasProjectSites,
+  existingIntervention
 }: InterventionListProps) => {
   const tProjectDetails = useTranslations("ProjectDetails.intervention");
   const handleFilterSelection = (key: INTERVENTION_TYPE) => {
@@ -29,9 +31,18 @@ const InterventionList = ({
     setSelectedInterventionType(key);
   };
 
+
+
   return (
     <ul className={`${styles.interventionListOptions} ${!hasProjectSites ? styles.interventionListOptionsAbove : styles.interventionListOptionsBelow}`}>
       {interventionList.map((intervention, index) => {
+        const exists = existingIntervention.includes(intervention.value);
+        if (!exists && intervention.value !== 'all') {
+          return null;
+        }
+        if (intervention.value == 'all' && existingIntervention.length === 1) {
+          return
+        }
         return (
           <li
             className={`${styles.listItem} ${intervention.value === selectedInterventionData?.value

--- a/src/features/projectsV2/ProjectsMap/InterventionDropDown/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/InterventionDropDown/index.tsx
@@ -63,10 +63,11 @@ const InterventionDropdown = ({
   };
 
   const showVisibleOption = () => {
-    if (existingIntervention.length === 1) {
-      return findMatchingIntervention(existingIntervention[0]);
-    }
-    return findMatchingIntervention(selectedInterventionType);
+    const interventionToCheck = existingIntervention.length === 1
+      ? existingIntervention[0]
+      : selectedInterventionType;
+  
+    return findMatchingIntervention(interventionToCheck);
   }
 
   const interventionData = showVisibleOption()

--- a/src/features/projectsV2/ProjectsMap/InterventionDropDown/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/InterventionDropDown/index.tsx
@@ -25,6 +25,7 @@ interface Props {
   enableInterventionFilter: () => void;
   disableInterventionMenu: boolean;
   hasProjectSites?: boolean;
+  existingIntervention: string[]
 }
 
 const InterventionDropdown = ({
@@ -35,6 +36,7 @@ const InterventionDropdown = ({
   disableInterventionMenu,
   isMobile,
   hasProjectSites,
+  existingIntervention
 }: Props) => {
   const tIntervention = useTranslations('ProjectDetails.intervention');
 
@@ -54,20 +56,29 @@ const InterventionDropdown = ({
     }
   }, [disableInterventionMenu]);
 
-  const interventionData = findMatchingIntervention(selectedInterventionType);
 
   const toggleMenu = () => {
     enableInterventionFilter();
     setIsMenuOpen((prev) => !prev);
   };
+
+  const showVisibleOption = () => {
+    if (existingIntervention.length === 1) {
+      return findMatchingIntervention(existingIntervention[0]);
+    }
+    return findMatchingIntervention(selectedInterventionType);
+  }
+
+  const interventionData = showVisibleOption()
+
+
   return (
     <>
       <div
-        className={`${styles.dropdownButton} ${
-          hasProjectSites
+        className={`${styles.dropdownButton} ${hasProjectSites
             ? styles.dropdownButtonAlignmentAbove
             : styles.dropdownButtonAlignmentBelow
-        }`}
+          }`}
         onClick={toggleMenu}
       >
         <div className={styles.interventionIconAndTextContainer}>
@@ -106,6 +117,7 @@ const InterventionDropdown = ({
           setIsMenuOpen={setIsMenuOpen}
           selectedInterventionData={interventionData}
           hasProjectSites={hasProjectSites}
+          existingIntervention={existingIntervention}
         />
       )}
     </>

--- a/src/features/projectsV2/ProjectsMap/MapControls.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapControls.tsx
@@ -2,7 +2,7 @@ import type { ViewMode } from '../../common/Layout/ProjectsLayout/MobileProjects
 import type { SetState } from '../../common/types/common';
 import type { MobileOs } from '../../../utils/projectV2';
 import type { SelectedTab } from './ProjectMapTabs';
-import { useMemo } from 'react'
+import { useMemo } from 'react';
 import ProjectSiteDropdown from './ProjectSiteDropDown';
 import InterventionDropDown from './InterventionDropDown';
 import ProjectListControlForMobile from '../ProjectListControls/ProjectListControlForMobile';
@@ -54,9 +54,8 @@ const MapControls = ({
     setSelectedInterventionType,
     disableInterventionMenu,
     setDisableInterventionMenu,
-    plantLocations
+    plantLocations,
   } = useProjects();
-
 
   const uniquePlantTypes = useMemo(() => {
     if (!plantLocations) return [];
@@ -68,7 +67,6 @@ const MapControls = ({
     return [...types];
   }, [plantLocations]);
 
-
   const hasProjectSites =
     singleProject?.sites?.length !== undefined &&
     singleProject?.sites?.length > 1;
@@ -79,7 +77,9 @@ const MapControls = ({
     ) && selectedTab === 'field';
   const isProjectDetailsPage = page === 'project-details';
   const canShowInterventionDropdown =
-    isProjectDetailsPage && selectedTab === 'field';
+    isProjectDetailsPage &&
+    selectedTab === 'field' &&
+    uniquePlantTypes.length > 0;
 
   const enableInterventionFilter = () => {
     setDisableInterventionMenu(true);
@@ -133,14 +133,13 @@ const MapControls = ({
     setSelectedMode && setSelectedMode('list');
   };
 
-  const layerToggleClass = `${styles.layerToggle} ${isMobile
-    ? mobileOS === 'android'
-      ? styles.layerToggleAndroid
-      : styles.layerToggleIos
-    : styles.layerToggleDesktop
-    }`;
-
-
+  const layerToggleClass = `${styles.layerToggle} ${
+    isMobile
+      ? mobileOS === 'android'
+        ? styles.layerToggleAndroid
+        : styles.layerToggleIos
+      : styles.layerToggleDesktop
+  }`;
 
   return (
     <>
@@ -156,7 +155,7 @@ const MapControls = ({
               {hasProjectSites && (
                 <ProjectSiteDropdown {...siteDropdownProps} />
               )}
-              {canShowInterventionDropdown && uniquePlantTypes.length > 0 && (
+              {canShowInterventionDropdown && (
                 <InterventionDropDown
                   {...interventionDropDownProps}
                   isMobile={isMobile}
@@ -164,7 +163,7 @@ const MapControls = ({
                   existingIntervention={uniquePlantTypes}
                 />
               )}
-              < button
+              <button
                 className={styles.exitMapModeButton}
                 onClick={exitMapMode}
               >
@@ -176,13 +175,13 @@ const MapControls = ({
               {hasProjectSites && (
                 <ProjectSiteDropdown {...siteDropdownProps} />
               )}
-              {canShowInterventionDropdown && uniquePlantTypes.length > 0 &&
+              {canShowInterventionDropdown && (
                 <InterventionDropDown
                   {...interventionDropDownProps}
                   hasProjectSites={hasProjectSites}
                   existingIntervention={uniquePlantTypes}
                 />
-              }
+              )}
             </>
           )}
           {canShowSatelliteToggle && (
@@ -194,8 +193,7 @@ const MapControls = ({
             </button>
           )}
         </>
-      )
-      }
+      )}
     </>
   );
 };

--- a/src/features/projectsV2/ProjectsMap/MapControls.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapControls.tsx
@@ -61,11 +61,11 @@ const MapControls = ({
   const uniquePlantTypes = useMemo(() => {
     if (!plantLocations) return [];
 
-    const uniqueTypes = new Set(
-      plantLocations?.map(location => location.type)
-    );
-
-    return Array.from(uniqueTypes);
+    const types = new Set();
+    for (let i = 0; i < plantLocations.length; i++) {
+      types.add(plantLocations[i].type);
+    }
+    return [...types];
   }, [plantLocations]);
 
 
@@ -134,10 +134,10 @@ const MapControls = ({
   };
 
   const layerToggleClass = `${styles.layerToggle} ${isMobile
-      ? mobileOS === 'android'
-        ? styles.layerToggleAndroid
-        : styles.layerToggleIos
-      : styles.layerToggleDesktop
+    ? mobileOS === 'android'
+      ? styles.layerToggleAndroid
+      : styles.layerToggleIos
+    : styles.layerToggleDesktop
     }`;
 
 
@@ -156,15 +156,15 @@ const MapControls = ({
               {hasProjectSites && (
                 <ProjectSiteDropdown {...siteDropdownProps} />
               )}
-              {canShowInterventionDropdown && uniquePlantTypes.length > 0 ? (
+              {canShowInterventionDropdown && uniquePlantTypes.length > 0 && (
                 <InterventionDropDown
                   {...interventionDropDownProps}
                   isMobile={isMobile}
                   hasProjectSites={hasProjectSites}
                   existingIntervention={uniquePlantTypes}
                 />
-              ) : null}
-              <button
+              )}
+              < button
                 className={styles.exitMapModeButton}
                 onClick={exitMapMode}
               >
@@ -176,13 +176,13 @@ const MapControls = ({
               {hasProjectSites && (
                 <ProjectSiteDropdown {...siteDropdownProps} />
               )}
-              {canShowInterventionDropdown && uniquePlantTypes.length > 0 ? (
+              {canShowInterventionDropdown && uniquePlantTypes.length > 0 &&
                 <InterventionDropDown
                   {...interventionDropDownProps}
                   hasProjectSites={hasProjectSites}
                   existingIntervention={uniquePlantTypes}
                 />
-              ) : null}
+              }
             </>
           )}
           {canShowSatelliteToggle && (
@@ -194,7 +194,8 @@ const MapControls = ({
             </button>
           )}
         </>
-      )}
+      )
+      }
     </>
   );
 };

--- a/src/features/projectsV2/ProjectsMap/MapControls.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapControls.tsx
@@ -79,7 +79,7 @@ const MapControls = ({
   const canShowInterventionDropdown =
     isProjectDetailsPage &&
     selectedTab === 'field' &&
-    uniquePlantTypes.length > 0;
+    uniquePlantTypes.length > 1;
 
   const enableInterventionFilter = () => {
     setDisableInterventionMenu(true);

--- a/src/features/projectsV2/ProjectsMap/MapControls.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapControls.tsx
@@ -2,7 +2,7 @@ import type { ViewMode } from '../../common/Layout/ProjectsLayout/MobileProjects
 import type { SetState } from '../../common/types/common';
 import type { MobileOs } from '../../../utils/projectV2';
 import type { SelectedTab } from './ProjectMapTabs';
-
+import { useMemo } from 'react'
 import ProjectSiteDropdown from './ProjectSiteDropDown';
 import InterventionDropDown from './InterventionDropDown';
 import ProjectListControlForMobile from '../ProjectListControls/ProjectListControlForMobile';
@@ -54,7 +54,21 @@ const MapControls = ({
     setSelectedInterventionType,
     disableInterventionMenu,
     setDisableInterventionMenu,
+    plantLocations
   } = useProjects();
+
+
+  const uniquePlantTypes = useMemo(() => {
+    if (!plantLocations) return [];
+
+    const uniqueTypes = new Set(
+      plantLocations?.map(location => location.type)
+    );
+
+    return Array.from(uniqueTypes);
+  }, [plantLocations]);
+
+
   const hasProjectSites =
     singleProject?.sites?.length !== undefined &&
     singleProject?.sites?.length > 1;
@@ -119,13 +133,14 @@ const MapControls = ({
     setSelectedMode && setSelectedMode('list');
   };
 
-  const layerToggleClass = `${styles.layerToggle} ${
-    isMobile
+  const layerToggleClass = `${styles.layerToggle} ${isMobile
       ? mobileOS === 'android'
         ? styles.layerToggleAndroid
         : styles.layerToggleIos
       : styles.layerToggleDesktop
-  }`;
+    }`;
+
+
 
   return (
     <>
@@ -141,13 +156,14 @@ const MapControls = ({
               {hasProjectSites && (
                 <ProjectSiteDropdown {...siteDropdownProps} />
               )}
-              {canShowInterventionDropdown && (
+              {canShowInterventionDropdown && uniquePlantTypes.length > 0 ? (
                 <InterventionDropDown
                   {...interventionDropDownProps}
                   isMobile={isMobile}
                   hasProjectSites={hasProjectSites}
+                  existingIntervention={uniquePlantTypes}
                 />
-              )}
+              ) : null}
               <button
                 className={styles.exitMapModeButton}
                 onClick={exitMapMode}
@@ -160,12 +176,13 @@ const MapControls = ({
               {hasProjectSites && (
                 <ProjectSiteDropdown {...siteDropdownProps} />
               )}
-              {canShowInterventionDropdown && (
+              {canShowInterventionDropdown && uniquePlantTypes.length > 0 ? (
                 <InterventionDropDown
                   {...interventionDropDownProps}
                   hasProjectSites={hasProjectSites}
+                  existingIntervention={uniquePlantTypes}
                 />
-              )}
+              ) : null}
             </>
           )}
           {canShowSatelliteToggle && (


### PR DESCRIPTION
In this PR, I have added a filter condition to hide options when an intervention is not available in the project.

- If only one intervention is present, only that option will be shown.
- If multiple interventions are available, the default selection will be "All Interventions," along with the specific interventions present.
Note: I have removed the default "Single/Multi Intervention" option, as it was confusing and seemed unnecessary.