### PR TITLE
Fixes non-working project grid navigation link (mangroves page)

### DIFF
--- a/src/tenants/salesforce/Mangroves/components/ContentSection.tsx
+++ b/src/tenants/salesforce/Mangroves/components/ContentSection.tsx
@@ -46,7 +46,7 @@ export default function ContentSection() {
                 <MangroveMapIcon /> View Project Map
               </button>
             </Link>
-            <Link href="/mangroves#project-grid">
+            <Link href="#project-grid">
               <button className={styles.projectListButton}>
                 <ViewIcon /> View Project List
               </button>


### PR DESCRIPTION
Change the link for project grid navigation so that it navigates (scrolls) correctly to the projects list.