### PR TITLE
refactor(manage-project): replace old MUI Switch with new custom Togg…

### DIFF
--- a/src/features/common/InputTypes/NewToggleSwitch.tsx
+++ b/src/features/common/InputTypes/NewToggleSwitch.tsx
@@ -14,51 +14,51 @@ interface ToggleSwitchProps {
   color?: string;
 }
 
-export default function NewToggleSwitch(props: ToggleSwitchProps) {
-  const NewToggleSwitch = styled(Switch)({
-    width: 50,
-    height: 26,
+const StyledSwitch = styled(Switch)({
+  width: 50,
+  height: 26,
+  padding: 0,
+  '& .MuiSwitch-switchBase': {
     padding: 0,
-    '& .MuiSwitch-switchBase': {
-      padding: 0,
-      margin: 2,
-      transitionDuration: '300ms',
-      '&.Mui-checked': {
-        transform: 'translateX(24px)',
-        color: '#fff',
-        '& + .MuiSwitch-track': {
-          backgroundColor: themeProperties.designSystem.colors.forestGreen,
-          opacity: 1,
-          border: 0,
-        },
-        '&.Mui-disabled + .MuiSwitch-track': {
-          opacity: 0.5,
-        },
-      },
-      '&.Mui-focusVisible .MuiSwitch-thumb': {
-        color: themeProperties.designSystem.colors.white,
-        border: `6px solid ${themeProperties.designSystem.colors.white}`,
+    margin: 2,
+    transitionDuration: '300ms',
+    '&.Mui-checked': {
+      transform: 'translateX(24px)',
+      color: '#fff',
+      '& + .MuiSwitch-track': {
+        backgroundColor: themeProperties.designSystem.colors.forestGreen,
+        opacity: 1,
+        border: 0,
       },
       '&.Mui-disabled + .MuiSwitch-track': {
-        background: themeProperties.designSystem.colors.mediumGreyTransparent30,
-        opacity: 1,
+        opacity: 0.5,
       },
     },
-    '& .MuiSwitch-thumb': {
-      boxSizing: 'border-box',
-      width: 22,
-      height: 22,
-      backgroundColor: themeProperties.designSystem.colors.white,
+    '&.Mui-focusVisible .MuiSwitch-thumb': {
+      color: themeProperties.designSystem.colors.white,
+      border: `6px solid ${themeProperties.designSystem.colors.white}`,
     },
-    '& .MuiSwitch-track': {
-      borderRadius: 26 / 2,
-      backgroundColor: themeProperties.designSystem.colors.mediumGrey,
+    '&.Mui-disabled + .MuiSwitch-track': {
+      background: themeProperties.designSystem.colors.mediumGreyTransparent30,
       opacity: 1,
     },
-  });
+  },
+  '& .MuiSwitch-thumb': {
+    boxSizing: 'border-box',
+    width: 22,
+    height: 22,
+    backgroundColor: themeProperties.designSystem.colors.white,
+  },
+  '& .MuiSwitch-track': {
+    borderRadius: 26 / 2,
+    backgroundColor: themeProperties.designSystem.colors.mediumGrey,
+    opacity: 1,
+  },
+});
 
+export default function NewToggleSwitch(props: ToggleSwitchProps) {
   return (
-    <NewToggleSwitch
+    <StyledSwitch
       checked={props.checked}
       onChange={props.onChange}
       id={props.id}

--- a/src/features/user/ManageProjects/StepForm.module.scss
+++ b/src/features/user/ManageProjects/StepForm.module.scss
@@ -785,3 +785,12 @@
   box-shadow: rgb(170 170 170 / 20%) 0px 1px 4px;
   border-radius: 10px;
 }
+
+.toggleLabelWithInfo {
+  display: flex;
+}
+
+.toggleText {
+  margin-left: 8px;
+  line-height: 20px;
+}

--- a/src/features/user/ManageProjects/StepForm.module.scss
+++ b/src/features/user/ManageProjects/StepForm.module.scss
@@ -754,10 +754,10 @@
 }
 
 .tooltipIcon {
-  display: inline-block;
-  width: 1em;
-  min-width: 1em;
-  vertical-align: middle;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 1rem;
   margin-left: 5px;
 }
 
@@ -788,9 +788,10 @@
 
 .toggleLabelWithInfo {
   display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .toggleText {
   margin-left: 8px;
-  line-height: 20px;
 }

--- a/src/features/user/ManageProjects/components/BasicDetails.tsx
+++ b/src/features/user/ManageProjects/components/BasicDetails.tsx
@@ -9,7 +9,7 @@ import type { ReverseAddress } from '../../../common/types/geocoder';
 
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
-import { Button, FormControlLabel, Switch, Tooltip } from '@mui/material';
+import { Button, FormControlLabel, Tooltip } from '@mui/material';
 import { useLocale, useTranslations } from 'next-intl';
 import styles from './../StepForm.module.scss';
 import MapGL, {
@@ -36,6 +36,7 @@ import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDispl
 import { handleError } from '@planet-sdk/common';
 import { ProjectCreationTabs } from '..';
 import { useApi } from '../../../../hooks/useApi';
+import NewToggleSwitch from '../../../common/InputTypes/NewToggleSwitch';
 
 type BaseFormData = {
   name: string;
@@ -629,8 +630,10 @@ export default function BasicDetails({
               render={({ field: { onChange, value } }) => (
                 <FormControlLabel
                   label={
-                    <div>
-                      {t('receiveDonations')}
+                    <div className={styles.toggleLabelWithInfo}>
+                      <span className={styles.toggleText}>
+                        {t('receiveDonations')}
+                      </span>
                       <Tooltip title={t('receiveDonationsInfo')} arrow>
                         <span className={styles.tooltipIcon}>
                           <InfoIcon />
@@ -640,7 +643,7 @@ export default function BasicDetails({
                   }
                   labelPlacement="end"
                   control={
-                    <Switch
+                    <NewToggleSwitch
                       checked={value}
                       onChange={(e: ChangeEvent<HTMLInputElement>) => {
                         onChange(e.target.checked);
@@ -649,6 +652,7 @@ export default function BasicDetails({
                       inputProps={{ 'aria-label': 'secondary checkbox' }}
                     />
                   }
+                  sx={{ marginLeft: '0px' }}
                 />
               )}
             />
@@ -852,10 +856,14 @@ export default function BasicDetails({
             control={control}
             render={({ field: { onChange, value } }) => (
               <FormControlLabel
-                label={t('visitorAssistanceLabel')}
+                label={
+                  <p className={styles.toggleText}>
+                    {t('visitorAssistanceLabel')}
+                  </p>
+                }
                 labelPlacement="end"
                 control={
-                  <Switch
+                  <NewToggleSwitch
                     checked={value}
                     onChange={(e: ChangeEvent<HTMLInputElement>) => {
                       onChange(e.target.checked);
@@ -863,6 +871,7 @@ export default function BasicDetails({
                     inputProps={{ 'aria-label': 'secondary checkbox' }}
                   />
                 }
+                sx={{ marginLeft: '0px' }}
               />
             )}
           />

--- a/src/features/user/ManageProjects/components/ProjectCertificates.tsx
+++ b/src/features/user/ManageProjects/components/ProjectCertificates.tsx
@@ -18,10 +18,11 @@ import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContex
 import { MobileDatePicker as MuiDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { TextField, Button, FormControlLabel, Switch } from '@mui/material';
+import { TextField, Button, FormControlLabel } from '@mui/material';
 import { handleError } from '@planet-sdk/common';
 import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDisplayGroup';
 import { useApi } from '../../../../hooks/useApi';
+import NewToggleSwitch from '../../../common/InputTypes/NewToggleSwitch';
 
 type CertificateApiPayload = {
   issueDate: number;
@@ -175,10 +176,10 @@ function ProjectCertificates({
     <div className={styles.certificateContainer}>
       {showToggle && (
         <FormControlLabel
-          label={t('isCertified')}
+          label={<span className={styles.toggleText}>{t('isCertified')}</span>}
           labelPlacement="end"
           control={
-            <Switch
+            <NewToggleSwitch
               name="isCertified"
               id="isCertified"
               checked={isCertified}
@@ -186,6 +187,7 @@ function ProjectCertificates({
               inputProps={{ 'aria-label': 'secondary checkbox' }}
             />
           }
+          sx={{ marginLeft: '0px' }}
         />
       )}
 

--- a/src/features/user/ManageProjects/components/SubmitForReview.tsx
+++ b/src/features/user/ManageProjects/components/SubmitForReview.tsx
@@ -9,9 +9,10 @@ import UnderReview from '../../../../../public/assets/images/icons/manageProject
 import { useTranslations } from 'next-intl';
 import NotReviewed from '../../../../../public/assets/images/icons/manageProjects/NotReviewed';
 import router from 'next/router';
-import { Button, FormControlLabel, Switch } from '@mui/material';
+import { Button, FormControlLabel } from '@mui/material';
 import { ProjectCreationTabs } from '..';
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
+import NewToggleSwitch from '../../../common/InputTypes/NewToggleSwitch';
 
 function SubmitForReview({
   submitForReview,
@@ -25,13 +26,15 @@ function SubmitForReview({
     return (
       <CenteredContainer>
         <FormControlLabel
-          label={t('publishProject')}
+          label={
+            <span className={styles.toggleText}>{t('publishProject')}</span>
+          }
           labelPlacement="end"
           control={
-            <Switch
+            <NewToggleSwitch
               name="canPublish"
               id="publish"
-              checked={projectDetails?.publish}
+              checked={projectDetails?.publish ?? false}
               onChange={(e) => handlePublishChange(e.target.checked)}
               inputProps={{ 'aria-label': 'secondary checkbox' }}
             />
@@ -80,13 +83,15 @@ function SubmitForReview({
           </ul>
         </div>
         <FormControlLabel
-          label={t('publishProject')}
+          label={
+            <span className={styles.toggleText}>{t('publishProject')}</span>
+          }
           labelPlacement="end"
           control={
-            <Switch
+            <NewToggleSwitch
               name="canPublish"
               id="publish"
-              checked={projectDetails?.publish}
+              checked={projectDetails?.publish ?? false}
               onChange={(e) => handlePublishChange(e.target.checked)}
               inputProps={{ 'aria-label': 'secondary checkbox' }}
             />


### PR DESCRIPTION
This PR updates the Manage Project feature to use the new ToggleSwitch component in place of the default MUI Switch.

Changes included :
- Replaced MUI Switch components in Manage Project forms with the `ToggleSwitch `component.

Why this change was needed :
- To ensure consistent styling across toggles within the Manage Project feature.
- To simplify maintenance by using a single, centralized custom `ToggleSwitch`.
- To improve visual consistency with the rest of the application’s design system.