### PR TITLE
Use centralized SetState type from common.d.ts

### DIFF
--- a/src/features/common/Layout/BulkCodeContext.tsx
+++ b/src/features/common/Layout/BulkCodeContext.tsx
@@ -1,4 +1,5 @@
-import type { FC, Dispatch, SetStateAction } from 'react';
+import type { FC } from 'react';
+import type { SetState } from '../types/common';
 import type { BulkCodeMethods } from '../../../utils/constants/bulkCodeConstants';
 import type {
   CountryCode,
@@ -36,8 +37,6 @@ export interface BulkGiftImportData {
 }
 
 type BulkGiftData = BulkGiftGenericData | BulkGiftImportData;
-
-export type SetState<T> = Dispatch<SetStateAction<T>>;
 
 interface BulkCodeContextInterface {
   bulkMethod: BulkCodeMethods | null;

--- a/src/features/user/BulkCodes/components/GenericCodesPartial.tsx
+++ b/src/features/user/BulkCodes/components/GenericCodesPartial.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, FocusEvent } from 'react';
-import type { SetState } from '../../../common/Layout/BulkCodeContext';
+import type { SetState } from '../../../common/types/common';
 
 import { TextField } from '@mui/material';
 import { useState } from 'react';


### PR DESCRIPTION
This PR removes the duplicate `SetState `type definition from` src/features/common/Layout/BulkCodeContext.tsx` and replaces it with the canonical definition from` src/features/common/types/common.d.ts.`

[Issue](https://github.com/Plant-for-the-Planet-org/planet-webapp/issues/2550)