### PR TITLE
Add self-gift detection to contributions procedure

### DIFF
--- a/src/features/common/types/myForest.d.ts
+++ b/src/features/common/types/myForest.d.ts
@@ -137,6 +137,7 @@ export type ContributionsQueryResult = {
   geometry: Point | Polygon | null;
   country: CountryCode | '';
   giftMethod: string | null;
+  isSelfGift: boolean | null;
   giftRecipient: string | null;
   giftType: string | null;
 };


### PR DESCRIPTION
Introduce self-gift detection in the contributions process by calculating an `isSelfGift` flag in the SQL query. Update donation handling to exclude self-gifts from the contributions.