### PR TITLE
Fix form reset after unmount and isPrimary flag inconsistency

### DIFF
--- a/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressForm.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressForm.tsx
@@ -247,8 +247,8 @@ const AddressForm = ({
           text={label}
           handleSubmit={handleSubmit(processFormData)}
           handleCancel={() => {
-            handleCancel();
             resetForm();
+            handleCancel();
           }}
         />
       )}

--- a/src/features/user/Settings/EditProfile/AddressManagement/utils.ts
+++ b/src/features/user/Settings/EditProfile/AddressManagement/utils.ts
@@ -21,7 +21,7 @@ export const updateAddressesAfterAdd = (
     newAddress.type === ADDRESS_TYPE.PRIMARY
       ? user.addresses.map((address) =>
           address.type === ADDRESS_TYPE.PRIMARY
-            ? { ...address, type: ADDRESS_TYPE.OTHER }
+            ? { ...address, type: ADDRESS_TYPE.OTHER, isPrimary: false }
             : address
         )
       : user.addresses;
@@ -101,7 +101,7 @@ export const updateAddressesAfterTypeChange = (
     }
 
     if (address.type === newType) {
-      return { ...address, type: ADDRESS_TYPE.OTHER };
+      return { ...address, type: ADDRESS_TYPE.OTHER, isPrimary: false };
     }
 
     return address;

--- a/src/features/user/Settings/EditProfile/AddressManagement/utils.ts
+++ b/src/features/user/Settings/EditProfile/AddressManagement/utils.ts
@@ -97,7 +97,11 @@ export const updateAddressesAfterTypeChange = (
 
   const updatedAddresses = user.addresses.map((address) => {
     if (address.id === updatedAddress.id) {
-      return { ...address, type: newType };
+      return {
+        ...address,
+        type: newType,
+        isPrimary: newType === ADDRESS_TYPE.PRIMARY,
+      };
     }
 
     if (address.type === newType) {


### PR DESCRIPTION
Fixes :

- Fixed a warning caused by calling `resetForm()` after the form modal unmounts.
- Ensured that downgraded PRIMARY addresses have their `isPrimary `flag correctly reset to avoid multiple logical primaries in the UI.