### PR TITLE
Fixes partially hidden mobile swiper for intervention info

### DIFF
--- a/src/features/projectsV2/MobileInfoSwiper/MobileInfoSwiper.module.scss
+++ b/src/features/projectsV2/MobileInfoSwiper/MobileInfoSwiper.module.scss
@@ -1,9 +1,11 @@
 @import '../../../theme/theme';
 
+$footerHeight: 49px;
+
 .mobileInfoSwiper {
   width: 100%;
   position: fixed;
-  bottom: 0;
+  bottom: $footerHeight;
   z-index: 9999;
   padding: 6px;
 }


### PR DESCRIPTION
Adds an offset from bottom equal to footer height while positioning MobileInfoSwiper, to avoid the footer partially hiding the swiper.

Before:
<img width="406" height="301" alt="Before" src="https://github.com/user-attachments/assets/fd5dd734-91d6-4d0a-8c44-1ec5b0ca982b" />

After:
<img width="403" height="355" alt="After" src="https://github.com/user-attachments/assets/782a4bdb-cf17-4643-a8e6-efda4556bf79" />
