### PR TITLE
Enable scroll zoom for the projects map

### DIFF
--- a/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
+++ b/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
@@ -25,13 +25,14 @@ const MobileProjectsLayout: FC<ProjectsLayoutProps> = ({
   setCurrencyCode,
   isMobile,
 }) => {
-  const { embed, showProjectList, showProjectDetails } =
+  const { embed, showProjectList, showProjectDetails, isContextLoaded } =
     useContext(ParamsContext);
+  const isEmbedded = embed === 'true';
   const [selectedMode, setSelectedMode] = useState<ViewMode>('list');
   const { isImpersonationModeOn } = useUserProps();
 
   useEffect(() => {
-    if (embed === 'true') {
+    if (isEmbedded && isContextLoaded) {
       if (page === 'project-details' && showProjectDetails === 'false') {
         setSelectedMode('map');
       }
@@ -39,11 +40,11 @@ const MobileProjectsLayout: FC<ProjectsLayoutProps> = ({
         setSelectedMode('map');
       }
     }
-  }, [page, embed, showProjectDetails, showProjectList]);
+  }, [page, isEmbedded, isContextLoaded, showProjectDetails, showProjectList]);
 
   const mobileLayoutClass = `${styles.mobileProjectsLayout} ${
     selectedMode === 'map' ? styles.mapMode : ''
-  } ${embed === 'true' ? styles.embedModeMobile : ''} ${
+  } ${isEmbedded ? styles.embedModeMobile : ''} ${
     isImpersonationModeOn ? styles.impersonationMobile : ''
   }`;
   return (
@@ -54,7 +55,10 @@ const MobileProjectsLayout: FC<ProjectsLayoutProps> = ({
       selectedMode={selectedMode}
       setSelectedMode={setSelectedMode}
     >
-      <ProjectsMapProvider>
+      <ProjectsMapProvider
+        isEmbedded={isEmbedded}
+        isQueryParamsLoaded={isContextLoaded}
+      >
         <main className={mobileLayoutClass}>
           {selectedMode === 'map' ? (
             <section className={styles.mobileMapContainer}>

--- a/src/features/common/Layout/ProjectsLayout/index.tsx
+++ b/src/features/common/Layout/ProjectsLayout/index.tsx
@@ -84,13 +84,19 @@ const ProjectsLayout: FC<ProjectsLayoutProps> = ({
   setCurrencyCode,
   page,
 }) => {
+  const { embed, isContextLoaded } = useContext(ParamsContext);
+  const isEmbedded = embed === 'true';
+
   return (
     <ProjectsProvider
       page={page}
       currencyCode={currencyCode}
       setCurrencyCode={setCurrencyCode}
     >
-      <ProjectsMapProvider>
+      <ProjectsMapProvider
+        isEmbedded={isEmbedded}
+        isQueryParamsLoaded={isContextLoaded}
+      >
         <ProjectsLayoutContent setCurrencyCode={setCurrencyCode} page={page}>
           {children}
         </ProjectsLayoutContent>

--- a/src/features/projectsV2/ProjectsMapContext.tsx
+++ b/src/features/projectsV2/ProjectsMapContext.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactNode } from 'react';
 import type { ViewState } from 'react-map-gl-v7';
 import type { MapStyle } from 'react-map-gl-v7/maplibre';
 import type { SetState } from '../common/types/common';
@@ -107,7 +107,18 @@ interface ProjectsMapState {
 }
 
 const ProjectsMapContext = createContext<ProjectsMapState | null>(null);
-export const ProjectsMapProvider: FC = ({ children }) => {
+
+interface ProjectsMapProviderProps {
+  children: ReactNode;
+  isEmbedded?: boolean;
+  isQueryParamsLoaded?: boolean;
+}
+
+export const ProjectsMapProvider: FC<ProjectsMapProviderProps> = ({
+  children,
+  isEmbedded = false,
+  isQueryParamsLoaded = false,
+}) => {
   const [mapState, setMapState] = useState<MapState>(DEFAULT_MAP_STATE);
   const [viewState, setViewState] = useState<ViewState>(DEFAULT_VIEW_STATE);
   const [isSatelliteView, setIsSatelliteView] = useState(false);
@@ -119,6 +130,16 @@ export const ProjectsMapProvider: FC = ({ children }) => {
   const [exploreLayersData, setExploreLayersData] =
     useState<ExploreLayersData | null>(null);
   const [isExploreMode, setIsExploreMode] = useState(false);
+
+  // Update mapState when embed status changes, but only after query params are loaded
+  useEffect(() => {
+    if (isQueryParamsLoaded) {
+      setMapState((prevState) => ({
+        ...prevState,
+        scrollZoom: !isEmbedded,
+      }));
+    }
+  }, [isEmbedded, isQueryParamsLoaded]);
 
   // Set isExploreMode to true if mapOptions has keys other than 'projects' set to true
   useEffect(() => {

--- a/src/features/projectsV2/ProjectsMapContext.tsx
+++ b/src/features/projectsV2/ProjectsMapContext.tsx
@@ -42,7 +42,7 @@ export const DEFAULT_VIEW_STATE: ExtendedViewState = {
 const DEFAULT_MAP_STATE: MapState = {
   mapStyle: EMPTY_STYLE,
   dragPan: true,
-  scrollZoom: false,
+  scrollZoom: true,
   minZoom: 1,
   maxZoom: 20,
 };


### PR DESCRIPTION
1. Activate scroll zoom functionality on the projects map (main map - seen on project list and details pages) to enhance user interaction.
2. Disables scroll zoom functionality in embed mode - i.e. when `embed=true` is passed as a url query parameter. This avoids scrolling issues on a page where the map is embedded. Otherwise, the user may get stuck while scrolling the page when the cursor is positioned over the embedded map.