### PR TITLE
Refactor TimeTravelDropdown open/closed state management

### DIFF
--- a/src/features/projectsV2/ProjectsMap/TimeTravel/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/TimeTravel/index.tsx
@@ -66,8 +66,6 @@ export default function TimeTravel({
   const [isLoading, setIsLoading] = useState(true);
   const [beforeLoaded, setBeforeLoaded] = useState(false);
   const [afterLoaded, setAfterLoaded] = useState(false);
-  const [beforeDropdownOpen, setBeforeDropdownOpen] = useState(false);
-  const [afterDropdownOpen, setAfterDropdownOpen] = useState(false);
 
   const availableYears = useMemo(() => {
     if (timeTravelConfig === null || timeTravelConfig.sources === null) {
@@ -461,22 +459,18 @@ export default function TimeTravel({
 
   const handleBeforeYearChange = (year: string) => {
     setSelectedYearBefore(year);
-    setBeforeDropdownOpen(false);
   };
 
   const handleBeforeSourceChange = (source: SourceName) => {
     setSelectedSourceBefore(source);
-    setBeforeDropdownOpen(false);
   };
 
   const handleAfterYearChange = (year: string) => {
     setSelectedYearAfter(year);
-    setAfterDropdownOpen(false);
   };
 
   const handleAfterSourceChange = (source: SourceName) => {
     setSelectedSourceAfter(source);
-    setAfterDropdownOpen(false);
   };
 
   return (
@@ -486,7 +480,6 @@ export default function TimeTravel({
         defaultSource={selectedSourceBefore}
         availableYears={availableYears}
         availableSources={availableSources}
-        isOpen={beforeDropdownOpen}
         onYearChange={handleBeforeYearChange}
         onSourceChange={handleBeforeSourceChange}
         customClassName={styles.beforeDropdown}
@@ -496,7 +489,6 @@ export default function TimeTravel({
         defaultSource={selectedSourceAfter}
         availableYears={availableYears}
         availableSources={availableSources}
-        isOpen={afterDropdownOpen}
         onYearChange={handleAfterYearChange}
         onSourceChange={handleAfterSourceChange}
         customClassName={styles.afterDropdown}

--- a/src/features/projectsV2/TimeTravelDropdown/index.tsx
+++ b/src/features/projectsV2/TimeTravelDropdown/index.tsx
@@ -2,10 +2,11 @@ import type { SourceName } from '../../../utils/mapsV2/timeTravel';
 
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import styles from './TimeTravelDropdown.module.scss';
 import CalendarIcon from '../../../../public/assets/images/icons/projectV2/CalendarIcon';
 import DropdownUpArrow from '../../../../public/assets/images/icons/projectV2/DropdownUpArrow';
 import DropdownDownArrow from '../../../../public/assets/images/icons/projectV2/DropdownDownArrow';
+import themeProperties from '../../../theme/themeProperties';
+import styles from './TimeTravelDropdown.module.scss';
 
 const SOURCE_LABELS: Record<SourceName, string> = {
   esri: 'Esri',
@@ -79,7 +80,10 @@ const TimeTravelDropdown = ({
         aria-label={tTimeTravel('timeTravelOptionsLabel')}
       >
         <div className={styles.menuButtonTitle}>
-          <CalendarIcon width={14} color={`${'var(--bold-font-color-new)'}`} />
+          <CalendarIcon
+            width={14}
+            color={themeProperties.designSystem.colors.coreText}
+          />
           <p className={styles.menuButtonText}>
             {tTimeTravel.rich('sourceAttributionLabel', {
               year: selectedYear,

--- a/src/features/projectsV2/TimeTravelDropdown/index.tsx
+++ b/src/features/projectsV2/TimeTravelDropdown/index.tsx
@@ -1,6 +1,6 @@
 import type { SourceName } from '../../../utils/mapsV2/timeTravel';
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import styles from './TimeTravelDropdown.module.scss';
 import CalendarIcon from '../../../../public/assets/images/icons/projectV2/CalendarIcon';
@@ -16,7 +16,6 @@ interface TimeTravelDropdownProps {
   defaultSource: SourceName;
   availableYears: string[];
   availableSources: SourceName[];
-  isOpen: boolean;
   onYearChange: (year: string) => void;
   onSourceChange: (source: SourceName) => void;
   customClassName?: string;
@@ -27,16 +26,33 @@ const TimeTravelDropdown = ({
   defaultSource,
   availableYears,
   availableSources,
-  isOpen,
   onYearChange,
   onSourceChange,
   customClassName,
 }: TimeTravelDropdownProps) => {
   const tTimeTravel = useTranslations('ProjectDetails.timeTravel');
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const [selectedYear, setSelectedYear] = useState(defaultYear);
   const [selectedSource, setSelectedSource] = useState(defaultSource);
-  const [isMenuOpen, setIsMenuOpen] = useState(isOpen);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsMenuOpen(false);
+      }
+    };
+    if (isMenuOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isMenuOpen]);
 
   const handleChangeYear = (year: string) => {
     setSelectedYear(year);
@@ -52,7 +68,10 @@ const TimeTravelDropdown = ({
     option.toLowerCase() === selectedValue.toLowerCase();
 
   return (
-    <div className={`${styles.menuContainer} ${customClassName || ''}`}>
+    <div
+      ref={dropdownRef}
+      className={`${styles.menuContainer} ${customClassName || ''}`}
+    >
       <button
         className={styles.menuButton}
         onClick={() => setIsMenuOpen(!isMenuOpen)}

--- a/src/features/projectsV2/TimeTravelDropdown/index.tsx
+++ b/src/features/projectsV2/TimeTravelDropdown/index.tsx
@@ -99,9 +99,9 @@ const TimeTravelDropdown = ({
       {isMenuOpen && (
         <div className={styles.menuItems}>
           <ul className={styles.yearMenuContainer}>
-            {availableYears?.map((year, index) => (
+            {availableYears?.map((year) => (
               <time
-                key={index}
+                key={year}
                 dateTime={`${year}`}
                 role="button"
                 aria-selected={isOptionSelected(year, selectedYear)}
@@ -117,9 +117,9 @@ const TimeTravelDropdown = ({
             ))}
           </ul>
           <ul className={styles.sourceMenuContainer}>
-            {availableSources?.map((source, index) => (
+            {availableSources?.map((source) => (
               <li
-                key={index}
+                key={source}
                 onClick={() => handleChangeSource(source)}
                 className={`${
                   isOptionSelected(source, selectedSource)


### PR DESCRIPTION
Remove unnecessary open/close state handling from TimeTravel and streamline the TimeTravelDropdown to manage its own open state with outside click detection.

Resolves #2379 

Additional:
1. Replaces `index` as key for TimeTravelDropdown menu items
2. Updates CalendarIcon color as per design system