### PR TITLE
feat: add expandable truncation on hover for long project name.

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
@@ -164,7 +164,7 @@ const ImageSection = (props: ImageSectionProps) => {
           </div>
         </div>
         <div className={styles.projectName}>
-          {truncateString(projectName, 30)}
+          <div className={styles.collapsibleText}>{projectName}</div>
           {isApproved && (
             <CustomTooltip
               showTooltipPopups={showTooltipPopups}

--- a/src/features/projectsV2/ProjectSnippet/styles/ProjectSnippet.module.scss
+++ b/src/features/projectsV2/ProjectSnippet/styles/ProjectSnippet.module.scss
@@ -304,3 +304,17 @@
     width: 328px;
   }
 }
+
+.collapsibleText {
+  max-width: 250px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: all 0.3s ease;
+  cursor: pointer;
+
+  &:hover {
+    white-space: normal;
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
This PR introduces a UI enhancement to handle long text content gracefully. By default, long text is truncated with an ellipsis, and when the user hovers over it, the full content is revealed in an expanded view.

Before hover :

<img width="267" alt="image" src="https://github.com/user-attachments/assets/3abfdc2e-27bf-4a6b-9350-914d3f5d4fa1" />

After hover :

<img width="274" alt="image" src="https://github.com/user-attachments/assets/7bd1a47e-7389-48ef-a941-268f6a09fff1" />
