### PR TITLE
Fix Image Slider Autorotate and Empty Image Handling; Refactor ImageCarousel for Manual/Auto Modes

### DIFF
--- a/src/features/common/types/projectv2.d.ts
+++ b/src/features/common/types/projectv2.d.ts
@@ -7,7 +7,6 @@ import type {
   TreeProjectConcise,
   ConservationProjectConcise,
 } from '@planet-sdk/common/build/types/project/map';
-import type { Nullable } from '@planet-sdk/common/build/types/util';
 import type { MutableRefObject } from 'react';
 import type { Map } from 'maplibre-gl';
 
@@ -18,17 +17,6 @@ export type MapProjectProperties =
 export type ExtendedProject = TreeProjectExtended | ConservationProjectExtended;
 
 export type MapProject = ProjectMapInfo<MapProjectProperties>;
-
-export interface Image {
-  image: string;
-  description: Nullable<string>;
-  id: string;
-}
-
-export type SliderImage = {
-  image?: string | undefined;
-  description?: string | null;
-};
 
 export type MapRef = MutableRefObject<ExtendedMapLibreMap | null>;
 export interface ExtendedMapLibreMap extends Map {

--- a/src/features/projectsV2/ProjectDetails/components/ImageSlider.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/ImageSlider.tsx
@@ -41,9 +41,9 @@ const ImageSlider = ({
             type={type}
             imageSize={imageSize}
             imageHeight={192}
-            setCurrentIndex={setCurrentIndex}
-            currentIndex={currentIndex}
-            isModalOpen={isModalOpen}
+            isMobile={isMobile}
+            isModalOpen={false}
+            mode="auto"
           />
         </div>
       )}

--- a/src/features/projectsV2/ProjectDetails/components/ImageSlider.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/ImageSlider.tsx
@@ -1,14 +1,14 @@
-import type { Image } from '../../../common/types/projectv2';
+import type { SliderImage } from './microComponents/ImageCarousel';
 
 import ExpandIcon from '../../../../../public/assets/images/icons/ExpandIcon';
 import ImageCarousel from './microComponents/ImageCarousel';
 import styles from '../styles/Slider.module.scss';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import ImageSliderModal from './microComponents/ImageSliderModal';
 import themeProperties from '../../../../theme/themeProperties';
 
 interface ImageSliderProps {
-  images: Image[];
+  images: SliderImage[];
   type: 'coordinate' | 'project';
   isMobile: boolean;
   imageSize: 'medium' | 'large';
@@ -25,6 +25,16 @@ const ImageSlider = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(0);
 
+  // Filter out images with empty or missing image property
+  const validImages = useMemo(() => {
+    return images.filter((image) => image?.image && image.image.trim() !== '');
+  }, [images]);
+
+  // Don't render if no valid images
+  if (validImages.length === 0) {
+    return null;
+  }
+
   return (
     <>
       {!isModalOpen && (
@@ -37,7 +47,7 @@ const ImageSlider = ({
             </button>
           )}
           <ImageCarousel
-            images={images}
+            images={validImages}
             type={type}
             imageSize={imageSize}
             imageHeight={192}
@@ -50,7 +60,7 @@ const ImageSlider = ({
       {allowFullView && (
         <ImageSliderModal
           currentIndex={currentIndex}
-          images={images}
+          images={validImages}
           setCurrentIndex={setCurrentIndex}
           isModalOpen={isModalOpen}
           setIsModalOpen={setIsModalOpen}

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/ImageCarousel.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/ImageCarousel.tsx
@@ -1,4 +1,3 @@
-import type { SliderImage } from '../../../../common/types/projectv2';
 import type { SetState } from '../../../../common/types/common';
 
 import React, { useMemo } from 'react';
@@ -28,8 +27,14 @@ const progressWrapperStyles = {
   background: PROGRESS_STYLES.BACKGROUND_OPACITY,
 };
 
+export interface SliderImage {
+  image: string;
+  description: string | null;
+  id: string;
+}
+
 interface BaseProps {
-  images: SliderImage[] | undefined;
+  images: SliderImage[];
   type: 'coordinate' | 'project';
   imageSize: 'large' | 'medium';
   imageHeight: number;
@@ -68,7 +73,7 @@ const ImageCarousel = (props: CarouselProps) => {
   }, [isModalOpen]);
 
   const processedImages = useMemo(() => {
-    if (!images || images.length === 0) {
+    if (images.length === 0) {
       return [];
     }
 

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/ImageCarousel.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/ImageCarousel.tsx
@@ -25,6 +25,7 @@ const progressStyles = {
 const progressWrapperStyles = {
   height: PROGRESS_STYLES.HEIGHT,
   background: PROGRESS_STYLES.BACKGROUND_OPACITY,
+  overflow: 'hidden',
 };
 
 export interface SliderImage {

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/ImageSliderModal.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/ImageSliderModal.tsx
@@ -74,9 +74,10 @@ const ImageSliderModal = ({
             imageSize={'large'}
             imageHeight={isMobile ? 220 : 600}
             isMobile={isMobile}
-            setCurrentIndex={setCurrentIndex}
+            isModalOpen={true}
+            mode="manual"
             currentIndex={currentIndex}
-            isModalOpen={isModalOpen}
+            setCurrentIndex={setCurrentIndex}
           />
           {isMobile &&
             renderSliderButton('next', styles.nextMobileSliderButton)}

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/ImageSliderModal.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/ImageSliderModal.tsx
@@ -1,5 +1,5 @@
 import type { SetState } from '../../../../common/types/common';
-import type { Image } from '@planet-sdk/common';
+import type { SliderImage } from './ImageCarousel';
 
 import { Modal } from '@mui/material';
 import SliderButton from './SliderButton';
@@ -12,7 +12,7 @@ interface ImageSliderModalProps {
   setCurrentIndex: SetState<number>;
   isModalOpen: boolean;
   setIsModalOpen: SetState<boolean>;
-  images: Image[];
+  images: SliderImage[];
   isMobile: boolean;
   type: 'coordinate' | 'project';
 }


### PR DESCRIPTION
This PR addresses multiple bugs and improves maintainability for the ImageSlider

- **Fixes image slider autorotation issues:** Ensures that the slider auto-rotates correctly in auto (non-modal) mode and disables autorotation in manual/modal mode. 
- **Refactors ImageCarousel:** Separates logic for manual (modal) and auto (carousel) modes using discriminated union props, improving code clarity and future extensibility.
- **Handles empty image values:** Filters out images with missing or empty URLs, preventing rendering of blank slides, and inconsistent counter values.
- **Refactors types:** sets up SliderImage type within ImageCarousel.tsx and removes Slider/ImageSlider types from src/features/common/types/projectv2.d.ts
- **Progress Bar UI fix:** Hides overflow of progress bar outside wrapper to avoid the green bar spilling outside the wrapper, resulting in rectangular corners at the left of each step when the slide changed.

**Bugs addressed:**
- Auto-rotation stopped after switching to second image due to feedback loop between Stories component and external state management
- Empty images passed in to the ImageSlider resulted in a inconsistent counter value in modal view. To better illustrate this problem, consider the following case where`images` contained 10 items, 4 of which contained `image: ""` or `image: null`
- Minor layout issue with progress bar spilling outside it's wrapper

    ```
    [
      {
        "id": "coord_ocvk36O5yzV3U1zkhOYJc6hx",
        "image": "632cbe2853643511957174.jpg",
        "description": "Sample Tree #18188"
      },
      {
        "id": "coord_oRXdSH031BA6ysmWtOBK5yfi",
        "image": "",
        "description": "Sample Tree #18190"
      },
      {
        "id": "coord_E9aJheIFUum5zFfiUXGMAnui",
        "image": "632cbe4db9fa0069998301.jpg",
        "description": "Sample Tree #18189"
      },
      {
        "id": "coord_v0VSRaHJkoLeiC4Mi7DX22UT",
        "image": "",
        "description": "Sample Tree #18187"
      }.....
    ```
    In this case, the counter would show a total of 6 images, but the value of the current position would be based on the index within an array of size 10, leading to a counter sequence like 1/6, 3/6, 5/6, 7/6, 8/6, 10/6.
    
 To reproduce this case: https://dev.pp.eco/en/yucatan?ploc=ALZS16
 After the fix: https://planet-webapp-multi-tenancy-setup-git-hotfix-i-3d2790-planetapp.vercel.app/en/yucatan?ploc=ALZS16