### PR TITLE
Use Api Hook 7

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -251,52 +251,52 @@ const PlanetWeb = ({
       >
         <CacheProvider value={emotionCache}>
           <ErrorHandlingProvider>
-            <CurrencyProvider>
-              <TenantProvider>
-                <QueryParamsProvider>
-                  <div>
-                    <div
-                      style={
-                        showVideo &&
-                        (tenantConfig.config.slug === 'planet' ||
-                          tenantConfig.config.slug === 'ttc')
-                          ? {}
-                          : { display: 'none' }
-                      }
-                    >
-                      <VideoContainer setshowVideo={setshowVideo} />
-                    </div>
+            <TenantProvider>
+              <QueryParamsProvider>
+                <div>
+                  <div
+                    style={
+                      showVideo &&
+                      (tenantConfig.config.slug === 'planet' ||
+                        tenantConfig.config.slug === 'ttc')
+                        ? {}
+                        : { display: 'none' }
+                    }
+                  >
+                    <VideoContainer setshowVideo={setshowVideo} />
+                  </div>
 
-                    <div
-                      style={
-                        showVideo &&
-                        (tenantConfig.config.slug === 'planet' ||
-                          tenantConfig.config.slug === 'ttc')
-                          ? { display: 'none' }
-                          : {}
+                  <div
+                    style={
+                      showVideo &&
+                      (tenantConfig.config.slug === 'planet' ||
+                        tenantConfig.config.slug === 'ttc')
+                        ? { display: 'none' }
+                        : {}
+                    }
+                  >
+                    <Auth0Provider
+                      domain={process.env.AUTH0_CUSTOM_DOMAIN!}
+                      clientId={
+                        tenantConfig.config?.auth0ClientId
+                          ? tenantConfig.config.auth0ClientId
+                          : process.env.AUTH0_CLIENT_ID
                       }
+                      redirectUri={
+                        typeof window !== 'undefined'
+                          ? window.location.origin
+                          : ''
+                      }
+                      audience={'urn:plant-for-the-planet'}
+                      cacheLocation={'localstorage'}
+                      onRedirectCallback={onRedirectCallback}
+                      useRefreshTokens={true}
                     >
-                      <Auth0Provider
-                        domain={process.env.AUTH0_CUSTOM_DOMAIN!}
-                        clientId={
-                          tenantConfig.config?.auth0ClientId
-                            ? tenantConfig.config.auth0ClientId
-                            : process.env.AUTH0_CLIENT_ID
-                        }
-                        redirectUri={
-                          typeof window !== 'undefined'
-                            ? window.location.origin
-                            : ''
-                        }
-                        audience={'urn:plant-for-the-planet'}
-                        cacheLocation={'localstorage'}
-                        onRedirectCallback={onRedirectCallback}
-                        useRefreshTokens={true}
-                      >
-                        <ThemeProvider>
-                          <MuiThemeProvider theme={materialTheme}>
-                            <CssBaseline />
-                            <UserPropsProvider>
+                      <ThemeProvider>
+                        <MuiThemeProvider theme={materialTheme}>
+                          <CssBaseline />
+                          <UserPropsProvider>
+                            <CurrencyProvider>
                               <PlanetCashProvider>
                                 <PayoutsProvider>
                                   <Layout>
@@ -317,15 +317,15 @@ const PlanetWeb = ({
                                   </Layout>
                                 </PayoutsProvider>
                               </PlanetCashProvider>
-                            </UserPropsProvider>
-                          </MuiThemeProvider>
-                        </ThemeProvider>
-                      </Auth0Provider>
-                    </div>
+                            </CurrencyProvider>
+                          </UserPropsProvider>
+                        </MuiThemeProvider>
+                      </ThemeProvider>
+                    </Auth0Provider>
                   </div>
-                </QueryParamsProvider>
-              </TenantProvider>
-            </CurrencyProvider>
+                </div>
+              </QueryParamsProvider>
+            </TenantProvider>
           </ErrorHandlingProvider>
         </CacheProvider>
       </NextIntlClientProvider>

--- a/pages/sites/[slug]/[locale]/all.tsx
+++ b/pages/sites/[slug]/[locale]/all.tsx
@@ -15,7 +15,6 @@ import type { AbstractIntlMessages } from 'next-intl';
 
 import React from 'react';
 import LeaderBoard from '../../../../src/tenants/planet/LeaderBoard';
-import { getRequest } from '../../../../src/utils/apiRequests/api';
 import GetLeaderboardMeta from '../../../../src/utils/getMetaTags/GetLeaderboardMeta';
 import { ErrorHandlingContext } from '../../../../src/features/common/Layout/ErrorHandlingContext';
 import { handleError } from '@planet-sdk/common';
@@ -88,10 +87,9 @@ export default function Home({ pageProps }: Props) {
   React.useEffect(() => {
     async function loadTreesDonated() {
       try {
-        const newTreesDonated = await getRequest<TreesDonated>({
-          tenant: pageProps.tenantConfig.id,
-          url: `${process.env.WEBHOOK_URL}/platform/total-tree-count`,
-        });
+        const newTreesDonated = await getApi<TreesDonated>(
+          `${process.env.WEBHOOK_URL}/platform/total-tree-count`
+        );
         setTreesDonated(newTreesDonated);
       } catch (err) {
         setErrors(handleError(err as APIError));

--- a/pages/sites/[slug]/[locale]/home.tsx
+++ b/pages/sites/[slug]/[locale]/home.tsx
@@ -18,7 +18,7 @@ import SalesforceHome from '../../../../src/tenants/salesforce/Home';
 import SternHome from '../../../../src/tenants/stern/Home';
 import BasicHome from '../../../../src/tenants/common/Home';
 import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
-import { getRequest } from '../../../../src/utils/apiRequests/api';
+import { useApi } from '../../../../src/hooks/useApi';
 import { ErrorHandlingContext } from '../../../../src/features/common/Layout/ErrorHandlingContext';
 import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../../../src/features/common/Layout/TenantContext';
@@ -35,6 +35,7 @@ interface Props {
 
 export default function Home({ pageProps }: Props) {
   const router = useRouter();
+  const { getApi } = useApi();
 
   const [leaderboard, setLeaderboard] = React.useState<LeaderBoardList | null>(
     null
@@ -42,7 +43,7 @@ export default function Home({ pageProps }: Props) {
   const [tenantScore, setTenantScore] = React.useState<TenantScore | null>(
     null
   );
-  const { redirect, setErrors } = React.useContext(ErrorHandlingContext);
+  const { setErrors } = React.useContext(ErrorHandlingContext);
 
   const { setTenantConfig } = useTenant();
 
@@ -55,10 +56,7 @@ export default function Home({ pageProps }: Props) {
   React.useEffect(() => {
     async function loadTenantScore() {
       try {
-        const newTenantScore = await getRequest<TenantScore>({
-          tenant: pageProps.tenantConfig.id,
-          url: `/app/tenantScore`,
-        });
+        const newTenantScore = await getApi<TenantScore>('/app/tenantScore');
         setTenantScore(newTenantScore);
       } catch (err) {
         setErrors(handleError(err as APIError));
@@ -70,10 +68,9 @@ export default function Home({ pageProps }: Props) {
   React.useEffect(() => {
     async function loadLeaderboard() {
       try {
-        const newLeaderBoard = await getRequest<LeaderBoardList>({
-          tenant: pageProps.tenantConfig.id,
-          url: `/app/leaderboard`,
-        });
+        const newLeaderBoard = await getApi<LeaderBoardList>(
+          '/app/leaderboard'
+        );
         setLeaderboard(newLeaderBoard);
       } catch (err) {
         setErrors(handleError(err as APIError));

--- a/pages/sites/[slug]/[locale]/projects-archive/[p].tsx
+++ b/pages/sites/[slug]/[locale]/projects-archive/[p].tsx
@@ -21,7 +21,7 @@ import { ErrorHandlingContext } from '../../../../../src/features/common/Layout/
 import { useProjectProps } from '../../../../../src/features/common/Layout/ProjectPropsContext';
 import Credits from '../../../../../src/features/projectsV2/ProjectsMap/Credits';
 import SingleProjectDetails from '../../../../../src/features/projects/screens/SingleProjectDetails';
-import { getRequest } from '../../../../../src/utils/apiRequests/api';
+import { useApi } from '../../../../../src/hooks/useApi';
 import getStoredCurrency from '../../../../../src/utils/countryCurrency/getStoredCurrency';
 import ProjectDetailsMeta from '../../../../../src/utils/getMetaTags/ProjectDetailsMeta';
 import { getAllPlantLocations } from '../../../../../src/utils/maps/plantLocations';
@@ -48,6 +48,7 @@ export default function Donate({
   pageProps,
 }: Props) {
   const router = useRouter();
+  const { getApi } = useApi();
   const [internalCurrencyCode, setInternalCurrencyCode] = React.useState<
     string | undefined | null
   >(undefined);
@@ -95,15 +96,15 @@ export default function Donate({
         setCurrencyCode(currency);
         try {
           const { p } = router.query;
-          const project = await getRequest<ProjectExtended>({
-            tenant: pageProps.tenantConfig.id,
-            url: encodeURI(`/app/projects/${p}`),
-            queryParams: {
-              _scope: 'extended',
-              currency: currency || '',
-              locale: locale,
-            },
-          });
+          const project = await getApi<ProjectExtended>(
+            encodeURI(`/app/projects/${p}`),
+            {
+              queryParams: {
+                _scope: 'extended',
+                currency: currency || '',
+              },
+            }
+          );
           if (
             project.purpose === 'conservation' ||
             project.purpose === 'trees'

--- a/pages/sites/[slug]/[locale]/projects-archive/index.tsx
+++ b/pages/sites/[slug]/[locale]/projects-archive/index.tsx
@@ -16,7 +16,7 @@ import React from 'react';
 import ProjectsList from '../../../../../src/features/projects/screens/Projects';
 import ProjectsListMeta from '../../../../../src/utils/getMetaTags/ProjectsListMeta';
 import getStoredCurrency from '../../../../../src/utils/countryCurrency/getStoredCurrency';
-import { getRequest } from '../../../../../src/utils/apiRequests/api';
+import { useApi } from '../../../../../src/hooks/useApi';
 import { useProjectProps } from '../../../../../src/features/common/Layout/ProjectPropsContext';
 import Credits from '../../../../../src/features/projectsV2/ProjectsMap/Credits';
 import Filters from '../../../../../src/features/projects/components/projects/Filters';
@@ -60,6 +60,7 @@ export default function Donate({
   const { redirect, setErrors } = React.useContext(ErrorHandlingContext);
   const locale = useLocale();
   const router = useRouter();
+  const { getApi } = useApi();
   const [internalCurrencyCode, setInternalCurrencyCode] = React.useState('');
   const [directGift, setDirectGift] = React.useState<DirectGiftI | null>(null);
   const [showDirectGift, setShowDirectGift] = React.useState(true);
@@ -115,15 +116,11 @@ export default function Donate({
         setCurrencyCode(currency);
         setInternalLanguage(locale);
         try {
-          const projects = await getRequest<MapProject[]>({
-            tenant: pageProps.tenantConfig.id,
-            url: `/app/projects`,
+          const projects = await getApi<MapProject[]>('/app/projects', {
             queryParams: {
               _scope: 'map',
               currency: currency,
-              tenant: pageProps.tenantConfig.id,
               'filter[purpose]': 'trees,conservation',
-              locale: locale,
             },
           });
           setProjects(projects);

--- a/src/features/common/Layout/CurrencyContext.tsx
+++ b/src/features/common/Layout/CurrencyContext.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react';
 
 import { handleError } from '@planet-sdk/common';
 import { createContext, useState, useContext, useEffect } from 'react';
-import { getRequest } from '../../../utils/apiRequests/api';
+import { useApi } from '../../../hooks/useApi';
 import { ErrorHandlingContext } from './ErrorHandlingContext';
 
 type CurrencyList = {
@@ -14,12 +14,11 @@ interface CurrencyContextInterface {
   supportedCurrencies: Set<CurrencyCode> | null;
 }
 
-export const CurrencyContext = createContext<CurrencyContextInterface | null>(
-  null
-);
+const CurrencyContext = createContext<CurrencyContextInterface | null>(null);
 
 export const CurrencyProvider: FC = ({ children }) => {
   const { setErrors } = useContext(ErrorHandlingContext);
+  const { getApi } = useApi();
   const [supportedCurrencies, setSupportedCurrencies] =
     useState<Set<CurrencyCode> | null>(null);
   const [fetchCount, setFetchCount] = useState(0);
@@ -27,9 +26,7 @@ export const CurrencyProvider: FC = ({ children }) => {
 
   const fetchCurrencies = async () => {
     try {
-      const currencyData = await getRequest<CurrencyList>({
-        url: '/app/currencies',
-      });
+      const currencyData = await getApi<CurrencyList>('/app/currencies');
       setFetchCount(fetchCount + 1);
       setSupportedCurrencies(
         new Set(Object.keys(currencyData) as CurrencyCode[])

--- a/src/features/projects/screens/Projects.tsx
+++ b/src/features/projects/screens/Projects.tsx
@@ -24,8 +24,8 @@ import { useApi } from '../../../hooks/useApi';
 
 interface Props {
   projects: MapProject[];
-  showProjects: Boolean;
-  setShowProjects: Function;
+  showProjects: boolean;
+  setShowProjects: SetState<boolean>;
   setsearchedProjects: SetState<MapProject[]>;
 }
 

--- a/src/features/projects/screens/Projects.tsx
+++ b/src/features/projects/screens/Projects.tsx
@@ -17,10 +17,10 @@ import { useDebouncedEffect } from '../../../utils/useDebouncedEffect';
 import Explore from '../components/maps/Explore';
 import { ParamsContext } from '../../common/Layout/QueryParamsContext';
 import { useUserProps } from '../../../../src/features/common/Layout/UserPropsContext';
-import { getRequest } from '../../../utils/apiRequests/api';
 import { ErrorHandlingContext } from '../../common/Layout/ErrorHandlingContext';
 import { handleError } from '@planet-sdk/common';
 import { useTenant } from '../../common/Layout/TenantContext';
+import { useApi } from '../../../hooks/useApi';
 
 interface Props {
   projects: MapProject[];
@@ -44,6 +44,7 @@ function ProjectsList({
   const screenWidth = window.innerWidth;
   const screenHeight = window.innerHeight;
   const isMobile = screenWidth <= 767;
+  const { getApi } = useApi();
   const { embed, showProjectList } = React.useContext(ParamsContext);
   const { isImpersonationModeOn } = useUserProps();
   const isEmbed = embed === 'true';
@@ -175,10 +176,7 @@ function ProjectsList({
   React.useEffect(() => {
     async function setListOrder() {
       try {
-        const res = await getRequest<Tenant>({
-          tenant: tenantConfig.id,
-          url: `/app/tenants/${tenantConfig.id}`,
-        });
+        const res = await getApi<Tenant>(`app/tenants/${tenantConfig.id}`);
         setShouldSortProjectList(res.topProjectsOnly);
       } catch (err) {
         setErrors(handleError(err as APIError));

--- a/src/features/user/Profile/TpoProjects/index.tsx
+++ b/src/features/user/Profile/TpoProjects/index.tsx
@@ -8,10 +8,9 @@ import NotFound from '../../../../../public/assets/images/NotFound';
 import ProjectLoader from '../../../common/ContentLoaders/Projects/ProjectLoader';
 import { useLocale, useTranslations } from 'next-intl';
 import styles from './TpoProjects.module.scss';
-import { getRequest } from '../../../../utils/apiRequests/api';
+import { useApi } from '../../../../hooks/useApi';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
 import { handleError } from '@planet-sdk/common';
-import { useTenant } from '../../../common/Layout/TenantContext';
 
 const ProjectSnippet = dynamic(
   () => import('../../../projectsV2/ProjectSnippet'),
@@ -25,7 +24,7 @@ interface Props {
 }
 
 export default function ProjectsContainer({ profile }: Props) {
-  const { tenantConfig } = useTenant();
+  const { getApi } = useApi();
   const t = useTranslations('Donate');
   const locale = useLocale();
   const [projects, setProjects] = React.useState<MapProject[]>();
@@ -33,13 +32,9 @@ export default function ProjectsContainer({ profile }: Props) {
 
   async function loadProjects() {
     try {
-      const projects = await getRequest<MapProject[]>({
-        tenant: tenantConfig?.id,
-        url: `/app/profiles/${profile.id}/projects`,
-        queryParams: {
-          locale: locale,
-        },
-      });
+      const projects = await getApi<MapProject[]>(
+        `/app/profiles/${profile.id}/projects`
+      );
       setProjects(projects);
     } catch (err) {
       setErrors(handleError(err as APIError));

--- a/src/tenants/salesforce/VTOCampaign2023/components/ProjectGrid.tsx
+++ b/src/tenants/salesforce/VTOCampaign2023/components/ProjectGrid.tsx
@@ -3,30 +3,26 @@ import type { APIError } from '@planet-sdk/common/build/types/errors';
 
 import React, { useEffect, useState } from 'react';
 import { ErrorHandlingContext } from '../../../../features/common/Layout/ErrorHandlingContext';
-import { getRequest } from '../../../../utils/apiRequests/api';
+import { useApi } from '../../../../hooks/useApi';
 import getStoredCurrency from '../../../../utils/countryCurrency/getStoredCurrency';
 import gridStyles from './../styles/Grid.module.scss';
 import styles from './../styles/ProjectGrid.module.scss';
 import ProjectSnippet from '../../../../features/projectsV2/ProjectSnippet';
 import { handleError } from '@planet-sdk/common/build/utils/handleError';
-import { useTenant } from '../../../../features/common/Layout/TenantContext';
 
 export default function ProjectGrid() {
+  const { getApi } = useApi();
   const { setErrors, redirect } = React.useContext(ErrorHandlingContext);
   const [projects, setProjects] = useState<MapProject[] | null>(null);
-  const { tenantConfig } = useTenant();
 
   useEffect(() => {
     async function loadProjects() {
       const currencyCode = getStoredCurrency();
       try {
-        const projects = await getRequest({
-          tenant: tenantConfig.id,
-          url: `/app/projects`,
+        const projects = await getApi('/app/projects', {
           queryParams: {
             _scope: 'map',
             currency: currencyCode,
-            tenant: tenantConfig.id,
             'filter[purpose]': 'trees,conservation',
           },
         });

--- a/src/tenants/salesforce/VTOCampaign2024/components/ProjectGrid.tsx
+++ b/src/tenants/salesforce/VTOCampaign2024/components/ProjectGrid.tsx
@@ -3,30 +3,26 @@ import type { APIError } from '@planet-sdk/common/build/types/errors';
 
 import React, { useEffect, useState } from 'react';
 import { ErrorHandlingContext } from '../../../../features/common/Layout/ErrorHandlingContext';
-import { getRequest } from '../../../../utils/apiRequests/api';
 import getStoredCurrency from '../../../../utils/countryCurrency/getStoredCurrency';
 import gridStyles from './../styles/Grid.module.scss';
 import styles from './../styles/ProjectGrid.module.scss';
 import ProjectSnippet from '../../../../features/projectsV2/ProjectSnippet';
 import { handleError } from '@planet-sdk/common/build/utils/handleError';
-import { useTenant } from '../../../../features/common/Layout/TenantContext';
+import { useApi } from '../../../../hooks/useApi';
 
 export default function ProjectGrid() {
+  const { getApi } = useApi();
   const { setErrors, redirect } = React.useContext(ErrorHandlingContext);
-  const { tenantConfig } = useTenant();
   const [projects, setProjects] = useState<MapProject[] | null>(null);
 
   useEffect(() => {
     async function loadProjects() {
       const currencyCode = getStoredCurrency();
       try {
-        const projects = await getRequest({
-          tenant: tenantConfig.id,
-          url: `/app/projects`,
+        const projects = await getApi('/app/projects', {
           queryParams: {
             _scope: 'map',
             currency: currencyCode,
-            tenant: tenantConfig.id,
             'filter[purpose]': 'trees,conservation',
           },
         });


### PR DESCRIPTION
Replace instances of getRequest with the useApi hook for API calls in multiple components, improving code consistency and maintainability.

### Routes and components updated
1. /projects-archive
2. `ProjectsList` - only affects /projects-archive
3. /projects-archive/:id
4. /all (leaderboard page)
5. /home (homepage for salesforce and certain tenants)
6. `CurrencyContext`- involved on all pages, used while updating country from the footer/dashboard menu
7. `TpoProjects` - affects public profile for a tpo
8. `ProjectGrid` components for salesforce vto campaign pages for 2023 (/vto-fitness-challenge-2023) and 2024(/vto-fitness-challenge-2024).

### Additional Changes
- moves `CurrencyProvider` within `UserProvider` in _app.tsx so that `UserProvider` is available while integrating `useApi` in `CurrencyProvider`