### PR TITLE
refactor: simplify measurement rendering by using latest values inste…

### DIFF
--- a/src/features/user/TreeMapper/components/PlantLocationPage.tsx
+++ b/src/features/user/TreeMapper/components/PlantLocationPage.tsx
@@ -173,8 +173,9 @@ export function LocationDetails({
               </div>
             </div>
             <div className={styles.measurements}>
-              {(location.interventionStartDate !== null ||
-                location?.plantDate !== null) && (
+              {Boolean(
+                location.interventionStartDate || location.plantDate
+              ) && (
                 <div className={styles.singleDetail}>
                   <p className={styles.title}>{tTreemapper('date')}</p>
                   <div className={styles.value}>
@@ -184,7 +185,6 @@ export function LocationDetails({
                   </div>
                 </div>
               )}
-
               <div className={styles.singleDetail}>
                 <p className={styles.title}>{tTreemapper('height')}</p>
                 <div className={styles.value}>

--- a/src/features/user/TreeMapper/components/PlantLocationPage.tsx
+++ b/src/features/user/TreeMapper/components/PlantLocationPage.tsx
@@ -173,29 +173,29 @@ export function LocationDetails({
               </div>
             </div>
             <div className={styles.measurements}>
-              <div className={styles.singleDetail}>
-                <p className={styles.title}>{tTreemapper('date')}</p>
-                {location.history?.map((h, index) => (
-                  <div className={styles.value} key={index}>
-                    {formatDate(h?.created)}
+              {(location.interventionStartDate !== null ||
+                location?.plantDate !== null) && (
+                <div className={styles.singleDetail}>
+                  <p className={styles.title}>{tTreemapper('date')}</p>
+                  <div className={styles.value}>
+                    {formatDate(
+                      location?.interventionStartDate || location?.plantDate
+                    )}
                   </div>
-                ))}
-              </div>
+                </div>
+              )}
+
               <div className={styles.singleDetail}>
                 <p className={styles.title}>{tTreemapper('height')}</p>
-                {location.history?.map((h, index) => (
-                  <div className={styles.value} key={index}>
-                    {h?.measurements?.height} {tTreemapper('m')}
-                  </div>
-                ))}
+                <div className={styles.value}>
+                  {location.measurements?.height} {tTreemapper('m')}
+                </div>
               </div>
               <div className={styles.singleDetail}>
                 <p className={styles.title}>{tTreemapper('width')}</p>
-                {location.history?.map((h, index) => (
-                  <div className={styles.value} key={index}>
-                    {h?.measurements?.width} {tTreemapper('cm')}
-                  </div>
-                ))}
+                <div className={styles.value}>
+                  {location.measurements?.width} {tTreemapper('cm')}
+                </div>
               </div>
             </div>
           </>


### PR DESCRIPTION
This PR refactors the logic for rendering plant location measurements:

Why ?
- The history array was often empty or unavailable, leading to no data being shown. Using the  available values from `location.measurements `ensures consistency and simplifies the UI logic.