### PR TITLE
Fix: Resolve z-index issue with MapFeatureExplorer and map zoom controls (Desktop/Tablet)

### DIFF
--- a/src/features/common/Layout/ProjectsLayout/ProjectsLayout.module.scss
+++ b/src/features/common/Layout/ProjectsLayout/ProjectsLayout.module.scss
@@ -55,7 +55,8 @@ $bottomMobileFooterSpace: 49px;
   top: calc($layoutPaddingTop + 10px);
   bottom: calc($layoutPaddingBottom + 10px);
   right: calc($layoutPaddingSide + 10px);
-  z-index: 50;
+  /* Makes the container transparent to clicks */
+  pointer-events: none;
 }
 
 // styles for mobile layout

--- a/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/MapFeatureExplorer.module.scss
+++ b/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/MapFeatureExplorer.module.scss
@@ -6,6 +6,16 @@
     flex-direction: column;
     height: 100%;
     gap: 12px;
+    pointer-events: auto;
+    position: relative;
+  }
+}
+
+.exploreButton {
+  @include smTabletView {
+    position: relative;
+    z-index: 10;
+    pointer-events: auto;
   }
 }
 
@@ -27,6 +37,9 @@
 }
 
 .exploreMainContainer {
+  position: relative;
+  z-index: 50;
+  pointer-events: auto;
   max-width: 240px;
   background-color: #fff;
   border-radius: 12px;

--- a/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/index.tsx
@@ -26,7 +26,7 @@ const MapFeatureExplorer = ({
       <CustomButton
         startIcon={<ExploreIcon />}
         onClick={() => setIsOpen(!isOpen)}
-        className={isOpen ? 'active' : ''}
+        className={`${styles.exploreButton} ${isOpen ? 'active' : ''}`}
       >
         <div className={styles.exploreButtonContent}>
           <h3>{tExplore('title')}</h3>


### PR DESCRIPTION
This PR addresses an issue where the MapFeatureExplorer component was preventing interaction with map zoom controls even when collapsed on desktop and tablet views.

### Changes
- Removed the z-index from .mapFeatureExplorerOverlay and added pointer-events: none to allow clicks to pass through to elements underneath
- Added a new .exploreButton class with appropriate z-index (10) and pointer-events: auto for non-mobile views to ensure the button remains visible and clickable
- Applied positioning and z-index styles only for tablet/desktop views using the existing smTabletView mixin
- Kept the high z-index (50) on the settings container (.exploreMainContainer) to ensure it appears above map controls when open

### Before
- The MapFeatureExplorer overlay was blocking map zoom buttons from being clicked even when the explorer was in its collapsed state on desktop/tablet views.

### After
- Map zoom controls are now accessible when the explorer is collapsed
- The explore button remains visible and clickable
- The settings panel still appears above all other elements when expanded
- Mobile experience remains unchanged