### PR TITLE
Enhance embed mode functionality and visibility controls

### DIFF
--- a/src/features/common/Layout/Navbar/index.tsx
+++ b/src/features/common/Layout/Navbar/index.tsx
@@ -1,6 +1,4 @@
-import React, { useContext } from 'react';
 import { useUserProps } from '../UserPropsContext';
-import { ParamsContext } from '../QueryParamsContext';
 import ImpersonationActivated from '../../../user/Settings/ImpersonateUser/ImpersonationActivated';
 import { useTenant } from '../TenantContext';
 import BrandLogo from './microComponents/BrandLogo';
@@ -30,7 +28,6 @@ const CommonHeader = () => {
 };
 
 export default function NavbarComponent() {
-  const { embed } = useContext(ParamsContext);
   const { tenantConfig } = useTenant();
   const { setUser, logoutUser, auth0Error } = useUserProps();
 
@@ -52,8 +49,6 @@ export default function NavbarComponent() {
       logoutUser(`${window.location.origin}/`);
     }
   }
-
-  if (embed === 'true') return null;
 
   return tenantConfig ? (
     <div className="mainNavContainer">

--- a/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
+++ b/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import type { SetState } from '../../types/common';
 
-import { useContext, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import styles from './ProjectsLayout.module.scss';
 import ProjectsMap from '../../../projectsV2/ProjectsMap';
 import { ProjectsProvider } from '../../../projectsV2/ProjectsContext';
@@ -24,8 +24,21 @@ const MobileProjectsLayout: FC<ProjectsLayoutProps> = ({
   setCurrencyCode,
   isMobile,
 }) => {
-  const { embed } = useContext(ParamsContext);
+  const { embed, showProjectList, showProjectDetails } =
+    useContext(ParamsContext);
   const [selectedMode, setSelectedMode] = useState<ViewMode>('list');
+
+  useEffect(() => {
+    if (embed === 'true') {
+      if (page === 'project-details' && showProjectDetails === 'false') {
+        setSelectedMode('map');
+      }
+      if (page === 'project-list' && showProjectList === 'false') {
+        setSelectedMode('map');
+      }
+    }
+  }, [page, embed, showProjectDetails, showProjectList]);
+
   const mobileLayoutClass = `${styles.mobileProjectsLayout} ${
     selectedMode === 'map' ? styles.mapMode : ''
   } ${embed === 'true' ? styles.embedModeMobile : ''}`;

--- a/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
+++ b/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
@@ -1,12 +1,13 @@
 import type { FC } from 'react';
 import type { SetState } from '../../types/common';
 
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import styles from './ProjectsLayout.module.scss';
 import ProjectsMap from '../../../projectsV2/ProjectsMap';
 import { ProjectsProvider } from '../../../projectsV2/ProjectsContext';
 import { ProjectsMapProvider } from '../../../projectsV2/ProjectsMapContext';
 import Credits from '../../../projectsV2/ProjectsMap/Credits';
+import { ParamsContext } from '../QueryParamsContext';
 
 export type ViewMode = 'list' | 'map';
 interface ProjectsLayoutProps {
@@ -23,10 +24,11 @@ const MobileProjectsLayout: FC<ProjectsLayoutProps> = ({
   setCurrencyCode,
   isMobile,
 }) => {
+  const { embed } = useContext(ParamsContext);
   const [selectedMode, setSelectedMode] = useState<ViewMode>('list');
   const mobileLayoutClass = `${styles.mobileProjectsLayout} ${
     selectedMode === 'map' ? styles.mapMode : ''
-  }`;
+  } ${embed === 'true' ? styles.embedModeMobile : ''}`;
   return (
     <ProjectsProvider
       page={page}

--- a/src/features/common/Layout/ProjectsLayout/ProjectsLayout.module.scss
+++ b/src/features/common/Layout/ProjectsLayout/ProjectsLayout.module.scss
@@ -75,6 +75,11 @@ $bottomMobileFooterSpace: 49px;
     top: 0;
     padding-top: 0;
   }
+
+  &.embedModeMobile {
+    top: 0;
+    bottom: 29px;
+  }
 }
 
 .mobileContentContainer {

--- a/src/features/common/Layout/ProjectsLayout/index.tsx
+++ b/src/features/common/Layout/ProjectsLayout/index.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import type { SetState } from '../../types/common';
 
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import styles from './ProjectsLayout.module.scss';
 import Credits from '../../../projectsV2/ProjectsMap/Credits';
 import ProjectsMap from '../../../projectsV2/ProjectsMap';
@@ -11,8 +11,8 @@ import {
   useProjectsMap,
 } from '../../../projectsV2/ProjectsMapContext';
 import MapFeatureExplorer from '../../../projectsV2/ProjectsMap/MapFeatureExplorer';
-import { useRouter } from 'next/router';
 import { useUserProps } from '../UserPropsContext';
+import { ParamsContext } from '../QueryParamsContext';
 
 interface ProjectsLayoutProps {
   currencyCode: string;
@@ -26,15 +26,27 @@ const ProjectsLayoutContent: FC<Omit<ProjectsLayoutProps, 'currencyCode'>> = ({
   page,
 }) => {
   const { mapOptions, updateMapOption } = useProjectsMap();
-  const { query } = useRouter();
   const { isImpersonationModeOn } = useUserProps();
-  const showContentContainer =
-    Boolean(mapOptions.projects) || page === 'project-details';
+  const { embed, showProjectDetails, showProjectList } =
+    useContext(ParamsContext);
+
+  const showContentContainer = useMemo(() => {
+    const hideProjectList =
+      page === 'project-list' &&
+      mapOptions.projects &&
+      !(embed === 'true' && showProjectList === 'false');
+    const hideProjectDetails =
+      page === 'project-details' &&
+      !(embed === 'true' && showProjectDetails === 'false');
+    return hideProjectList || hideProjectDetails;
+  }, [page, embed, showProjectDetails, showProjectList]);
+
   const layoutClass = useMemo(() => {
-    if (query.embed === 'true') return styles.embedMode;
+    if (embed === 'true') return styles.embedMode;
     if (isImpersonationModeOn) return styles.impersonationMode;
     return styles.projectsLayout;
-  }, [isImpersonationModeOn, query.embed]);
+  }, [isImpersonationModeOn, embed]);
+
   return (
     <div className={layoutClass}>
       <main className={styles.mainContent}>

--- a/src/features/common/Layout/QueryParamsContext.tsx
+++ b/src/features/common/Layout/QueryParamsContext.tsx
@@ -13,7 +13,11 @@ export interface ParamsContextType {
   showProjectList: QueryParamType;
   enableIntro: QueryParamType;
   isContextLoaded: boolean;
+  page: EmbeddablePages | null;
 }
+
+type EmbeddablePages = 'project-list' | 'project-details';
+
 export const ParamsContext = createContext<ParamsContextType>({
   embed: undefined,
   showBackIcon: undefined,
@@ -22,6 +26,7 @@ export const ParamsContext = createContext<ParamsContextType>({
   showProjectList: undefined,
   enableIntro: undefined,
   isContextLoaded: false,
+  page: null,
 });
 
 const QueryParamsProvider: FC = ({ children }) => {
@@ -30,6 +35,7 @@ const QueryParamsProvider: FC = ({ children }) => {
   const [embed, setEmbed] = useState<QueryParamType>(undefined);
   const [showBackIcon, setShowBackIcon] = useState<QueryParamType>(undefined);
   const [callbackUrl, setCallbackUrl] = useState<QueryParamType>(undefined);
+  const [page, setPage] = useState<EmbeddablePages | null>(null);
 
   const [showProjectDetails, setShowProjectDetails] =
     useState<QueryParamType>(undefined);
@@ -40,7 +46,14 @@ const QueryParamsProvider: FC = ({ children }) => {
 
   useEffect(() => {
     if (router.isReady) {
-      const { query } = router;
+      const { query, pathname } = router;
+      if (pathname === '/sites/[slug]/[locale]') {
+        setPage('project-list');
+      } else if (query.p !== undefined) {
+        setPage('project-details');
+      } else {
+        setPage(null);
+      }
       if (query.embed) setEmbed(query.embed);
       if (query.back_icon) setShowBackIcon(query.back_icon);
       if (query.callback) setCallbackUrl(query.callback);
@@ -69,6 +82,7 @@ const QueryParamsProvider: FC = ({ children }) => {
         showProjectList,
         enableIntro,
         isContextLoaded,
+        page,
       }}
     >
       {children}

--- a/src/features/common/Layout/index.tsx
+++ b/src/features/common/Layout/index.tsx
@@ -7,14 +7,14 @@ import CookiePolicy from './CookiePolicy';
 import ErrorPopup from './ErrorPopup';
 import Header from './Header';
 import Navbar from './Navbar';
-// import RedeemPopup from './RedeemPopup';
 import { ParamsContext } from './QueryParamsContext';
 
 const Layout: FC = ({ children }) => {
   const { theme: themeType } = useTheme();
-  const { embed } = useContext(ParamsContext);
+  const { embed, page } = useContext(ParamsContext);
 
-  const isEmbed = embed === 'true';
+  const isEmbed =
+    embed === 'true' && (page === 'project-list' || page === 'project-details');
 
   return (
     <>

--- a/src/features/projectsV2/ProjectListControls/ProjectListControlForMobile.tsx
+++ b/src/features/projectsV2/ProjectListControls/ProjectListControlForMobile.tsx
@@ -5,7 +5,7 @@ import type { MapProject } from '../../common/types/projectv2';
 import type { ViewMode } from '../../common/Layout/ProjectsLayout/MobileProjectsLayout';
 import type { MapOptions } from '../ProjectsMapContext';
 
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import styles from './styles/ProjectListControls.module.scss';
 import ProjectListTabForMobile from './microComponents/ProjectListTabForMobile';
@@ -15,6 +15,7 @@ import ClassificationDropDown from './microComponents/ClassificationDropDown';
 import ActiveSearchField from './microComponents/ActiveSearchField';
 import { useUserProps } from '../../common/Layout/UserPropsContext';
 import MapFeatureExplorer from '../ProjectsMap/MapFeatureExplorer';
+import { ParamsContext } from '../../common/Layout/QueryParamsContext';
 
 interface ProjectListControlForMobileProps {
   projectCount: number | undefined;
@@ -58,10 +59,14 @@ const ProjectListControlForMobile = ({
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const tAllProjects = useTranslations('AllProjects');
   const { isImpersonationModeOn } = useUserProps();
+  const { embed, showProjectList, page } = useContext(ParamsContext);
+
   const hasFilterApplied = selectedClassification.length > 0;
   const shouldDisplayFilterResults = hasFilterApplied && selectedMode !== 'map';
   const shouldDisplayProjectListTab =
     !hasFilterApplied && selectedMode !== 'map' && !shouldHideProjectTabs;
+  const onlyMapModeAllowed =
+    embed === 'true' && page === 'project-list' && showProjectList === 'false';
   const shouldDisplayMapFeatureExplorer = selectedMode === 'map';
   const projectListControlsMobileClasses = `${
     styles.projectListControlsMobile
@@ -112,7 +117,7 @@ const ProjectListControlForMobile = ({
       {isSearching ? (
         <div className={tabContainerClasses}>
           <ActiveSearchField {...activeSearchFieldProps} />
-          <ViewModeTabs {...viewModeTabsProps} />
+          {!onlyMapModeAllowed && <ViewModeTabs {...viewModeTabsProps} />}
         </div>
       ) : (
         <div className={projectListControlsMobileClasses}>
@@ -136,7 +141,7 @@ const ProjectListControlForMobile = ({
               isMobile={true}
             />
           )}
-          <ViewModeTabs {...viewModeTabsProps} />
+          {!onlyMapModeAllowed && <ViewModeTabs {...viewModeTabsProps} />}
         </div>
       )}
       {isFilterOpen && !isSearching && (

--- a/src/features/projectsV2/ProjectListControls/microComponents/ActiveSearchField.tsx
+++ b/src/features/projectsV2/ProjectListControls/microComponents/ActiveSearchField.tsx
@@ -1,13 +1,14 @@
 import type { ChangeEvent } from 'react';
 import type { SetState } from '../../../common/types/common';
 
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { SearchTextField } from './SearchTextField';
 import CrossIcon from '../../../../../public/assets/images/icons/projectV2/CrossIcon';
 import styles from '../styles/ProjectListControls.module.scss';
 import SearchIcon from '../../../../../public/assets/images/icons/projectV2/SearchIcon';
 import { useDebouncedEffect } from '../../../../utils/useDebouncedEffect';
+import { ParamsContext } from '../../../common/Layout/QueryParamsContext';
 
 interface ActiveSearchFieldProps {
   setIsSearching: SetState<boolean>;
@@ -23,7 +24,10 @@ const ActiveSearchField = ({
   setDebouncedSearchValue,
 }: ActiveSearchFieldProps) => {
   const t = useTranslations('AllProjects');
+  const { embed, showProjectList } = useContext(ParamsContext);
+
   const [searchValue, setSearchValue] = useState(debouncedSearchValue);
+  const onlyMapModeAllowed = embed === 'true' && showProjectList === 'false';
 
   useDebouncedEffect(
     () => {
@@ -38,7 +42,11 @@ const ActiveSearchField = ({
     setIsFilterOpen(false);
   };
   return (
-    <div className={styles.activeSearchFieldContainer}>
+    <div
+      className={`${styles.activeSearchFieldContainer} ${
+        onlyMapModeAllowed ? styles.onlyMapMode : ''
+      }`}
+    >
       <button className={styles.activeSearchIcon}>
         <SearchIcon />
       </button>

--- a/src/features/projectsV2/ProjectListControls/styles/ProjectListControls.module.scss
+++ b/src/features/projectsV2/ProjectListControls/styles/ProjectListControls.module.scss
@@ -16,6 +16,11 @@
     min-width: 200px;
     border-radius: 8px;
     border: 1px solid rgba($borderColor, 0.5);
+
+    &.onlyMapMode {
+      max-width: none;
+      width: 100%;
+    }
   }
 }
 
@@ -225,15 +230,16 @@
   z-index: 2;
   box-shadow: 4px 8px 16px rgba(0, 0, 0, 0.2);
   left: 193px;
+
+  .listMode {
+    left: 168px;
+    top: 67px;
+  }
+
   @include xsPhoneView {
     left: 127px;
     top: 29px;
   }
-}
-
-.listMode {
-  left: 168px;
-  top: 67px;
 }
 
 .classificationItem {

--- a/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
@@ -37,8 +37,10 @@ const ImageSection = (props: ImageSectionProps) => {
   const tProjectsCommon = useTranslations('Project');
   const router = useRouter();
   const locale = useLocale();
-  const { embed, callbackUrl } = useContext(ParamsContext);
+  const { embed, callbackUrl, showBackIcon } = useContext(ParamsContext);
   const isEmbed = embed === 'true';
+  const showBackButton =
+    page === 'project-details' && !(isEmbed && showBackIcon === 'false');
 
   const handleBackButton = () => {
     if (setPreventShallowPush) {
@@ -93,7 +95,7 @@ const ImageSection = (props: ImageSectionProps) => {
 
   return (
     <div className={imageContainerClasses}>
-      {page === 'project-details' && (
+      {showBackButton && (
         <button onClick={handleBackButton} className={styles.backButton}>
           <BackButton />
         </button>

--- a/src/features/projectsV2/ProjectsContext.tsx
+++ b/src/features/projectsV2/ProjectsContext.tsx
@@ -283,11 +283,9 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
     projectSlug: string,
     siteId: string | null
   ) => {
-    const updatedQueryParams = buildProjectDetailsQuery(
-      router.asPath,
-      router.query,
-      { siteId }
-    );
+    const updatedQueryParams = buildProjectDetailsQuery(router.query, {
+      siteId,
+    });
     updateProjectDetailsPath(locale, projectSlug, updatedQueryParams);
   };
 
@@ -347,11 +345,9 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
 
     // Handles updating the URL with the 'ploc' parameter when a user selects a different plant location.
     if (selectedPlantLocation) {
-      const updatedQueryParams = buildProjectDetailsQuery(
-        router.asPath,
-        router.query,
-        { plocId: selectedPlantLocation.hid }
-      );
+      const updatedQueryParams = buildProjectDetailsQuery(router.query, {
+        plocId: selectedPlantLocation.hid,
+      });
       updateProjectDetailsPath(locale, singleProject.slug, updatedQueryParams);
     }
   }, [
@@ -417,7 +413,6 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({
       setSelectedSamplePlantLocation(null);
       setSelectedPlantLocation(null);
       setHoveredPlantLocation(null);
-      updateSiteAndUrl(locale, singleProject.slug, hasNoSites ? undefined : 0);
     }
   }, [selectedMode, singleProject, locale, hasNoSites]);
 

--- a/src/features/projectsV2/ProjectsMap/MapControls.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapControls.tsx
@@ -57,7 +57,7 @@ const MapControls = ({
     setDisableInterventionMenu,
     plantLocations,
   } = useProjects();
-  const { embed } = useContext(ParamsContext);
+  const { embed, showProjectDetails } = useContext(ParamsContext);
 
   const uniquePlantTypes = useMemo(() => {
     if (!plantLocations) return [];
@@ -82,6 +82,11 @@ const MapControls = ({
     isProjectDetailsPage &&
     selectedTab === 'field' &&
     uniquePlantTypes.length > 1;
+  const onlyMapModeAllowed =
+    embed === 'true' &&
+    isMobile &&
+    page === 'project-details' &&
+    showProjectDetails === 'false';
 
   const enableInterventionFilter = () => {
     setDisableInterventionMenu(true);
@@ -171,12 +176,14 @@ const MapControls = ({
                   existingIntervention={uniquePlantTypes}
                 />
               )}
-              <button
-                className={styles.exitMapModeButton}
-                onClick={exitMapMode}
-              >
-                <CrossIcon width={18} />
-              </button>
+              {!onlyMapModeAllowed && (
+                <button
+                  className={styles.exitMapModeButton}
+                  onClick={exitMapMode}
+                >
+                  <CrossIcon width={18} />
+                </button>
+              )}
             </div>
           ) : (
             <>

--- a/src/features/projectsV2/ProjectsMap/MapControls.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapControls.tsx
@@ -2,7 +2,7 @@ import type { ViewMode } from '../../common/Layout/ProjectsLayout/MobileProjects
 import type { SetState } from '../../common/types/common';
 import type { MobileOs } from '../../../utils/projectV2';
 import type { SelectedTab } from './ProjectMapTabs';
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import ProjectSiteDropdown from './ProjectSiteDropDown';
 import InterventionDropDown from './InterventionDropDown';
 import ProjectListControlForMobile from '../ProjectListControls/ProjectListControlForMobile';
@@ -13,6 +13,7 @@ import LayerDisabled from '../../../../public/assets/images/icons/LayerDisabled'
 import CrossIcon from '../../../../public/assets/images/icons/projectV2/CrossIcon';
 import styles from '../ProjectsMap/ProjectsMap.module.scss';
 import { AllInterventions } from '../../../utils/constants/intervention';
+import { ParamsContext } from '../../common/Layout/QueryParamsContext';
 
 interface MapControlsProps {
   isMobile: boolean;
@@ -56,6 +57,7 @@ const MapControls = ({
     setDisableInterventionMenu,
     plantLocations,
   } = useProjects();
+  const { embed } = useContext(ParamsContext);
 
   const uniquePlantTypes = useMemo(() => {
     if (!plantLocations) return [];
@@ -140,18 +142,24 @@ const MapControls = ({
         : styles.layerToggleIos
       : styles.layerToggleDesktop
   }`;
+  const projectListControlsContainerStyles = `${
+    styles.projectListControlsContainer
+  } ${embed === 'true' ? styles.embedModeMobile : ''}`;
+  const projectDetailsControlsContainerStyles = `${
+    styles.projectDetailsControlsContainer
+  } ${embed === 'true' ? styles.embedModeMobile : ''}`;
 
   return (
     <>
       {isMobile && page === 'project-list' && (
-        <div className={styles.projectListControlsContainer}>
+        <div className={projectListControlsContainerStyles}>
           <ProjectListControlForMobile {...projectListControlProps} />
         </div>
       )}
       {isProjectDetailsPage && (
         <>
           {isMobile ? (
-            <div className={styles.projectDetailsControlsContainer}>
+            <div className={projectDetailsControlsContainerStyles}>
               {hasProjectSites && (
                 <ProjectSiteDropdown {...siteDropdownProps} />
               )}

--- a/src/features/projectsV2/ProjectsMap/MapControls.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapControls.tsx
@@ -104,6 +104,7 @@ const MapControls = ({
     setSelectedSamplePlantLocation,
     disableInterventionFilter,
     disableInterventionMenu,
+    canShowInterventionDropdown,
   };
 
   const interventionDropDownProps = {

--- a/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/ProjectSiteList.tsx
+++ b/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/ProjectSiteList.tsx
@@ -20,7 +20,9 @@ interface ProjectSiteListProps {
   selectedSiteData: SiteData | undefined;
   setSelectedPlantLocation: SetState<PlantLocation | null>;
   setSelectedSamplePlantLocation: SetState<SamplePlantLocation | null>;
+  canShowInterventionDropdown: boolean;
 }
+
 const ProjectSiteList = ({
   siteList,
   setSelectedSite,
@@ -28,6 +30,7 @@ const ProjectSiteList = ({
   selectedSiteData,
   setSelectedPlantLocation,
   setSelectedSamplePlantLocation,
+  canShowInterventionDropdown,
 }: ProjectSiteListProps) => {
   const locale = useLocale();
   const handleSiteSelection = (index: number) => {
@@ -38,7 +41,11 @@ const ProjectSiteList = ({
   };
 
   return (
-    <ul className={styles.siteListOptions}>
+    <ul
+      className={`${styles.siteListOptions} ${
+        canShowInterventionDropdown ? styles.withInterventions : ''
+      }`}
+    >
       {siteList.map((site, index) => {
         return (
           <li

--- a/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/SiteDropdown.module.scss
+++ b/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/SiteDropdown.module.scss
@@ -142,8 +142,13 @@ $layoutPaddingSide: 20px;
     max-width: 140px;
     padding: 8px 12px;
     top: 36px;
-    right: 40%;
+    right: 0;
     min-width: 160px;
+
+    &.withInterventions {
+      right: 40%;
+    }
+
     .listItem {
       display: flex;
       flex-direction: column;

--- a/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/index.tsx
@@ -43,6 +43,7 @@ interface Props {
   setSelectedSamplePlantLocation: SetState<SamplePlantLocation | null>;
   disableInterventionFilter: () => void;
   disableInterventionMenu: boolean;
+  canShowInterventionDropdown: boolean;
 }
 
 const ProjectSiteDropdown = ({
@@ -54,6 +55,7 @@ const ProjectSiteDropdown = ({
   setSelectedSamplePlantLocation,
   disableInterventionFilter,
   disableInterventionMenu,
+  canShowInterventionDropdown,
 }: Props) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const tProjectDetails = useTranslations('ProjectDetails');
@@ -142,6 +144,7 @@ const ProjectSiteDropdown = ({
           selectedSiteData={selectedSiteData}
           setSelectedPlantLocation={setSelectedPlantLocation}
           setSelectedSamplePlantLocation={setSelectedSamplePlantLocation}
+          canShowInterventionDropdown={canShowInterventionDropdown}
         />
       )}
     </>

--- a/src/features/projectsV2/ProjectsMap/ProjectsMap.module.scss
+++ b/src/features/projectsV2/ProjectsMap/ProjectsMap.module.scss
@@ -5,6 +5,10 @@
   width: 100%;
   top: 101px;
   z-index: 2;
+
+  &.embedModeMobile {
+    top: 24px;
+  }
 }
 
 .projectDetailsControlsContainer {
@@ -17,6 +21,10 @@
   right: 10px;
   z-index: 2px;
   width: 85%;
+
+  &.embedModeMobile {
+    top: 24px;
+  }
 
   > .exitMapModeButton {
     z-index: 2;

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -40,7 +40,6 @@ const isStringValue = (entry: [string, unknown]): entry is [string, string] => {
  */
 
 export const buildProjectDetailsQuery = (
-  asPath: string,
   query: ParsedUrlQuery,
   routeParams: RouteParams
 ): Record<string, string> => {


### PR DESCRIPTION
### Pages affected
- project list page (/) and project details page (/[p])

### Changes
- fixes missing / non-functional /buggy functionality related to query parameters passed in the project list and details pages
- restricts embed mode (using `?embed=true`) to project list and details pages only 
- adapts mobile layout for embed mode
- fixes missing functionality to hide back button in embed mode using `?embed=true&back_icon=false`
- implements missing direct map mode functionality (for embed mode) on project list (`?embed=true&project_list=false`) and details (`?embed=true&project_details=false`) pages on mobile and non-mobile, including layout adjustments to related elements while conditionally rendering elements/components like ViewModeTabs and exitMapModeButton (so that the layout remains consistent without extra spaces/inconsistent positioning)

### Preview URLs (in mobile and non-mobile separately):
- https://planet-webapp-multi-tenancy-setup-git-feature-5cc785-planetapp.vercel.app/en?embed=true
- https://planet-webapp-multi-tenancy-setup-git-feature-5cc785-planetapp.vercel.app/en?embed=true&project_list=false
- https://planet-webapp-multi-tenancy-setup-git-feature-5cc785-planetapp.vercel.app/en/yucatan?embed=true
- https://planet-webapp-multi-tenancy-setup-git-feature-5cc785-planetapp.vercel.app/en/yucatan?embed=true&project_details=false
- https://planet-webapp-multi-tenancy-setup-git-feature-5cc785-planetapp.vercel.app/en/yucatan?embed=true&back_icon=false

### Mobile screenshots
Project list - ?embed=true
<img width="374" alt="Screenshot 2025-03-19 at 12 36 46 PM" src="https://github.com/user-attachments/assets/95f86892-7106-4983-81dc-0b287cd9e6e9" />

Project list - ?embed=true&project_list=false
<img width="377" alt="Screenshot 2025-03-19 at 12 36 57 PM" src="https://github.com/user-attachments/assets/d649906b-8598-4749-b2fe-0254b64c6715" />

Project details - ?embed=true
<img width="374" alt="Screenshot 2025-03-19 at 12 36 29 PM" src="https://github.com/user-attachments/assets/14cf4edc-276e-436e-9d24-ac7f0f9b3dd8" />

Project details - ?embed=true&project_details=false
<img width="376" alt="Screenshot 2025-03-19 at 12 36 10 PM" src="https://github.com/user-attachments/assets/57f3d3f2-b935-4bdf-9f2e-56518261fb75" />

Project details - ?embed=true&back_icon=false
<img width="376" alt="Screenshot 2025-03-19 at 12 36 21 PM" src="https://github.com/user-attachments/assets/bac479a3-344b-479e-8f0a-1a406f8be0cb" />

### Non-mobile screenshots
Project list - ?embed=true
<img width="1440" alt="Screenshot 2025-03-19 at 12 37 18 PM" src="https://github.com/user-attachments/assets/c8e6d4a1-9a21-499e-8fdc-247ece583f45" />

Project list - ?embed=true&project_list=false
<img width="1440" alt="Screenshot 2025-03-19 at 12 37 08 PM" src="https://github.com/user-attachments/assets/64df81cc-60f7-440c-a8d6-2ed8edd8b708" />

Project details - ?embed=true
<img width="1440" alt="Screenshot 2025-03-19 at 12 37 36 PM" src="https://github.com/user-attachments/assets/05ecfb49-dc97-4b05-816d-36e06b5be305" />

Project details - ?embed=true&project_details=false
<img width="1440" alt="Screenshot 2025-03-19 at 12 38 10 PM" src="https://github.com/user-attachments/assets/dc6eff53-46fd-4eba-8879-7f9bd807b761" />

Project details - ?embed=true&back_icon=false
<img width="1440" alt="Screenshot 2025-03-19 at 12 37 52 PM" src="https://github.com/user-attachments/assets/8eb6493d-e246-4bcd-b44d-9ceea679f7ed" />

