### PR TITLE
Fix double locale bug in back navigation

### DIFF
--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -262,8 +262,9 @@ export const getLocalizedPath = (path: string, locale: string): string => {
     return `/${locale}`;
   }
 
-  // If path already starts with locale, return as is
-  if (cleanPath.startsWith(`/${locale}/`)) {
+  // If path already contains locale as a segment, return as is
+  const pathSegments = cleanPath.split('/').filter(Boolean);
+  if (pathSegments[0] === locale) {
     return cleanPath;
   }
 


### PR DESCRIPTION
Resolve an issue with back navigation that caused double locale entries by improving the logic for handling paths that already contain locales.

To reproduce issue: 

- Open https://dev.pp.eco/en/yucatan in a new browser tab. After the page loads, press back. You should see the url https://dev.pp.eco/en/en and an error message ("Resource not found").

- Try out the same approach with the preview link in this PR (append /yucatan or /en/yucatan after the link), the issue should no longer be seen