### PR TITLE
refactor: use useServerApi() hook for fetching project and plant loca…

### DIFF
--- a/pages/sites/[slug]/[locale]/all.tsx
+++ b/pages/sites/[slug]/[locale]/all.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../../../src/utils/multiTenancy/helpers';
 import { defaultTenant } from '../../../../tenant.config';
 import getMessagesForPage from '../../../../src/utils/language/getMessagesForPage';
+import { useServerApi } from '../../../../src/hooks/useServerApi';
 
 interface Props {
   pageProps: PageProps;
@@ -40,6 +41,7 @@ export default function Home({ pageProps }: Props) {
 
   const router = useRouter();
   const { setTenantConfig } = useTenant();
+  const { getApi } = useServerApi();
 
   React.useEffect(() => {
     if (router.isReady) {
@@ -50,10 +52,9 @@ export default function Home({ pageProps }: Props) {
   React.useEffect(() => {
     async function loadLeaderboard() {
       try {
-        const newLeaderboard = await getRequest<LeaderBoardList>({
-          tenant: pageProps.tenantConfig.id,
-          url: `/app/leaderboard/${pageProps.tenantConfig.id}`,
-        });
+        const newLeaderboard = await getApi<LeaderBoardList>(
+          `/app/leaderboard/${pageProps.tenantConfig.id}`
+        );
         setLeaderboard(newLeaderboard);
       } catch (err) {
         setErrors(handleError(err as APIError));
@@ -69,10 +70,9 @@ export default function Home({ pageProps }: Props) {
   React.useEffect(() => {
     async function loadTenantScore() {
       try {
-        const newTenantScore = await getRequest<TenantScore>({
-          tenant: pageProps.tenantConfig.id,
-          url: `/app/tenantScore/${pageProps.tenantConfig.id}`,
-        });
+        const newTenantScore = await getApi<TenantScore>(
+          `/app/tenantScore/${pageProps.tenantConfig.id}`
+        );
         setTenantScore(newTenantScore);
       } catch (err) {
         setErrors(handleError(err as APIError));

--- a/src/utils/apiRequests/apiClient.ts
+++ b/src/utils/apiRequests/apiClient.ts
@@ -22,23 +22,12 @@ const apiClient = async <T>(
     options = await mw(options);
   }
 
-  // Ensure API endpoint is defined
-  const baseUrl = process.env.API_ENDPOINT;
-  if (!baseUrl) {
-    throw new Error(
-      'API_ENDPOINT is not defined in your environment variables.'
-    );
-  }
-
   // Construct full URL
   const queryString = options.queryParams
     ? '?' + getQueryString(options.queryParams)
     : '';
-  const fullUrl = options.url.startsWith('http')
-    ? options.url
-    : `${baseUrl}${options.url.startsWith('/') ? '' : '/'}${
-        options.url
-      }${queryString}`;
+
+  const fullUrl = `${options.url}${queryString}`;
 
   // Build headers
   const headers: Record<string, string> = {


### PR DESCRIPTION
Utilized `useServerApi `hook to centralize API calls and eliminate the need to manually pass `locale, tenantID`.
Added support for GET, POST, PUT, and DELETE requests with both authenticated and non-authenticated versions.