### PR TITLE
Fix: simplify and correct showContentContainer conditional logic

### DIFF
--- a/src/features/common/Layout/ProjectsLayout/index.tsx
+++ b/src/features/common/Layout/ProjectsLayout/index.tsx
@@ -31,15 +31,19 @@ const ProjectsLayoutContent: FC<Omit<ProjectsLayoutProps, 'currencyCode'>> = ({
     useContext(ParamsContext);
 
   const showContentContainer = useMemo(() => {
-    const hideProjectList =
-      page === 'project-list' &&
-      mapOptions.projects &&
-      !(embed === 'true' && showProjectList === 'false');
-    const hideProjectDetails =
-      page === 'project-details' &&
-      !(embed === 'true' && showProjectDetails === 'false');
-    return hideProjectList || hideProjectDetails;
-  }, [page, embed, showProjectDetails, showProjectList]);
+    if (page === 'project-list') {
+      return (
+        (embed !== 'true' || showProjectList !== 'false') &&
+        Boolean(mapOptions.projects)
+      );
+    }
+
+    if (page === 'project-details') {
+      return embed !== 'true' || showProjectDetails !== 'false';
+    }
+
+    return false;
+  }, [page, embed, showProjectList, showProjectDetails, mapOptions.projects]);
 
   const layoutClass = useMemo(() => {
     if (embed === 'true') return styles.embedMode;


### PR DESCRIPTION
This PR refactors the conditional logic for displaying the content container in the ProjectsLayout component and fixes a minor bug in the display logic where the content container was not hiding when the explore projects toggle was switched off.

Changes
- Fix a bug where the content container was not hiding when the explore projects toggle was switched off.
- Simplify the logic that determines visibility of the content container

The bug fix ensures that:
- For project-list pages: Content correctly hides when the projects are toggled off.
- Additionally maintains correct behavior for hiding content when embedded with explicit hide parameter (project_details=false on the project details page, and project_list=false on the project list page)