### PR TITLE
Correctly initialize TenantProvider to avoid default tenant usage

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -251,7 +251,7 @@ const PlanetWeb = ({
       >
         <CacheProvider value={emotionCache}>
           <ErrorHandlingProvider>
-            <TenantProvider>
+            <TenantProvider initialTenantConfig={pageProps.tenantConfig}>
               <QueryParamsProvider>
                 <div>
                   <div

--- a/src/features/common/Layout/TenantContext.tsx
+++ b/src/features/common/Layout/TenantContext.tsx
@@ -3,7 +3,6 @@ import type { SetState } from '../types/common';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
 import { useContext, createContext, useMemo, useState } from 'react';
-import { defaultTenant } from '../../../../tenant.config';
 
 interface TenantContextInterface {
   tenantConfig: Tenant;
@@ -12,8 +11,15 @@ interface TenantContextInterface {
 
 const TenantContext = createContext<TenantContextInterface | null>(null);
 
-export const TenantProvider: FC = ({ children }) => {
-  const [tenantConfig, setTenantConfig] = useState<Tenant>(defaultTenant);
+interface TenantProviderProps {
+  initialTenantConfig: Tenant;
+}
+
+export const TenantProvider: FC<TenantProviderProps> = ({
+  children,
+  initialTenantConfig,
+}) => {
+  const [tenantConfig, setTenantConfig] = useState<Tenant>(initialTenantConfig);
 
   const value: TenantContextInterface | null = useMemo(
     () => ({


### PR DESCRIPTION
Initialize the TenantProvider with the correct tenant configuration to ensure the appropriate tenant-key header is used in API calls.

To tenant: visit https://planet-app-sf.herokuapp.com/en/home directly (check network tab, correct tenant key should be passed in header). Compare with https://weareams.web.plant-for-the-planet.org/en/home.