### PR TITLE
Fix validation logic in DonationReceiptContext for donor/address changes

### DIFF
--- a/src/features/common/Layout/DonationReceiptContext.tsx
+++ b/src/features/common/Layout/DonationReceiptContext.tsx
@@ -110,7 +110,8 @@ interface DonationReceiptContextInterface {
   updateDonorAndAddress: (
     donor: DonorView,
     address: AddressView,
-    addressGuid: string
+    addressGuid: string,
+    user: User | null
   ) => void;
   clearSessionStorage: () => void;
 }
@@ -238,14 +239,35 @@ export const DonationReceiptProvider: React.FC<{
   const updateDonorAndAddress = (
     donor: DonorView,
     address: AddressView,
-    addressGuid: string
+    addressGuid: string,
+    user: User | null
   ): void => {
-    setState((prevState) => ({
-      ...prevState,
-      donor,
-      address,
-      addressGuid,
-    }));
+    setState((prevState) => {
+      let isValid = prevState.isValid;
+      if (prevState.operation === RECEIPT_STATUS.ISSUE) {
+        isValid = validateUnissuedReceipt(
+          donor,
+          address,
+          prevState.tinIsRequired,
+          addressGuid,
+          user
+        );
+      } else {
+        isValid = validateIssuedReceipt(
+          donor,
+          address,
+          prevState.tinIsRequired,
+          user
+        );
+      }
+      return {
+        ...prevState,
+        donor,
+        address,
+        addressGuid,
+        isValid,
+      };
+    });
   };
 
   // Context value

--- a/src/features/user/DonationReceipt/DonorContactManagement.tsx
+++ b/src/features/user/DonationReceipt/DonorContactManagement.tsx
@@ -117,7 +117,12 @@ const DonorContactManagement = () => {
         country: selectedAddress?.country ?? '',
       };
 
-      updateDonorAndAddress(donorView, addressView, checkedAddressGuid);
+      updateDonorAndAddress(
+        donorView,
+        addressView,
+        checkedAddressGuid,
+        updatedUser
+      );
       navigateToVerificationPage();
     } catch (error) {
       setErrors(handleError(error as APIError));


### PR DESCRIPTION
Update the validation logic to recalculate the `isValid` state when donor or address changes, ensuring the Confirm button in the verify receipt screen appears correctly after correcting invalid contact information.