### PR TITLE
Fix TPO profile rendering bug due to class conflicts

### DIFF
--- a/src/features/user/Profile/PublicProfileLayout/index.tsx
+++ b/src/features/user/Profile/PublicProfileLayout/index.tsx
@@ -83,8 +83,8 @@ const PublicProfileLayout = ({ profile, isProfileLoaded }: Props) => {
   return (
     <article
       className={`${styles.publicProfileLayout} ${
-        !canShowLeaderboard ? styles.noLeaderboard : ''
-      } ${isProgressBarDisabled ? styles.noProgress : ''} ${
+        !canShowLeaderboard && !isTpoProfile ? styles.noLeaderboard : ''
+      } ${isProgressBarDisabled && !isTpoProfile ? styles.noProgress : ''} ${
         isTpoProfile ? styles.tpoProfile : ''
       }`}
     >


### PR DESCRIPTION
Resolve a bug in the rendering of TPO profiles by adjusting class conditions to prevent conflicts.

When a tpo profile was loaded without any score/progress data, an incorrect layout was applied due to class conflicts. This has been resolved.

Before:
https://dev.pp.eco/en/t/perry-institute-for-marine-science
<img width="509" alt="Screenshot 2025-02-20 at 4 38 50 PM" src="https://github.com/user-attachments/assets/56e3624f-4a37-4cbe-8a94-26a6644ba5bf" />
<img width="1063" alt="Screenshot 2025-02-20 at 4 38 58 PM" src="https://github.com/user-attachments/assets/7237e1bc-6b26-4eea-ae6a-5451d379aacb" />

After:
https://planet-webapp-multi-tenancy-setup-git-hotfix-t-c7992c-planetapp.vercel.app/en/t/perry-institute-for-marine-science
<img width="591" alt="Screenshot 2025-02-20 at 4 39 07 PM" src="https://github.com/user-attachments/assets/34d5375e-2bfc-4362-9d08-06693cef6343" />
<img width="1010" alt="Screenshot 2025-02-20 at 4 39 18 PM" src="https://github.com/user-attachments/assets/d36cdaac-fa3e-4a5d-95a0-8c2b35a3eab8" />
