### PR TITLE
refactor(api): clean up ApiConfig types for better clarity

### DIFF
--- a/src/features/user/Settings/ApiKey/ApiKeyForm.tsx
+++ b/src/features/user/Settings/ApiKey/ApiKeyForm.tsx
@@ -65,7 +65,8 @@ export default function ApiKey() {
     setIsUploadingData(true);
     try {
       const res = await putApiAuthenticated<ApiKeyResponse>(
-        `/app/profile/apiKey`
+        `/app/profile/apiKey`,
+        { payload: {} }
       );
       if (res) {
         setApiKey(res.apiKey || '');

--- a/src/features/user/Settings/ImpersonateUser/SupportPin.tsx
+++ b/src/features/user/Settings/ImpersonateUser/SupportPin.tsx
@@ -16,7 +16,8 @@ const SupportPin = () => {
   const handleNewPin = async () => {
     try {
       const response = await putApiAuthenticated<SupportPin>(
-        '/app/profile/supportPin'
+        '/app/profile/supportPin',
+        { payload: {} }
       );
       if (response) {
         const updateUserData = { ...user };

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -64,7 +64,6 @@
  * @notes
  * - Ensure that `useUserProps` and `useTenant` contexts are properly configured in your application.
  */
-import type { ImpersonationData } from '../utils/apiRequests/impersonation';
 import type { RequestOptions } from '../utils/apiRequests/apiClient';
 
 import apiClient from '../utils/apiRequests/apiClient';
@@ -82,7 +81,6 @@ type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
 type ApiConfigBase = {
   queryParams?: Record<string, string>;
-  impersonationData?: ImpersonationData;
   additionalHeaders?: Record<string, string>;
   version?: string;
 };
@@ -111,11 +109,9 @@ export const useApi = () => {
     data,
     queryParams,
     authRequired = false,
-    impersonationData,
     version,
     additionalHeaders,
   }: RequestOptions & {
-    impersonationData?: ImpersonationData;
     version?: string;
   }): Promise<T> => {
     const headers: Record<string, string> = {
@@ -140,7 +136,7 @@ export const useApi = () => {
       }
       headers.Authorization = `Bearer ${token}`;
     }
-    const finalHeader = setHeaderForImpersonation(headers, impersonationData);
+    const finalHeader = setHeaderForImpersonation(headers);
     const requestOptions =
       method === 'POST' || method === 'PUT'
         ? { method, url, data, queryParams, additionalHeaders: finalHeader }

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -80,15 +80,25 @@ const INVALID_TOKEN_STATUS_CODE = 498;
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
-type ApiConfig<
-  P extends Record<string, unknown>,
-  M extends HttpMethod = 'GET' | 'DELETE'
-> = {
+type ApiConfigBase = {
   queryParams?: Record<string, string>;
   impersonationData?: ImpersonationData;
   additionalHeaders?: Record<string, string>;
   version?: string;
-} & (M extends 'POST' | 'PUT' ? { payload: P } : Record<string, unknown>);
+};
+
+type ApiConfigWithPayload<P extends Record<string, unknown>> = {
+  payload: P;
+} & ApiConfigBase;
+
+type ApiConfigWithoutPayload = ApiConfigBase;
+
+type ApiConfig<
+  P extends Record<string, unknown>,
+  M extends HttpMethod
+> = M extends 'POST' | 'PUT'
+  ? ApiConfigWithPayload<P>
+  : ApiConfigWithoutPayload;
 
 export const useApi = () => {
   const { token, logoutUser } = useUserProps();
@@ -276,7 +286,7 @@ export const useApi = () => {
     P extends Record<string, unknown> = Record<string, unknown>
   >(
     url: string,
-    config: ApiConfig<P, 'PUT'> = { payload: {} as P }
+    config: ApiConfig<P, 'PUT'>
   ): Promise<T> => {
     return callApi<T>({
       method: 'PUT',

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -170,7 +170,8 @@ export const useApi = () => {
       method: 'GET',
       url,
       authRequired: true,
-      ...config,
+      queryParams: config.queryParams,
+      additionalHeaders: config.additionalHeaders,
     });
   };
 
@@ -194,8 +195,9 @@ export const useApi = () => {
     return callApi<T>({
       method: 'POST',
       url,
-      data: config.payload,
       authRequired: true,
+      data: config.payload,
+      queryParams: config.queryParams,
       additionalHeaders: config.additionalHeaders,
     });
   };
@@ -215,7 +217,8 @@ export const useApi = () => {
     return callApi<T>({
       method: 'GET',
       url,
-      ...config,
+      queryParams: config.queryParams,
+      additionalHeaders: config.additionalHeaders,
     });
   };
 
@@ -239,6 +242,7 @@ export const useApi = () => {
       method: 'POST',
       url,
       data: config.payload,
+      queryParams: config.queryParams,
       additionalHeaders: config.additionalHeaders,
     });
   };
@@ -263,6 +267,7 @@ export const useApi = () => {
       method: 'PUT',
       url,
       data: config.payload,
+      queryParams: config.queryParams,
       additionalHeaders: config.additionalHeaders,
     });
   };
@@ -287,8 +292,8 @@ export const useApi = () => {
     return callApi<T>({
       method: 'PUT',
       url,
-      data: config.payload,
       authRequired: true,
+      data: config.payload,
       queryParams: config.queryParams,
       additionalHeaders: config.additionalHeaders,
     });
@@ -311,6 +316,7 @@ export const useApi = () => {
       method: 'DELETE',
       url,
       authRequired: true,
+      queryParams: config.queryParams,
       additionalHeaders: config.additionalHeaders,
     });
   };

--- a/src/utils/apiRequests/setHeader.ts
+++ b/src/utils/apiRequests/setHeader.ts
@@ -2,29 +2,17 @@ import type { ImpersonationData } from '../../features/user/Settings/Impersonate
 /**
  * Sets keys for header in impersonation mode
  */
-export const setHeaderForImpersonation = (
-  header: Record<string, string>,
-  impersonationData?: ImpersonationData
-) => {
+export const setHeaderForImpersonation = (header: Record<string, string>) => {
   const impersonationDataFromLocal: ImpersonationData = JSON.parse(
     `${localStorage.getItem('impersonationData')}`
   );
-  if (impersonationDataFromLocal || impersonationData) {
-    if (
-      impersonationData?.targetEmail ||
-      impersonationDataFromLocal?.targetEmail
-    ) {
-      header['X-SWITCH-USER'] =
-        impersonationData?.targetEmail ||
-        impersonationDataFromLocal?.targetEmail;
+  if (impersonationDataFromLocal) {
+    if (impersonationDataFromLocal?.targetEmail) {
+      header['X-SWITCH-USER'] = impersonationDataFromLocal?.targetEmail;
     }
 
-    if (
-      impersonationData?.supportPin ||
-      impersonationDataFromLocal?.supportPin
-    ) {
-      header['X-USER-SUPPORT-PIN'] =
-        impersonationData?.supportPin || impersonationDataFromLocal?.supportPin;
+    if (impersonationDataFromLocal?.supportPin) {
+      header['X-USER-SUPPORT-PIN'] = impersonationDataFromLocal?.supportPin;
     }
     const impersonationHeader = header;
     return impersonationHeader;

--- a/src/utils/apiRequests/setHeader.ts
+++ b/src/utils/apiRequests/setHeader.ts
@@ -2,17 +2,29 @@ import type { ImpersonationData } from '../../features/user/Settings/Impersonate
 /**
  * Sets keys for header in impersonation mode
  */
-export const setHeaderForImpersonation = (header: Record<string, string>) => {
+export const setHeaderForImpersonation = (
+  header: Record<string, string>,
+  impersonationData?: ImpersonationData
+) => {
   const impersonationDataFromLocal: ImpersonationData = JSON.parse(
     `${localStorage.getItem('impersonationData')}`
   );
-  if (impersonationDataFromLocal) {
-    if (impersonationDataFromLocal?.targetEmail) {
-      header['X-SWITCH-USER'] = impersonationDataFromLocal?.targetEmail;
+  if (impersonationDataFromLocal || impersonationData) {
+    if (
+      impersonationData?.targetEmail ||
+      impersonationDataFromLocal?.targetEmail
+    ) {
+      header['X-SWITCH-USER'] =
+        impersonationData?.targetEmail ||
+        impersonationDataFromLocal?.targetEmail;
     }
 
-    if (impersonationDataFromLocal?.supportPin) {
-      header['X-USER-SUPPORT-PIN'] = impersonationDataFromLocal?.supportPin;
+    if (
+      impersonationData?.supportPin ||
+      impersonationDataFromLocal?.supportPin
+    ) {
+      header['X-USER-SUPPORT-PIN'] =
+        impersonationData?.supportPin || impersonationDataFromLocal?.supportPin;
     }
     const impersonationHeader = header;
     return impersonationHeader;


### PR DESCRIPTION
[Issue](https://github.com/Plant-for-the-Planet-org/planet-webapp/issues/2495)

This PR addresses inconsistencies in how authenticated API methods are typed and how request configs are handled across the codebase.

Changes Introduced: 

- Ensured consistent extraction and forwarding of `queryParams, additionalHeaders,`
- Improved typing for `ApiConfig`
     - Separated common config (ApiConfigBase) from method-specific payload requirements.
     - Introduced clear types: `ApiConfigWithPayload `and `ApiConfigWithoutPayload`.
     - Fixed incorrect defaults and conditional typing behavior, especially for POST/PUT vs GET/DELETE.
     
- Updated usages of `putApiAuthenticated`
    - Explicitly passed` { payload: {} }` to ensure consistent behavior and type safety.
    
- Removed the unused `impersonationData `parameter.

Why this matters :

 - Consistency across API methods
→ Ensures all request methods handle `queryParams`, headers, etc., uniformly.

- Improved type safety
→ Clear separation of payload vs. non-payload configs prevents misuse.

- Fewer runtime bugs
→ TypeScript catches missing or misused fields early.

-  Cleaner, simpler function signatures
→ Removed unused `impersonationData `param.

 - Better defaults and structure
→ Predictable behavior across GET, POST, PUT, DELETE methods.

- Easier to maintain and extend
→ More readable and scalable typing for future API changes.
 
 

