### PR TITLE
Add URL parameters for project filters

### DIFF
--- a/src/features/projectsV2/ProjectsSection.tsx
+++ b/src/features/projectsV2/ProjectsSection.tsx
@@ -38,6 +38,15 @@ const ProjectsSection = ({ isMobile }: ProjectsSectionProps) => {
   const [tabSelected, setTabSelected] = useState<ProjectTabs>('topProjects');
 
   useEffect(() => {
+    if (
+      (selectedClassification.length > 0 || showDonatableProjects) &&
+      tabSelected === 'topProjects'
+    ) {
+      setTabSelected('allProjects');
+    }
+  }, [selectedClassification, showDonatableProjects]);
+
+  useEffect(() => {
     // When tenantConfig.topProjectsOnly is true, it indicates all projects returned by the projects endpoint are to be shown, without splitting them into top projects and all projects
     if (tenantConfig.topProjectsOnly === true) {
       setTabSelected('allProjects');

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -95,6 +95,12 @@ export const availableFilters: TreeProjectClassification[] = [
   'other-planting',
 ];
 
+export const isValidClassification = (
+  value: string
+): value is TreeProjectClassification => {
+  return availableFilters.includes(value as TreeProjectClassification);
+};
+
 /**
  * Retrieves the information of a plant location based on a user's interaction with the map.
  *


### PR DESCRIPTION
- Introduce URL parameters to preselect project filters, allowing users to filter projects based on classification and donation status using url query params
- Update logic to automatically select the 'allProjects' tab when filters are applied.

Usage:
1. The following classification filters can be applied using query parameters to the index route: 'large-scale-planting', 'agroforestry', 'natural-regeneration', 'managed-regeneration', 'urban-planting', 'mangroves', 'other-planting' . 
    - e.g. `?filter=mangroves`
    - e.g. `?filter=agroforestry&filter=urban-planting`
2. Only donatable projects can be filtered out using `?donatable_projects_only=true`