### PR TITLE
Update API endpoint for fetching interventions in ProjectDetails

### DIFF
--- a/src/features/projectsV2/ProjectDetails/index.tsx
+++ b/src/features/projectsV2/ProjectDetails/index.tsx
@@ -60,8 +60,13 @@ const ProjectDetails = ({
     setIsLoading(true);
     try {
       const result = await getApi<PlantLocation[]>(
-        `/app/plantLocations/${projectId}`,
-        { queryParams: { _scope: 'extended' } }
+        `/app/interventions/${projectId}`,
+        {
+          queryParams: {
+            // Fetches sampleInterventions within each intervention
+            _scope: 'extended',
+          },
+        }
       );
       setPlantLocations(result);
     } catch (err) {


### PR DESCRIPTION
Change the API endpoint used to fetch interventions from 

`/app/plantLocations/:projectId` to 

`/app/interventions/:projectId`