### PR TITLE
Make additional explore layers visible

### DIFF
--- a/src/utils/mapsV2/mapSettings.config.ts
+++ b/src/utils/mapsV2/mapSettings.config.ts
@@ -109,7 +109,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'deforestation',
-      canShow: false,
+      canShow: true,
       isAvailable: null,
       color: '#EB5757',
       additionalInfo: {
@@ -230,7 +230,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'birdDensity',
-      canShow: false,
+      canShow: true,
       isAvailable: null,
       additionalInfo: {
         resolution: '~10km',
@@ -247,7 +247,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'mammalDensity',
-      canShow: false,
+      canShow: true,
       isAvailable: null,
       additionalInfo: {
         resolution: '~10km',
@@ -263,7 +263,7 @@ export const mapSettingsConfig: MapSettingsConfig = {
     },
     {
       key: 'amphibianDensity',
-      canShow: false,
+      canShow: true,
       isAvailable: null,
       additionalInfo: {
         resolution: '~10km',


### PR DESCRIPTION
Enable visibility for the deforestation, bird density, mammal density, and amphibian density layers in the map settings configuration (for MapFeatureExplorer).