### PR TITLE
Disable US planetcash account creation

### DIFF
--- a/src/features/user/PlanetCash/screens/CreateAccount.tsx
+++ b/src/features/user/PlanetCash/screens/CreateAccount.tsx
@@ -11,7 +11,6 @@ import AccountListLoader from '../../../../../public/assets/images/icons/Account
 const initialAllowedCountries: CountryType[] = [
   { code: 'DE', currency: 'EUR' },
   { code: 'ES', currency: 'EUR' },
-  { code: 'US', currency: 'USD' },
 ];
 
 const CreateAccount = (): ReactElement | null => {


### PR DESCRIPTION
Remove the US from the list of allowed countries for planetcash account creation.