### PR TITLE
Display a warning message in donation receipt verification page if TI…

### DIFF
--- a/public/static/locales/en/donationReceipt.json
+++ b/public/static/locales/en/donationReceipt.json
@@ -32,6 +32,7 @@
       "addressRequired": "Please choose an address to proceed.",
       "invalidContactInfoMessage": "Your contact information is invalid. Please update it by clicking Modify Contact Information below.",
       "addressLimitReached": "You've reached the address limit. You can update your existing addresses, but adding a new one isn't possible.",
+      "missingTIN": "<b>NOTICE:</b> Your tax identification number is missing, please click on the button below to add it.",
       "loginRequired": "<b>IMPORTANT:</b> To modify your data, you will need to log in to your profile. If you are encountering issues, please contact us via the information at the bottom of this page."
     },
     "verifyDonationHeaderPrimary": "Verify your data and download the donation receipt",

--- a/src/features/user/DonationReceipt/DonationReceiptWrapper.tsx
+++ b/src/features/user/DonationReceipt/DonationReceiptWrapper.tsx
@@ -24,6 +24,7 @@ const DonationReceiptWrapper = () => {
     initForVerification,
     email,
     isValid,
+    tinIsRequired,
     clearSessionStorage,
   } = useDonationReceiptContext();
 
@@ -128,6 +129,7 @@ const DonationReceiptWrapper = () => {
       donationReceipt={receiptData}
       isLoading={isLoading}
       isValid={isValid}
+      tinIsRequired={tinIsRequired}
       operation={operation}
       confirmReceiptData={confirmReceiptData}
     />

--- a/src/features/user/DonationReceipt/microComponents/DonationReceipt.tsx
+++ b/src/features/user/DonationReceipt/microComponents/DonationReceipt.tsx
@@ -8,6 +8,7 @@ interface DonationReceiptProps {
   donationReceipt: ReceiptData;
   isLoading: boolean;
   isValid: boolean;
+  tinIsRequired: boolean;
   operation: Operation;
   confirmReceiptData: () => Promise<void>;
 }
@@ -16,6 +17,7 @@ const DonationReceipt = ({
   donationReceipt,
   isLoading,
   isValid,
+  tinIsRequired,
   operation,
   confirmReceiptData,
 }: DonationReceiptProps) => {
@@ -28,6 +30,7 @@ const DonationReceipt = ({
           isLoading={isLoading}
           confirmReceiptData={confirmReceiptData}
           isValid={isValid}
+          tinIsRequired={tinIsRequired}
         />
         <VerifyReceiptFooter />
       </div>

--- a/src/features/user/DonationReceipt/microComponents/ReceiptDataSection.tsx
+++ b/src/features/user/DonationReceipt/microComponents/ReceiptDataSection.tsx
@@ -13,6 +13,7 @@ interface ReceiptDataSectionProps {
   isLoading: boolean;
   confirmReceiptData: () => Promise<void>;
   isValid: boolean;
+  tinIsRequired: boolean;
 }
 
 const ReceiptDataSection = ({
@@ -20,6 +21,7 @@ const ReceiptDataSection = ({
   isLoading,
   confirmReceiptData,
   isValid,
+  tinIsRequired,
 }: ReceiptDataSectionProps) => {
   const {
     amount,
@@ -50,6 +52,13 @@ const ReceiptDataSection = ({
           !address.country
         }
       />
+      {tinIsRequired && !donor.tin && (
+        <p className={styles.loginAlert}>
+          {tReceipt.rich('notifications.missingTIN', {
+            b: (chunks) => <strong>{chunks}</strong>,
+          })}
+        </p>
+      )}
       {!isAuthenticated && (
         <p className={styles.loginAlert}>
           {tReceipt.rich('notifications.loginRequired', {


### PR DESCRIPTION
This PR will render an additional message on the donation receipt verification page when the /app/donationReceipt lookup endpoint returns tinIsRequired=true and the donation receipt donor data does not contain a TIN.

Fixes #

Check this list and then dismiss it:
- **Localization**
  - Have you added translation resources?
  - Have you localized numbers, dates and other stuff?
- **Validation and error management**
  - Is the user input validated?
  - Is the API response valided and are error responses properly handled?
  - Are errors caught if necessary?
- **Coding style**
  - Have you used a specific type for declaring the properties and parameters instead of `any`?
  - Have you defined interfaces for new components?
  - Have you added a source file not using TypeScript?
  - Have you checked if your newly introduced modules or functions are not already existing?
  - Is your `React.useEffect` using the right dependencies?
  - Check your code if it matches the existing code formatting.

Changes in this pull request:
-
-
-

@