### PR TITLE
Fix: Export complex objects (geometry and metadata) as JSON strings in DataExplorer

### DIFF
--- a/pages/api/data-explorer/export.ts
+++ b/pages/api/data-explorer/export.ts
@@ -22,11 +22,13 @@ handler.post(async (req, response) => {
 				iv.intervention_start_date, 
 				COALESCE(ss.name, ps.other_species, iv.other_species, 'Unknown') AS species, 
 				CASE WHEN iv.type='single-tree-registration' THEN 1 ELSE ps.tree_count END AS tree_count, 
-				iv.geometry, 
+				-- Convert geometry to a JSON string using to_json() and then to text
+				CASE WHEN iv.geometry IS NOT NULL THEN TO_JSON(iv.geometry)::text ELSE NULL END AS geometry, 
 				iv.type, 
 				iv.trees_allocated, 
 				iv.trees_planted, 
-				iv.metadata, 
+				-- Convert metadata to a JSON string using to_json() and then to text
+				CASE WHEN iv.metadata IS NOT NULL THEN TO_JSON(iv.metadata)::text ELSE NULL END AS metadata, 
 				iv.description, 
 				iv.plant_project_id, 
 				iv.sample_tree_count, 


### PR DESCRIPTION
### Problem

- When exporting data to Excel, complex objects like geometry and metadata are appearing as null in the resultant Excel file, despite these fields containing valid data in the API response.

### Solution

- Modified the PostgreSQL query to convert complex objects to JSON strings at the database level using to_json()::text, ensuring that all data is properly exported to Excel files.

### Changes

- Updated SQL query in the export API endpoint to stringify JSON objects before they're returned
- Used PostgreSQL's native to_json() function with a text cast to convert complex objects to strings
- Added null handling with CASE statements to gracefully handle null values

### Performance
This approach is more efficient than client-side processing as it:

- Reduces data transfer size
- Leverages database optimization
- Eliminates additional JavaScript processing in the API layer
