### PR TITLE
Add maxLength validation for zipCode in forms

### DIFF
--- a/src/features/user/CompleteSignup/index.tsx
+++ b/src/features/user/CompleteSignup/index.tsx
@@ -492,6 +492,10 @@ export default function CompleteSignup(): ReactElement | null {
                         value: postalRegex as RegExp,
                         message: t('validationErrors.zipCodeInvalid'),
                       },
+                      maxLength: {
+                        value: 15,
+                        message: t('validationErrors.zipCodeInvalid'),
+                      },
                     }}
                     defaultValue={
                       getStoredConfig('loc').postalCode === 'T1' ||

--- a/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressForm.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressForm.tsx
@@ -182,6 +182,10 @@ const AddressForm = ({
               value: postalRegex as RegExp,
               message: t('validationErrors.zipCodeInvalid'),
             },
+            maxLength: {
+              value: 15,
+              message: t('validationErrors.zipCodeInvalid'),
+            },
           }}
           render={({ field: { onChange, value, onBlur } }) => (
             <TextField


### PR DESCRIPTION
Implement maxLength validation for postal code in the CompleteSignup and AddressForm components to enhance input validation.