### PR TITLE
fix: restrict project fetch when registering a tree for non-TPO users

### DIFF
--- a/src/features/user/RegisterTrees/RegisterTreesWidget.tsx
+++ b/src/features/user/RegisterTrees/RegisterTreesWidget.tsx
@@ -235,7 +235,7 @@ function RegisterTreesForm({
     if (contextLoaded && user?.type === 'tpo') {
       loadProjects();
     }
-  }, [contextLoaded, user]);
+  }, [contextLoaded]);
 
   const _onStateChange = (state: any) => setMapState({ ...state });
   const _onViewportChange = (view: any) => setViewPort({ ...view });

--- a/src/features/user/RegisterTrees/RegisterTreesWidget.tsx
+++ b/src/features/user/RegisterTrees/RegisterTreesWidget.tsx
@@ -232,10 +232,10 @@ function RegisterTreesForm({
   }
 
   React.useEffect(() => {
-    if (contextLoaded) {
+    if (contextLoaded && user?.type === 'tpo') {
       loadProjects();
     }
-  }, [contextLoaded]);
+  }, [contextLoaded, user]);
 
   const _onStateChange = (state: any) => setMapState({ ...state });
   const _onViewportChange = (view: any) => setViewPort({ ...view });


### PR DESCRIPTION
This fix ensures that projects are only fetched when registering a tree if the user is a TPO (Tree Planting Organization). Previously, the endpoint was being called unnecessarily for non-TPO users. The logic has been updated to check the user type before triggering the project fetch, improving performance and reducing unnecessary API calls.

