### PR TITLE
Fixes bug while cancelling address modals (donation receipt flow)

### DIFF
--- a/src/features/user/DonationReceipt/DonorContactManagement.tsx
+++ b/src/features/user/DonationReceipt/DonorContactManagement.tsx
@@ -129,8 +129,10 @@ const DonorContactManagement = () => {
     if (!addressAction) return null;
 
     const commonProps = {
-      setIsModalOpen,
-      setAddressAction,
+      handleCancel: () => {
+        setIsModalOpen(false);
+        setAddressAction(null);
+      },
       showPrimaryAddressToggle: true,
     };
 


### PR DESCRIPTION
Handle cancel action for Add address and Edit address while modifying contact details for a donation receipt. This was missing earlier, resulting in a client side error.