### PR TITLE
Hotfix/address action clean up

### DIFF
--- a/src/features/user/Settings/EditProfile/AddressManagement/AddAddress.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/AddAddress.tsx
@@ -1,19 +1,14 @@
 import type { ExtendedCountryCode } from '../../../../common/types/country';
-import type { SetState } from '../../../../common/types/common';
-import type { Address, APIError } from '@planet-sdk/common';
-import type { AddressAction } from '../../../../common/types/profile';
 import type { AddressFormData } from './microComponents/AddressForm';
 
-import { useState, useContext, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
-import { handleError } from '@planet-sdk/common';
 import { useUserProps } from '../../../../common/Layout/UserPropsContext';
-import { ErrorHandlingContext } from '../../../../common/Layout/ErrorHandlingContext';
 import AddressForm from './microComponents/AddressForm';
 import { ADDRESS_TYPE } from '../../../../../utils/addressManagement';
 import AddressFormLayout from './microComponents/AddressFormLayout';
 import { getStoredConfig } from '../../../../../utils/storeConfig';
-import { useApi } from '../../../../../hooks/useApi';
+import { useAddressOperations } from './useAddressOperations';
 
 export type AddAddressApiPayload = AddressFormData & {
   country: ExtendedCountryCode | string;
@@ -21,8 +16,7 @@ export type AddAddressApiPayload = AddressFormData & {
 };
 
 interface Props {
-  setIsModalOpen: SetState<boolean>;
-  setAddressAction: SetState<AddressAction | null>;
+  handleCancel: () => void;
   showPrimaryAddressToggle: boolean;
 }
 
@@ -35,78 +29,28 @@ const defaultAddressDetail = {
   type: ADDRESS_TYPE.OTHER,
 };
 
-const AddAddress = ({
-  setIsModalOpen,
-  setAddressAction,
-  showPrimaryAddressToggle,
-}: Props) => {
+const AddAddress = ({ handleCancel, showPrimaryAddressToggle }: Props) => {
   const tAddressManagement = useTranslations('EditProfile.addressManagement');
-  const { contextLoaded, user, token, logoutUser, setUser } = useUserProps();
+  const { user } = useUserProps();
+  const { addAddress, isLoading } = useAddressOperations();
   const configCountry = getStoredConfig('country');
   const defaultCountry = user?.country || configCountry || 'DE';
-  const { setErrors } = useContext(ErrorHandlingContext);
-  const { postApiAuthenticated } = useApi();
   const [country, setCountry] = useState<ExtendedCountryCode | ''>(
     defaultCountry
   );
-  const [isLoading, setIsLoading] = useState(false);
+
   const [primaryAddressChecked, setPrimaryAddressChecked] = useState(false);
 
-  const addAddress = useCallback(
+  const handleAdd = useCallback(
     async (data: AddressFormData) => {
-      if (!contextLoaded || !user || !token) return;
-      setIsLoading(true);
       const payload: AddAddressApiPayload = {
         ...data,
         country,
         type: primaryAddressChecked ? ADDRESS_TYPE.PRIMARY : ADDRESS_TYPE.OTHER,
       };
-      try {
-        const res = await postApiAuthenticated<Address, AddAddressApiPayload>(
-          '/app/addresses',
-          {
-            payload,
-          }
-        );
-        if (res) {
-          setUser((prev) => {
-            if (!prev) return null;
-
-            const updatedAddresses =
-              res.type === ADDRESS_TYPE.PRIMARY
-                ? prev.addresses.map((addr) =>
-                    addr.type === ADDRESS_TYPE.PRIMARY
-                      ? { ...addr, type: ADDRESS_TYPE.OTHER }
-                      : addr
-                  )
-                : prev.addresses;
-
-            return {
-              ...prev,
-              addresses: [...updatedAddresses, res],
-            };
-          });
-        }
-      } catch (error) {
-        setErrors(handleError(error as APIError));
-      } finally {
-        setIsLoading(false);
-        setIsModalOpen(false);
-        setAddressAction(null);
-      }
+      await addAddress(payload).finally(handleCancel);
     },
-    [
-      contextLoaded,
-      user,
-      token,
-      country,
-      logoutUser,
-      handleError,
-      setIsLoading,
-      setIsModalOpen,
-      postApiAuthenticated,
-      primaryAddressChecked,
-    ]
+    [country, primaryAddressChecked, addAddress]
   );
 
   return (
@@ -114,15 +58,14 @@ const AddAddress = ({
       <AddressForm
         country={country}
         setCountry={setCountry}
-        setIsModalOpen={setIsModalOpen}
         isLoading={isLoading}
         label={tAddressManagement('addressForm.addAddress')}
         defaultAddressDetail={defaultAddressDetail}
-        processFormData={addAddress}
-        setAddressAction={setAddressAction}
+        processFormData={handleAdd}
         showPrimaryAddressToggle={showPrimaryAddressToggle}
         primaryAddressChecked={primaryAddressChecked}
         setPrimaryAddressChecked={setPrimaryAddressChecked}
+        handleCancel={handleCancel}
       />
     </AddressFormLayout>
   );

--- a/src/features/user/Settings/EditProfile/AddressManagement/DeleteAddress.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/DeleteAddress.tsx
@@ -1,67 +1,21 @@
-import type { SetState } from '../../../../common/types/common';
-import type { APIError } from '@planet-sdk/common';
-import type { AddressAction } from '../../../../common/types/profile';
-
-import { useContext, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { handleError } from '@planet-sdk/common';
 import { CircularProgress } from '@mui/material';
-import { ErrorHandlingContext } from '../../../../common/Layout/ErrorHandlingContext';
-import { useUserProps } from '../../../../common/Layout/UserPropsContext';
 import WebappButton from '../../../../common/WebappButton';
 import styles from './AddressManagement.module.scss';
-import { useApi } from '../../../../../hooks/useApi';
+import { useAddressOperations } from './useAddressOperations';
 
 interface Props {
-  setIsModalOpen: SetState<boolean>;
   addressId: string;
-  setAddressAction: SetState<AddressAction | null>;
+  handleCancel: () => void;
 }
 
-const DeleteAddress = ({
-  setIsModalOpen,
-  addressId,
-  setAddressAction,
-}: Props) => {
+const DeleteAddress = ({ addressId, handleCancel }: Props) => {
   const tAddressManagement = useTranslations('EditProfile.addressManagement');
   const tCommon = useTranslations('Common');
-  const { contextLoaded, user, token, setUser } = useUserProps();
+  const { deleteAddress, isLoading } = useAddressOperations();
 
-  const { setErrors } = useContext(ErrorHandlingContext);
-  const { deleteApiAuthenticated } = useApi();
-  const [isLoading, setIsLoading] = useState(false);
+  const handleDelete = () => deleteAddress(addressId).finally(handleCancel);
 
-  const deleteAddress = async () => {
-    if (!contextLoaded || !user || !token) return;
-    try {
-      setIsLoading(true);
-
-      await deleteApiAuthenticated(`/app/addresses/${addressId}`);
-
-      setUser((prev) => {
-        if (!prev) return null;
-
-        const updatedAddresses = prev.addresses.filter(
-          (address) => address.id !== addressId
-        );
-
-        return {
-          ...prev,
-          addresses: updatedAddresses,
-        };
-      });
-    } catch (error) {
-      setErrors(handleError(error as APIError));
-    } finally {
-      setIsModalOpen(false);
-      setIsLoading(false);
-      setAddressAction(null);
-    }
-  };
-  const handleCancel = () => {
-    setIsModalOpen(false);
-    setAddressAction(null);
-  };
   return (
     <div className={styles.addressActionContainer}>
       <h2 className={styles.header}>
@@ -82,7 +36,7 @@ const DeleteAddress = ({
             text={tAddressManagement('deleteAction.deleteButton')}
             elementType="button"
             variant="primary"
-            onClick={deleteAddress}
+            onClick={handleDelete}
           />
         </div>
       ) : (

--- a/src/features/user/Settings/EditProfile/AddressManagement/EditAddress.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/EditAddress.tsx
@@ -1,6 +1,7 @@
+import type { Address } from '@planet-sdk/common';
 import type { ExtendedCountryCode } from '../../../../common/types/country';
-import type { Address, AddressType } from '@planet-sdk/common';
 import type { AddressFormData } from './microComponents/AddressForm';
+import type { EditAddressApiPayload } from './useAddressOperations';
 
 import { useState, useCallback, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
@@ -14,11 +15,6 @@ interface Props {
   showPrimaryAddressToggle: boolean;
   handleCancel: () => void;
 }
-
-export type EditAddressApiPayload = AddressFormData & {
-  country: ExtendedCountryCode | string;
-  type: AddressType;
-};
 
 const EditAddress = ({
   selectedAddressForAction,

--- a/src/features/user/Settings/EditProfile/AddressManagement/EditAddress.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/EditAddress.tsx
@@ -48,19 +48,28 @@ const EditAddress = ({
       );
   }, [selectedAddressForAction]);
 
-  const handleEdit = useCallback(async (data: AddressFormData) => {
-    const payload: EditAddressApiPayload = {
-      ...data,
-      country,
-      type: primaryAddressChecked
-        ? ADDRESS_TYPE.PRIMARY
-        : selectedAddressForAction.type,
-    };
+  const handleEdit = useCallback(
+    async (data: AddressFormData) => {
+      const payload: EditAddressApiPayload = {
+        ...data,
+        country,
+        type: primaryAddressChecked
+          ? ADDRESS_TYPE.PRIMARY
+          : selectedAddressForAction.type,
+      };
 
-    await editAddress(selectedAddressForAction.id, payload).finally(
-      handleCancel
-    );
-  }, []);
+      await editAddress(selectedAddressForAction.id, payload).finally(
+        handleCancel
+      );
+    },
+    [
+      country,
+      primaryAddressChecked,
+      selectedAddressForAction,
+      editAddress,
+      handleCancel,
+    ]
+  );
 
   return (
     <AddressFormLayout label={tAddressManagement('addressForm.editAddress')}>

--- a/src/features/user/Settings/EditProfile/AddressManagement/EditAddress.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/EditAddress.tsx
@@ -1,37 +1,29 @@
 import type { ExtendedCountryCode } from '../../../../common/types/country';
-import type { SetState } from '../../../../common/types/common';
-import type { Address, AddressType, APIError } from '@planet-sdk/common';
+import type { Address, AddressType } from '@planet-sdk/common';
 import type { AddressFormData } from './microComponents/AddressForm';
-import type { AddressAction } from '../../../../common/types/profile';
 
-import { useState, useContext, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
-import { handleError } from '@planet-sdk/common';
-import { useUserProps } from '../../../../common/Layout/UserPropsContext';
-import { useTenant } from '../../../../common/Layout/TenantContext';
-import { ErrorHandlingContext } from '../../../../common/Layout/ErrorHandlingContext';
 import AddressForm from './microComponents/AddressForm';
 import AddressFormLayout from './microComponents/AddressFormLayout';
 import { ADDRESS_TYPE } from '../../../../../utils/addressManagement';
-import { useApi } from '../../../../../hooks/useApi';
+import { useAddressOperations } from './useAddressOperations';
 
 interface Props {
-  setIsModalOpen: SetState<boolean>;
   selectedAddressForAction: Address;
-  setAddressAction: SetState<AddressAction | null>;
   showPrimaryAddressToggle: boolean;
+  handleCancel: () => void;
 }
 
-type EditAddressApiPayload = AddressFormData & {
+export type EditAddressApiPayload = AddressFormData & {
   country: ExtendedCountryCode | string;
   type: AddressType;
 };
 
 const EditAddress = ({
-  setIsModalOpen,
   selectedAddressForAction,
-  setAddressAction,
   showPrimaryAddressToggle,
+  handleCancel,
 }: Props) => {
   const defaultAddressDetail = {
     address: selectedAddressForAction.address,
@@ -43,14 +35,10 @@ const EditAddress = ({
   };
 
   const tAddressManagement = useTranslations('EditProfile.addressManagement');
-  const { contextLoaded, user, token, logoutUser, setUser } = useUserProps();
-  const { tenantConfig } = useTenant();
-  const { setErrors } = useContext(ErrorHandlingContext);
-  const { putApiAuthenticated } = useApi();
+  const { editAddress, isLoading } = useAddressOperations();
   const [country, setCountry] = useState<ExtendedCountryCode | ''>(
-    selectedAddressForAction?.country ?? 'DE'
+    selectedAddressForAction.country ?? 'DE'
   );
-  const [isLoading, setIsLoading] = useState(false);
   const [primaryAddressChecked, setPrimaryAddressChecked] = useState(false);
 
   useEffect(() => {
@@ -60,92 +48,33 @@ const EditAddress = ({
       );
   }, [selectedAddressForAction]);
 
-  const updateAddress = useCallback(
-    async (data: AddressFormData) => {
-      if (!contextLoaded || !user || !token) return;
-      setIsLoading(true);
-      const payload: EditAddressApiPayload = {
-        ...data,
-        country,
-        type: primaryAddressChecked
-          ? ADDRESS_TYPE.PRIMARY
-          : selectedAddressForAction?.type,
-      };
-      try {
-        const res = await putApiAuthenticated<Address, EditAddressApiPayload>(
-          `/app/addresses/${selectedAddressForAction?.id}`,
-          {
-            payload,
-          }
-        );
-        if (res) {
-          setUser((prev) => {
-            if (!prev) return null;
-
-            const updatedAddresses = prev.addresses.reduce<Address[]>(
-              (acc, addr) => {
-                if (addr.id === res.id) return acc;
-
-                if (res.isPrimary && addr.isPrimary) {
-                  acc.push({
-                    ...addr,
-                    isPrimary: false,
-                    type: ADDRESS_TYPE.OTHER,
-                  });
-                } else {
-                  acc.push(addr);
-                }
-
-                return acc;
-              },
-              []
-            );
-
-            updatedAddresses.push(res);
-
-            return {
-              ...prev,
-              addresses: updatedAddresses,
-            };
-          });
-        }
-      } catch (error) {
-        setErrors(handleError(error as APIError));
-      } finally {
-        setIsLoading(false);
-        setIsModalOpen(false);
-        setAddressAction(null);
-      }
-    },
-    [
-      contextLoaded,
-      user,
-      token,
+  const handleEdit = useCallback(async (data: AddressFormData) => {
+    const payload: EditAddressApiPayload = {
+      ...data,
       country,
-      selectedAddressForAction?.type,
-      selectedAddressForAction?.id,
-      tenantConfig.id,
-      logoutUser,
-      handleError,
-      putApiAuthenticated,
-      primaryAddressChecked,
-    ]
-  );
+      type: primaryAddressChecked
+        ? ADDRESS_TYPE.PRIMARY
+        : selectedAddressForAction.type,
+    };
+
+    await editAddress(selectedAddressForAction.id, payload).finally(
+      handleCancel
+    );
+  }, []);
 
   return (
     <AddressFormLayout label={tAddressManagement('addressForm.editAddress')}>
       <AddressForm
         country={country}
         setCountry={setCountry}
-        setIsModalOpen={setIsModalOpen}
         isLoading={isLoading}
         label={tAddressManagement('addressForm.saveChanges')}
         defaultAddressDetail={defaultAddressDetail}
-        processFormData={updateAddress}
-        setAddressAction={setAddressAction}
+        processFormData={handleEdit}
         showPrimaryAddressToggle={showPrimaryAddressToggle}
         primaryAddressChecked={primaryAddressChecked}
         setPrimaryAddressChecked={setPrimaryAddressChecked}
+        handleCancel={handleCancel}
       />
     </AddressFormLayout>
   );

--- a/src/features/user/Settings/EditProfile/AddressManagement/UnsetBillingAddress.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/UnsetBillingAddress.tsx
@@ -12,10 +12,6 @@ interface Props {
   handleCancel: () => void;
 }
 
-export type UnsetBillingAddressApiPayload = {
-  type: 'other';
-};
-
 const UnsetBillingAddress = ({
   addressType,
   selectedAddressForAction,

--- a/src/features/user/Settings/EditProfile/AddressManagement/UpdateAddressType.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/UpdateAddressType.tsx
@@ -1,93 +1,35 @@
-import type { SetState } from '../../../../common/types/common';
-import type { APIError, Address } from '@planet-sdk/common';
-import type { AddressAction } from '../../../../common/types/profile';
+import type { Address } from '@planet-sdk/common';
 
-import { useContext, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { handleError } from '@planet-sdk/common';
 import { CircularProgress } from '@mui/material';
 import styles from './AddressManagement.module.scss';
 import WebappButton from '../../../../common/WebappButton';
-import { useUserProps } from '../../../../common/Layout/UserPropsContext';
-import { ErrorHandlingContext } from '../../../../common/Layout/ErrorHandlingContext';
 import FormattedAddressBlock from './microComponents/FormattedAddressBlock';
-import { ADDRESS_TYPE } from '../../../../../utils/addressManagement';
-import { useApi } from '../../../../../hooks/useApi';
+import { useAddressOperations } from './useAddressOperations';
 
 type AddressType = 'primary' | 'mailing';
 interface Props {
   addressType: AddressType;
-  setIsModalOpen: SetState<boolean>;
   userAddress: Address | undefined;
   selectedAddressForAction: Address;
-  setAddressAction: SetState<AddressAction | null>;
+  handleCancel: () => void;
 }
-
-type AddressTypeApiPayload = {
-  type: AddressType;
-};
 
 const UpdateAddressType = ({
   addressType,
-  setIsModalOpen,
   userAddress,
   selectedAddressForAction,
-  setAddressAction,
+  handleCancel,
 }: Props) => {
   const tAddressManagement = useTranslations('EditProfile.addressManagement');
   const tCommon = useTranslations('Common');
-  const { contextLoaded, user, token, setUser } = useUserProps();
-  const { putApiAuthenticated } = useApi();
-  const { setErrors } = useContext(ErrorHandlingContext);
-  const [isUploadingData, setIsUploadingData] = useState(false);
+  const { updateAddressType, isLoading } = useAddressOperations();
 
-  const updateAddress = async (addressType: AddressType) => {
-    if (!contextLoaded || !user || !token) return;
-    setIsUploadingData(true);
-    const payload: AddressTypeApiPayload = {
-      type: addressType,
-    };
-    try {
-      const res = await putApiAuthenticated<Address, AddressTypeApiPayload>(
-        `/app/addresses/${selectedAddressForAction.id}`,
-        {
-          payload,
-        }
-      );
-      if (res) {
-        setUser((prev) => {
-          if (!prev) return null;
+  const handleAddressType = () =>
+    updateAddressType(selectedAddressForAction.id, addressType).finally(
+      handleCancel
+    );
 
-          const updatedAddresses = prev.addresses.map((addr) => {
-            if (addr.id === selectedAddressForAction.id)
-              return { ...addr, type: addressType };
-
-            if (addr.type === addressType)
-              return {
-                ...addr,
-                type: ADDRESS_TYPE.OTHER,
-              };
-
-            return addr;
-          });
-          return {
-            ...prev,
-            addresses: updatedAddresses,
-          };
-        });
-      }
-    } catch (error) {
-      setErrors(handleError(error as APIError));
-    } finally {
-      setIsUploadingData(false);
-      setIsModalOpen(false);
-      setAddressAction(null);
-    }
-  };
-  const handleCancel = () => {
-    setIsModalOpen(false);
-    setAddressAction(null);
-  };
   return (
     <div className={styles.addressActionContainer}>
       <h2 className={styles.header}>
@@ -107,7 +49,7 @@ const UpdateAddressType = ({
           <FormattedAddressBlock userAddress={userAddress} />
         </div>
       )}
-      {!isUploadingData ? (
+      {!isLoading ? (
         <div className={styles.buttonContainer}>
           <WebappButton
             text={tCommon('cancel')}
@@ -119,7 +61,7 @@ const UpdateAddressType = ({
             text={tAddressManagement('updateAddressType.confirmButton')}
             elementType="button"
             variant="primary"
-            onClick={() => updateAddress(addressType)}
+            onClick={handleAddressType}
           />
         </div>
       ) : (

--- a/src/features/user/Settings/EditProfile/AddressManagement/index.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/index.tsx
@@ -24,6 +24,8 @@ import UnsetBillingAddress from './UnsetBillingAddress';
 
 const AddressManagement = () => {
   const { user } = useUserProps();
+  // If addresses is null (not an empty array), it indicates a malformed API response
+  // Normal users without addresses will have an empty array, not null
   if (!user?.addresses) return null;
   const userAddresses = user.addresses;
   const tAddressManagement = useTranslations('EditProfile.addressManagement');

--- a/src/features/user/Settings/EditProfile/AddressManagement/index.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/index.tsx
@@ -56,24 +56,27 @@ const AddressManagement = () => {
     [userAddresses]
   );
 
+  const handleCancel = () => {
+    setIsModalOpen(false);
+    setAddressAction(null);
+  };
+
   const renderModalContent = useMemo(() => {
     switch (addressAction) {
       case ADDRESS_ACTIONS.ADD:
         return (
           <AddAddress
-            setIsModalOpen={setIsModalOpen}
-            setAddressAction={setAddressAction}
             showPrimaryAddressToggle={false}
+            handleCancel={handleCancel}
           />
         );
       case ADDRESS_ACTIONS.EDIT:
         if (!selectedAddressForAction) return <></>;
         return (
           <EditAddress
-            setIsModalOpen={setIsModalOpen}
             selectedAddressForAction={selectedAddressForAction}
-            setAddressAction={setAddressAction}
             showPrimaryAddressToggle={false}
+            handleCancel={handleCancel}
           />
         );
       case ADDRESS_ACTIONS.DELETE:
@@ -81,8 +84,7 @@ const AddressManagement = () => {
         return (
           <DeleteAddress
             addressId={selectedAddressForAction.id}
-            setIsModalOpen={setIsModalOpen}
-            setAddressAction={setAddressAction}
+            handleCancel={handleCancel}
           />
         );
       case ADDRESS_ACTIONS.SET_PRIMARY:
@@ -91,9 +93,8 @@ const AddressManagement = () => {
           <UpdateAddressType
             addressType={ADDRESS_TYPE.PRIMARY}
             userAddress={primaryAddress}
-            setAddressAction={setAddressAction}
-            setIsModalOpen={setIsModalOpen}
             selectedAddressForAction={selectedAddressForAction}
+            handleCancel={handleCancel}
           />
         );
       case ADDRESS_ACTIONS.SET_BILLING:
@@ -102,9 +103,8 @@ const AddressManagement = () => {
           <UpdateAddressType
             addressType={ADDRESS_TYPE.MAILING}
             userAddress={billingAddress}
-            setAddressAction={setAddressAction}
-            setIsModalOpen={setIsModalOpen}
             selectedAddressForAction={selectedAddressForAction}
+            handleCancel={handleCancel}
           />
         );
       case ADDRESS_ACTIONS.UNSET_BILLING:
@@ -112,9 +112,8 @@ const AddressManagement = () => {
         return (
           <UnsetBillingAddress
             addressType={ADDRESS_TYPE.MAILING}
-            setIsModalOpen={setIsModalOpen}
-            setAddressAction={setAddressAction}
             selectedAddressForAction={selectedAddressForAction}
+            handleCancel={handleCancel}
           />
         );
       default:

--- a/src/features/user/Settings/EditProfile/AddressManagement/index.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/index.tsx
@@ -1,7 +1,7 @@
 import type { Address } from '@planet-sdk/common';
 import type { AddressAction } from '../../../../common/types/profile';
 
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Modal } from '@mui/material';
 import AddressList from './microComponents/AddressList';
@@ -56,10 +56,10 @@ const AddressManagement = () => {
     [userAddresses]
   );
 
-  const handleCancel = () => {
+  const handleCancel = useCallback(() => {
     setIsModalOpen(false);
     setAddressAction(null);
-  };
+  }, [setIsModalOpen, setAddressAction]);
 
   const renderModalContent = useMemo(() => {
     switch (addressAction) {

--- a/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressForm.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressForm.tsx
@@ -2,7 +2,6 @@ import type { AddressSuggestionsType } from '../../../../../common/types/geocode
 import type { ExtendedCountryCode } from '../../../../../common/types/country';
 import type { SetState } from '../../../../../common/types/common';
 import type { Nullable } from '@planet-sdk/common/build/types/util';
-import type { AddressAction } from '../../../../../common/types/profile';
 import type { AddressType } from '@planet-sdk/common';
 
 import { useCallback, useMemo, useState } from 'react';
@@ -40,23 +39,21 @@ interface Props {
   label: string;
   processFormData: (data: AddressFormData) => Promise<void>;
   defaultAddressDetail: AddressFormData & { type: AddressType };
-  setIsModalOpen: SetState<boolean>;
   isLoading: boolean;
-  setAddressAction: SetState<AddressAction | null>;
   showPrimaryAddressToggle: boolean;
   primaryAddressChecked: boolean;
   setPrimaryAddressChecked: SetState<boolean>;
+  handleCancel: () => void;
 }
 
 const AddressForm = ({
   country,
   setCountry,
   defaultAddressDetail,
-  setIsModalOpen,
+  handleCancel,
   label,
   processFormData,
   isLoading,
-  setAddressAction,
   showPrimaryAddressToggle,
   primaryAddressChecked,
   setPrimaryAddressChecked,
@@ -128,11 +125,7 @@ const AddressForm = ({
     reset(defaultAddressDetail);
     setAddressSuggestions([]);
   };
-  const handleCancel = () => {
-    setIsModalOpen(false);
-    setAddressAction(null);
-    resetForm();
-  };
+
   return (
     <form className={styles.addressForm}>
       <AddressInput
@@ -253,7 +246,10 @@ const AddressForm = ({
         <AddressFormButtons
           text={label}
           handleSubmit={handleSubmit(processFormData)}
-          handleCancel={handleCancel}
+          handleCancel={() => {
+            handleCancel();
+            resetForm();
+          }}
         />
       )}
     </form>

--- a/src/features/user/Settings/EditProfile/AddressManagement/useAddressOperations.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/useAddressOperations.tsx
@@ -1,0 +1,131 @@
+import type { ExtendedCountryCode } from '../../../../common/types/country';
+import type { AddressFormData } from './microComponents/AddressForm';
+import type { AddressType, Address, APIError } from '@planet-sdk/common';
+
+import { useContext, useState } from 'react';
+import { useUserProps } from '../../../../common/Layout/UserPropsContext';
+import { useApi } from '../../../../../hooks/useApi';
+import { ErrorHandlingContext } from '../../../../common/Layout/ErrorHandlingContext';
+import { handleError } from '@planet-sdk/common';
+import {
+  updateAddressesAfterAdd,
+  updateAddressesAfterEdit,
+  updateAddressesAfterTypeChange,
+} from './utils';
+
+export type UnsetBillingAddressApiPayload = {
+  type: 'other';
+};
+
+export type EditAddressApiPayload = AddressFormData & {
+  country: ExtendedCountryCode | string;
+  type: AddressType;
+};
+
+export type AddAddressApiPayload = AddressFormData & {
+  country: ExtendedCountryCode | string;
+  type: 'other' | 'primary';
+};
+
+type AddressTypeApiPayload = {
+  type: AddressType;
+};
+
+export const useAddressOperations = () => {
+  const { contextLoaded, user, token, setUser } = useUserProps();
+  const { postApiAuthenticated, putApiAuthenticated, deleteApiAuthenticated } =
+    useApi();
+  const { setErrors } = useContext(ErrorHandlingContext);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const safeExecute = async (operation: () => Promise<void>) => {
+    if (!contextLoaded || !user || !token) return;
+    setIsLoading(true);
+    try {
+      await operation();
+    } catch (error) {
+      setErrors(handleError(error as APIError));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const addAddress = async (payload: AddAddressApiPayload) => {
+    await safeExecute(async () => {
+      const res = await postApiAuthenticated<Address, AddAddressApiPayload>(
+        '/app/addresses',
+        { payload }
+      );
+      if (res) setUser((prev) => updateAddressesAfterAdd(prev, res));
+    });
+  };
+
+  const editAddress = async (id: string, payload: EditAddressApiPayload) => {
+    await safeExecute(async () => {
+      const res = await putApiAuthenticated<Address, EditAddressApiPayload>(
+        `/app/addresses/${id}`,
+        { payload }
+      );
+      if (res) setUser((prev) => updateAddressesAfterEdit(prev, res));
+    });
+  };
+
+  const updateAddressType = async (id: string, addressType: AddressType) => {
+    await safeExecute(async () => {
+      const payload: AddressTypeApiPayload = { type: addressType };
+      const res = await putApiAuthenticated<Address, AddressTypeApiPayload>(
+        `/app/addresses/${id}`,
+        { payload }
+      );
+      if (res)
+        setUser((prev) =>
+          updateAddressesAfterTypeChange(prev, res, addressType)
+        );
+    });
+  };
+
+  const unsetBillingAddress = async (id: string) => {
+    await safeExecute(async () => {
+      const payload: UnsetBillingAddressApiPayload = { type: 'other' };
+      const res = await putApiAuthenticated<
+        Address,
+        UnsetBillingAddressApiPayload
+      >(`/app/addresses/${id}`, { payload });
+      if (res) {
+        setUser((prev) =>
+          prev
+            ? {
+                ...prev,
+                addresses: prev.addresses.map((addr) =>
+                  addr.id === id ? { ...addr, type: 'other' } : addr
+                ),
+              }
+            : null
+        );
+      }
+    });
+  };
+
+  const deleteAddress = async (id: string) => {
+    await safeExecute(async () => {
+      await deleteApiAuthenticated(`/app/addresses/${id}`);
+      setUser((prev) =>
+        prev
+          ? {
+              ...prev,
+              addresses: prev.addresses.filter((addr) => addr.id !== id),
+            }
+          : null
+      );
+    });
+  };
+
+  return {
+    isLoading,
+    addAddress,
+    editAddress,
+    deleteAddress,
+    updateAddressType,
+    unsetBillingAddress,
+  };
+};

--- a/src/features/user/Settings/EditProfile/AddressManagement/useAddressOperations.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/useAddressOperations.tsx
@@ -52,34 +52,44 @@ export const useAddressOperations = () => {
 
   const addAddress = async (payload: AddAddressApiPayload) => {
     await safeExecute(async () => {
-      const res = await postApiAuthenticated<Address, AddAddressApiPayload>(
-        '/app/addresses',
-        { payload }
-      );
-      if (res) setUser((prev) => updateAddressesAfterAdd(prev, res));
+      const addAddressResponse = await postApiAuthenticated<
+        Address,
+        AddAddressApiPayload
+      >('/app/addresses', { payload });
+      if (addAddressResponse)
+        setUser((existingUserDetails) =>
+          updateAddressesAfterAdd(existingUserDetails, addAddressResponse)
+        );
     });
   };
 
   const editAddress = async (id: string, payload: EditAddressApiPayload) => {
     await safeExecute(async () => {
-      const res = await putApiAuthenticated<Address, EditAddressApiPayload>(
-        `/app/addresses/${id}`,
-        { payload }
-      );
-      if (res) setUser((prev) => updateAddressesAfterEdit(prev, res));
+      const editAddressResponse = await putApiAuthenticated<
+        Address,
+        EditAddressApiPayload
+      >(`/app/addresses/${id}`, { payload });
+      if (editAddressResponse)
+        setUser((existingUserDetails) =>
+          updateAddressesAfterEdit(existingUserDetails, editAddressResponse)
+        );
     });
   };
 
   const updateAddressType = async (id: string, addressType: AddressType) => {
     await safeExecute(async () => {
       const payload: AddressTypeApiPayload = { type: addressType };
-      const res = await putApiAuthenticated<Address, AddressTypeApiPayload>(
-        `/app/addresses/${id}`,
-        { payload }
-      );
-      if (res)
-        setUser((prev) =>
-          updateAddressesAfterTypeChange(prev, res, addressType)
+      const updateAddressResponse = await putApiAuthenticated<
+        Address,
+        AddressTypeApiPayload
+      >(`/app/addresses/${id}`, { payload });
+      if (updateAddressResponse)
+        setUser((existingUserDetails) =>
+          updateAddressesAfterTypeChange(
+            existingUserDetails,
+            updateAddressResponse,
+            addressType
+          )
         );
     });
   };
@@ -87,17 +97,17 @@ export const useAddressOperations = () => {
   const unsetBillingAddress = async (id: string) => {
     await safeExecute(async () => {
       const payload: UnsetBillingAddressApiPayload = { type: 'other' };
-      const res = await putApiAuthenticated<
+      const updateAddressResponse = await putApiAuthenticated<
         Address,
         UnsetBillingAddressApiPayload
       >(`/app/addresses/${id}`, { payload });
-      if (res) {
-        setUser((prev) =>
-          prev
+      if (updateAddressResponse) {
+        setUser((existingUserDetails) =>
+          existingUserDetails
             ? {
-                ...prev,
-                addresses: prev.addresses.map((addr) =>
-                  addr.id === id ? { ...addr, type: 'other' } : addr
+                ...existingUserDetails,
+                addresses: existingUserDetails.addresses.map((address) =>
+                  address.id === id ? { ...address, type: 'other' } : address
                 ),
               }
             : null
@@ -109,11 +119,13 @@ export const useAddressOperations = () => {
   const deleteAddress = async (id: string) => {
     await safeExecute(async () => {
       await deleteApiAuthenticated(`/app/addresses/${id}`);
-      setUser((prev) =>
-        prev
+      setUser((existingUserDetails) =>
+        existingUserDetails
           ? {
-              ...prev,
-              addresses: prev.addresses.filter((addr) => addr.id !== id),
+              ...existingUserDetails,
+              addresses: existingUserDetails.addresses.filter(
+                (address) => address.id !== id
+              ),
             }
           : null
       );

--- a/src/features/user/Settings/EditProfile/AddressManagement/utils.ts
+++ b/src/features/user/Settings/EditProfile/AddressManagement/utils.ts
@@ -52,7 +52,10 @@ export const updateAddressesAfterEdit = (
     (nonEditedAddresses, address) => {
       if (address.id === editedAddress.id) return nonEditedAddresses;
 
-      if (editedAddress.isPrimary && address.isPrimary) {
+      if (
+        editedAddress.type === ADDRESS_TYPE.PRIMARY &&
+        address.type === ADDRESS_TYPE.PRIMARY
+      ) {
         nonEditedAddresses.push({
           ...address,
           isPrimary: false,

--- a/src/features/user/Settings/EditProfile/AddressManagement/utils.ts
+++ b/src/features/user/Settings/EditProfile/AddressManagement/utils.ts
@@ -19,10 +19,10 @@ export const updateAddressesAfterAdd = (
 
   const updatedAddresses =
     newAddress.type === ADDRESS_TYPE.PRIMARY
-      ? user.addresses.map((addr) =>
-          addr.type === ADDRESS_TYPE.PRIMARY
-            ? { ...addr, type: ADDRESS_TYPE.OTHER }
-            : addr
+      ? user.addresses.map((address) =>
+          address.type === ADDRESS_TYPE.PRIMARY
+            ? { ...address, type: ADDRESS_TYPE.OTHER }
+            : address
         )
       : user.addresses;
 
@@ -48,17 +48,24 @@ export const updateAddressesAfterEdit = (
 ): User | null => {
   if (!user) return null;
 
-  const updatedAddresses = user.addresses.reduce<Address[]>((acc, addr) => {
-    if (addr.id === editedAddress.id) return acc;
+  const updatedAddresses = user.addresses.reduce<Address[]>(
+    (nonEditedAddresses, address) => {
+      if (address.id === editedAddress.id) return nonEditedAddresses;
 
-    if (editedAddress.isPrimary && addr.isPrimary) {
-      acc.push({ ...addr, isPrimary: false, type: ADDRESS_TYPE.OTHER });
-    } else {
-      acc.push(addr);
-    }
+      if (editedAddress.isPrimary && address.isPrimary) {
+        nonEditedAddresses.push({
+          ...address,
+          isPrimary: false,
+          type: ADDRESS_TYPE.OTHER,
+        });
+      } else {
+        nonEditedAddresses.push(address);
+      }
 
-    return acc;
-  }, []);
+      return nonEditedAddresses;
+    },
+    []
+  );
 
   updatedAddresses.push(editedAddress);
 
@@ -85,16 +92,16 @@ export const updateAddressesAfterTypeChange = (
 ): User | null => {
   if (!user) return null;
 
-  const updatedAddresses = user.addresses.map((addr) => {
-    if (addr.id === updatedAddress.id) {
-      return { ...addr, type: newType };
+  const updatedAddresses = user.addresses.map((address) => {
+    if (address.id === updatedAddress.id) {
+      return { ...address, type: newType };
     }
 
-    if (addr.type === newType) {
-      return { ...addr, type: ADDRESS_TYPE.OTHER };
+    if (address.type === newType) {
+      return { ...address, type: ADDRESS_TYPE.OTHER };
     }
 
-    return addr;
+    return address;
   });
 
   return {

--- a/src/features/user/Settings/EditProfile/AddressManagement/utils.ts
+++ b/src/features/user/Settings/EditProfile/AddressManagement/utils.ts
@@ -1,0 +1,104 @@
+import type { Address, AddressType, User } from '@planet-sdk/common';
+import { ADDRESS_TYPE } from '../../../../../utils/addressManagement';
+
+/**
+ * Updates the user's addresses after adding a new address.
+ * - If the new address is of type PRIMARY, existing PRIMARY addresses are downgraded to OTHER.
+ * - The new address is appended to the list.
+ *
+ * @param user - The current user object or null.
+ * @param newAddress - The new address being added.
+ * @returns Updated user object with the modified address list, or null if user is null.
+ */
+
+export const updateAddressesAfterAdd = (
+  user: User | null,
+  newAddress: Address
+): User | null => {
+  if (!user) return null;
+
+  const updatedAddresses =
+    newAddress.type === ADDRESS_TYPE.PRIMARY
+      ? user.addresses.map((addr) =>
+          addr.type === ADDRESS_TYPE.PRIMARY
+            ? { ...addr, type: ADDRESS_TYPE.OTHER }
+            : addr
+        )
+      : user.addresses;
+
+  return {
+    ...user,
+    addresses: [...updatedAddresses, newAddress],
+  };
+};
+
+/**
+ * Updates the user's addresses after editing an address.
+ * - Replaces the old address with the edited one.
+ * - If the edited address is marked as primary, any existing primary address is downgraded.
+ *
+ * @param user - The current user object or null.
+ * @param editedAddress - The address that has been edited.
+ * @returns Updated user object with the modified address list, or null if user is null.
+ */
+
+export const updateAddressesAfterEdit = (
+  user: User | null,
+  editedAddress: Address
+): User | null => {
+  if (!user) return null;
+
+  const updatedAddresses = user.addresses.reduce<Address[]>((acc, addr) => {
+    if (addr.id === editedAddress.id) return acc;
+
+    if (editedAddress.isPrimary && addr.isPrimary) {
+      acc.push({ ...addr, isPrimary: false, type: ADDRESS_TYPE.OTHER });
+    } else {
+      acc.push(addr);
+    }
+
+    return acc;
+  }, []);
+
+  updatedAddresses.push(editedAddress);
+
+  return {
+    ...user,
+    addresses: updatedAddresses,
+  };
+};
+
+/**
+ * Updates the address type for a specific address.
+ * - The address with the specified ID gets the new type.
+ * - Any other address currently using that type is downgraded to OTHER.
+ *
+ * @param user - The current user object or null.
+ * @param updatedAddress - The address to update.
+ * @param newType - The new address type to assign.
+ * @returns Updated user object with the modified address list, or null if user is null.
+ */
+export const updateAddressesAfterTypeChange = (
+  user: User | null,
+  updatedAddress: Address,
+  newType: AddressType
+): User | null => {
+  if (!user) return null;
+
+  const updatedAddresses = user.addresses.map((addr) => {
+    if (addr.id === updatedAddress.id) {
+      return { ...addr, type: newType };
+    }
+
+    if (addr.type === newType) {
+      return { ...addr, type: ADDRESS_TYPE.OTHER };
+    }
+
+    return addr;
+  });
+
+  return {
+    ...user,
+    addresses: updatedAddresses,
+  };
+};


### PR DESCRIPTION
Refactored all address-related components to use centralized CRUD methods from the `useAddressOperations `hook, improving consistency and reducing duplicated logic

Why this change:

- Promote code reusability by leveraging shared hooks.
- Reduce component-level complexity and duplication.
- Centralize address-related side effects and error handling.
- Improve readability and maintainability of the address form feature.

[issue](https://github.com/Plant-for-the-Planet-org/planet-webapp/issues/2543)