### PR TITLE
Add ability to show/hide project content in embed mode

### DIFF
--- a/src/features/common/Layout/Navbar/index.tsx
+++ b/src/features/common/Layout/Navbar/index.tsx
@@ -1,6 +1,4 @@
-import React, { useContext } from 'react';
 import { useUserProps } from '../UserPropsContext';
-import { ParamsContext } from '../QueryParamsContext';
 import ImpersonationActivated from '../../../user/Settings/ImpersonateUser/ImpersonationActivated';
 import { useTenant } from '../TenantContext';
 import BrandLogo from './microComponents/BrandLogo';
@@ -30,7 +28,6 @@ const CommonHeader = () => {
 };
 
 export default function NavbarComponent() {
-  const { embed } = useContext(ParamsContext);
   const { tenantConfig } = useTenant();
   const { setUser, logoutUser, auth0Error } = useUserProps();
 
@@ -52,8 +49,6 @@ export default function NavbarComponent() {
       logoutUser(`${window.location.origin}/`);
     }
   }
-
-  if (embed === 'true') return null;
 
   return tenantConfig ? (
     <div className="mainNavContainer">

--- a/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
+++ b/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
@@ -1,12 +1,13 @@
 import type { FC } from 'react';
 import type { SetState } from '../../types/common';
 
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import styles from './ProjectsLayout.module.scss';
 import ProjectsMap from '../../../projectsV2/ProjectsMap';
 import { ProjectsProvider } from '../../../projectsV2/ProjectsContext';
 import { ProjectsMapProvider } from '../../../projectsV2/ProjectsMapContext';
 import Credits from '../../../projectsV2/ProjectsMap/Credits';
+import { ParamsContext } from '../QueryParamsContext';
 
 export type ViewMode = 'list' | 'map';
 interface ProjectsLayoutProps {
@@ -23,10 +24,11 @@ const MobileProjectsLayout: FC<ProjectsLayoutProps> = ({
   setCurrencyCode,
   isMobile,
 }) => {
+  const { embed } = useContext(ParamsContext);
   const [selectedMode, setSelectedMode] = useState<ViewMode>('list');
   const mobileLayoutClass = `${styles.mobileProjectsLayout} ${
     selectedMode === 'map' ? styles.mapMode : ''
-  }`;
+  } ${embed === 'true' ? styles.embedModeMobile : ''}`;
   return (
     <ProjectsProvider
       page={page}

--- a/src/features/common/Layout/ProjectsLayout/ProjectsLayout.module.scss
+++ b/src/features/common/Layout/ProjectsLayout/ProjectsLayout.module.scss
@@ -75,6 +75,11 @@ $bottomMobileFooterSpace: 49px;
     top: 0;
     padding-top: 0;
   }
+
+  &.embedModeMobile {
+    top: 0;
+    bottom: 29px;
+  }
 }
 
 .mobileContentContainer {

--- a/src/features/common/Layout/ProjectsLayout/index.tsx
+++ b/src/features/common/Layout/ProjectsLayout/index.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import type { SetState } from '../../types/common';
 
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import styles from './ProjectsLayout.module.scss';
 import Credits from '../../../projectsV2/ProjectsMap/Credits';
 import ProjectsMap from '../../../projectsV2/ProjectsMap';
@@ -11,8 +11,8 @@ import {
   useProjectsMap,
 } from '../../../projectsV2/ProjectsMapContext';
 import MapFeatureExplorer from '../../../projectsV2/ProjectsMap/MapFeatureExplorer';
-import { useRouter } from 'next/router';
 import { useUserProps } from '../UserPropsContext';
+import { ParamsContext } from '../QueryParamsContext';
 
 interface ProjectsLayoutProps {
   currencyCode: string;
@@ -26,15 +26,27 @@ const ProjectsLayoutContent: FC<Omit<ProjectsLayoutProps, 'currencyCode'>> = ({
   page,
 }) => {
   const { mapOptions, updateMapOption } = useProjectsMap();
-  const { query } = useRouter();
   const { isImpersonationModeOn } = useUserProps();
-  const showContentContainer =
-    Boolean(mapOptions.projects) || page === 'project-details';
+  const { embed, showProjectDetails, showProjectList } =
+    useContext(ParamsContext);
+
+  const showContentContainer = useMemo(() => {
+    const hideProjectList =
+      page === 'project-list' &&
+      mapOptions.projects &&
+      !(embed === 'true' && showProjectList === 'false');
+    const hideProjectDetails =
+      page === 'project-details' &&
+      !(embed === 'true' && showProjectDetails === 'false');
+    return hideProjectList || hideProjectDetails;
+  }, [page, embed, showProjectDetails, showProjectList]);
+
   const layoutClass = useMemo(() => {
-    if (query.embed === 'true') return styles.embedMode;
+    if (embed === 'true') return styles.embedMode;
     if (isImpersonationModeOn) return styles.impersonationMode;
     return styles.projectsLayout;
-  }, [isImpersonationModeOn, query.embed]);
+  }, [isImpersonationModeOn, embed]);
+
   return (
     <div className={layoutClass}>
       <main className={styles.mainContent}>

--- a/src/features/common/Layout/QueryParamsContext.tsx
+++ b/src/features/common/Layout/QueryParamsContext.tsx
@@ -13,7 +13,11 @@ export interface ParamsContextType {
   showProjectList: QueryParamType;
   enableIntro: QueryParamType;
   isContextLoaded: boolean;
+  page: EmbeddablePages | null;
 }
+
+type EmbeddablePages = 'project-list' | 'project-details';
+
 export const ParamsContext = createContext<ParamsContextType>({
   embed: undefined,
   showBackIcon: undefined,
@@ -22,6 +26,7 @@ export const ParamsContext = createContext<ParamsContextType>({
   showProjectList: undefined,
   enableIntro: undefined,
   isContextLoaded: false,
+  page: null,
 });
 
 const QueryParamsProvider: FC = ({ children }) => {
@@ -30,6 +35,7 @@ const QueryParamsProvider: FC = ({ children }) => {
   const [embed, setEmbed] = useState<QueryParamType>(undefined);
   const [showBackIcon, setShowBackIcon] = useState<QueryParamType>(undefined);
   const [callbackUrl, setCallbackUrl] = useState<QueryParamType>(undefined);
+  const [page, setPage] = useState<EmbeddablePages | null>(null);
 
   const [showProjectDetails, setShowProjectDetails] =
     useState<QueryParamType>(undefined);
@@ -40,7 +46,14 @@ const QueryParamsProvider: FC = ({ children }) => {
 
   useEffect(() => {
     if (router.isReady) {
-      const { query } = router;
+      const { query, pathname } = router;
+      if (pathname === '/sites/[slug]/[locale]') {
+        setPage('project-list');
+      } else if (query.p !== undefined) {
+        setPage('project-details');
+      } else {
+        setPage(null);
+      }
       if (query.embed) setEmbed(query.embed);
       if (query.back_icon) setShowBackIcon(query.back_icon);
       if (query.callback) setCallbackUrl(query.callback);
@@ -69,6 +82,7 @@ const QueryParamsProvider: FC = ({ children }) => {
         showProjectList,
         enableIntro,
         isContextLoaded,
+        page,
       }}
     >
       {children}

--- a/src/features/common/Layout/index.tsx
+++ b/src/features/common/Layout/index.tsx
@@ -7,14 +7,14 @@ import CookiePolicy from './CookiePolicy';
 import ErrorPopup from './ErrorPopup';
 import Header from './Header';
 import Navbar from './Navbar';
-// import RedeemPopup from './RedeemPopup';
 import { ParamsContext } from './QueryParamsContext';
 
 const Layout: FC = ({ children }) => {
   const { theme: themeType } = useTheme();
-  const { embed } = useContext(ParamsContext);
+  const { embed, page } = useContext(ParamsContext);
 
-  const isEmbed = embed === 'true';
+  const isEmbed =
+    embed === 'true' && (page === 'project-list' || page === 'project-details');
 
   return (
     <>

--- a/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
@@ -37,8 +37,10 @@ const ImageSection = (props: ImageSectionProps) => {
   const tProjectsCommon = useTranslations('Project');
   const router = useRouter();
   const locale = useLocale();
-  const { embed, callbackUrl } = useContext(ParamsContext);
+  const { embed, callbackUrl, showBackIcon } = useContext(ParamsContext);
   const isEmbed = embed === 'true';
+  const showBackButton =
+    page === 'project-details' && !(isEmbed && showBackIcon === 'false');
 
   const handleBackButton = () => {
     if (setPreventShallowPush) {
@@ -93,7 +95,7 @@ const ImageSection = (props: ImageSectionProps) => {
 
   return (
     <div className={imageContainerClasses}>
-      {page === 'project-details' && (
+      {showBackButton && (
         <button onClick={handleBackButton} className={styles.backButton}>
           <BackButton />
         </button>

--- a/src/features/projectsV2/ProjectsContext.tsx
+++ b/src/features/projectsV2/ProjectsContext.tsx
@@ -283,11 +283,9 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
     projectSlug: string,
     siteId: string | null
   ) => {
-    const updatedQueryParams = buildProjectDetailsQuery(
-      router.asPath,
-      router.query,
-      { siteId }
-    );
+    const updatedQueryParams = buildProjectDetailsQuery(router.query, {
+      siteId,
+    });
     updateProjectDetailsPath(locale, projectSlug, updatedQueryParams);
   };
 
@@ -347,11 +345,9 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
 
     // Handles updating the URL with the 'ploc' parameter when a user selects a different plant location.
     if (selectedPlantLocation) {
-      const updatedQueryParams = buildProjectDetailsQuery(
-        router.asPath,
-        router.query,
-        { plocId: selectedPlantLocation.hid }
-      );
+      const updatedQueryParams = buildProjectDetailsQuery(router.query, {
+        plocId: selectedPlantLocation.hid,
+      });
       updateProjectDetailsPath(locale, singleProject.slug, updatedQueryParams);
     }
   }, [
@@ -417,7 +413,6 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
       setSelectedSamplePlantLocation(null);
       setSelectedPlantLocation(null);
       setHoveredPlantLocation(null);
-      updateSiteAndUrl(locale, singleProject.slug, hasNoSites ? undefined : 0);
     }
   }, [selectedMode, singleProject, locale, hasNoSites]);
 

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -40,7 +40,6 @@ const isStringValue = (entry: [string, unknown]): entry is [string, string] => {
  */
 
 export const buildProjectDetailsQuery = (
-  asPath: string,
   query: ParsedUrlQuery,
   routeParams: RouteParams
 ): Record<string, string> => {


### PR DESCRIPTION
## Description
This PR adds the ability to control whether project list or project details content is visible when using embed mode. This allows for more flexible embedding options where users can choose to display only the map if desired.

## Changes
- Added support for `showProjectList` and `showProjectDetails` URL parameters
- Implemented conditional logic to show/hide content based on these parameters
- Replaced router.query with ParamsContext for code consistency