### PR TITLE
Refactors geocoding logic into reusable utility module

### DIFF
--- a/public/static/locales/en/manageProjects.json
+++ b/public/static/locales/en/manageProjects.json
@@ -224,7 +224,6 @@
     "addProjectDescription": "You're few steps away from showcasing your work on the Plant-for-the-Planet platform.",
     "createProjectsEnglishOnly": "<noteLabel>Important: </noteLabel>Please create projects with English language setting only.",
     "contactSupportEmail": "If you need any help contact us at <supportLink>support@plant-for-the-planet.org</supportLink> ",
-    "wrongCoordinates": "Wrong Coordinates",
     "actionInfo": "The actions your organization is taking to conserve the ecosystem.",
     "mainChallengeInfo": "The biggest challenge this project is facing.",
     "motivationInfo": "The motivation behind protecting this specific ecosystem.",
@@ -245,6 +244,11 @@
     "annualReport": "Latest annual report",
     "financialReport": "Latest audited financial report",
     "PlantingReport": "Project Progress Report",
-    "siteCount": "Site {siteId} of {totalCount}"
+    "siteCount": "Site {siteId} of {totalCount}",
+    "coordinateError": {
+      "seaCoordinates": "The selected location appears to be in the sea. Please choose a nearby point on land.",
+      "latitudeRange": "Latitude must be between -90 and 90.",
+      "longitudeRange": "Longitude must be between -180 and 180."
+    }
   }
 }

--- a/src/features/user/CompleteSignup/index.tsx
+++ b/src/features/user/CompleteSignup/index.tsx
@@ -32,7 +32,7 @@ import {
   getAddressSuggestions,
 } from '../../../utils/geocoder';
 import { useDebouncedEffect } from '../../../utils/useDebouncedEffect';
-import { getPostalRegex } from '../../../utils/geocoder';
+import { getPostalRegex } from '../../../utils/addressManagement';
 
 const MuiTextField = styled(TextField)(() => {
   return {

--- a/src/features/user/CompleteSignup/index.tsx
+++ b/src/features/user/CompleteSignup/index.tsx
@@ -77,7 +77,7 @@ export default function CompleteSignup(): ReactElement | null {
   const [submit, setSubmit] = useState(false);
   //  snackbars (for warnings, success messages, errors)
   const [snackbarOpen, setSnackbarOpen] = useState(false);
-  const [addressInput, setAddressInput] = useState<string | null>(null);
+  const [addressInput, setAddressInput] = useState('');
 
   const postalRegex = useMemo(() => getPostalRegex(country), [country]);
   const profileTypes = [
@@ -214,13 +214,21 @@ export default function CompleteSignup(): ReactElement | null {
 
   useDebouncedEffect(
     () => {
-      if (addressInput) {
-        handleSuggestAddress(addressInput);
+      const trimmedInput = addressInput.trim();
+
+      // Clear suggestions if input is empty or just whitespace
+      if (trimmedInput === '') {
+        setAddressSuggestions([]);
+        return;
       }
+
+      // Fetch suggestions only if input is meaningful (e.g., length > 3)
+      handleSuggestAddress(trimmedInput);
     },
     700,
     [addressInput]
   );
+
   if (
     !contextLoaded ||
     (contextLoaded && token && user) ||

--- a/src/features/user/CompleteSignup/index.tsx
+++ b/src/features/user/CompleteSignup/index.tsx
@@ -212,7 +212,7 @@ export default function CompleteSignup(): ReactElement | null {
     [country]
   );
 
-  const handleGetAddress = useCallback(
+  const handleAddressSelection = useCallback(
     async (value: string) => {
       try {
         const details = await getAddressDetailsFromText(value);
@@ -438,7 +438,7 @@ export default function CompleteSignup(): ReactElement | null {
                             <div
                               key={index}
                               onMouseDown={() => {
-                                handleGetAddress(suggestion.text);
+                                handleAddressSelection(suggestion.text);
                               }}
                               className="suggestion"
                             >

--- a/src/features/user/CompleteSignup/index.tsx
+++ b/src/features/user/CompleteSignup/index.tsx
@@ -111,7 +111,7 @@ export default function CompleteSignup(): ReactElement | null {
   useEffect(() => {
     // This will remove field values which do not exist for the new type
     reset();
-  }, [type]);
+  }, [type, reset]);
 
   useEffect(() => {
     async function loadFunction() {

--- a/src/features/user/CompleteSignup/index.tsx
+++ b/src/features/user/CompleteSignup/index.tsx
@@ -122,6 +122,10 @@ export default function CompleteSignup(): ReactElement | null {
     }
   }, [contextLoaded, user, token]);
 
+  const handleSnackbarOpen = () => {
+    setSnackbarOpen(true);
+  };
+
   const sendRequest = async (bodyToSend: CreateUserRequest) => {
     setRequestSent(true);
     setIsProcessing(true);
@@ -144,9 +148,6 @@ export default function CompleteSignup(): ReactElement | null {
     }
   };
 
-  const handleSnackbarOpen = () => {
-    setSnackbarOpen(true);
-  };
   const handleSnackbarClose = (event?: SyntheticEvent, reason?: string) => {
     if (reason === 'clickaway') {
       return;

--- a/src/features/user/ManageProjects/StepForm.module.scss
+++ b/src/features/user/ManageProjects/StepForm.module.scss
@@ -293,18 +293,7 @@
   color: $dsFireRed;
   margin-left: 14px;
   margin-top: 3px;
-  max-width: 320px;
-}
-
-.formErrorsAbsolute {
-  position: absolute;
-  bottom: -16px;
-  left: 50%;
-  transform: translateX(-50%);
-  font-family: $primaryFontFamily;
-  font-size: $fontXSmall;
-  color: $dsFireRed;
-  max-width: 320px;
+  // max-width: 320px;
 }
 
 .inputStartAdornment {

--- a/src/features/user/ManageProjects/components/BasicDetails.tsx
+++ b/src/features/user/ManageProjects/components/BasicDetails.tsx
@@ -396,39 +396,42 @@ export default function BasicDetails({
     }
   };
 
-  const handleMapClick = useCallback(async (event: MapEvent) => {
-    const [longitude, latitude] = event.lngLat;
-    setProjectCoords(event.lngLat);
+  const handleMapClick = useCallback(
+    async (event: MapEvent) => {
+      const [longitude, latitude] = event.lngLat;
+      setProjectCoords(event.lngLat);
 
-    try {
-      const result = await getAddressFromCoordinates(latitude, longitude);
+      try {
+        const result = await getAddressFromCoordinates(latitude, longitude);
 
-      if (result?.address.CountryCode) {
-        clearErrors(['latitude', 'longitude']);
-      } else {
-        setError('latitude', {
-          message: t('coordinateError.seaCoordinates'),
-        });
-        setError('longitude', {
-          message: t('coordinateError.seaCoordinates'),
-        });
+        if (result?.address.CountryCode) {
+          clearErrors(['latitude', 'longitude']);
+        } else {
+          setError('latitude', {
+            message: t('coordinateError.seaCoordinates'),
+          });
+          setError('longitude', {
+            message: t('coordinateError.seaCoordinates'),
+          });
+        }
+      } catch (error) {
+        console.error('Reverse geocoding error:', error);
       }
-    } catch (error) {
-      console.error('Reverse geocoding error:', error);
-    }
 
-    setViewPort((prev) => ({
-      ...prev,
-      latitude,
-      longitude,
-      transitionDuration: 400,
-      transitionInterpolator: new FlyToInterpolator(),
-      transitionEasing: d3.easeCubic,
-    }));
+      setViewPort((prev) => ({
+        ...prev,
+        latitude,
+        longitude,
+        transitionDuration: 400,
+        transitionInterpolator: new FlyToInterpolator(),
+        transitionEasing: d3.easeCubic,
+      }));
 
-    setValue('latitude', latitude.toString());
-    setValue('longitude', longitude.toString());
-  }, []);
+      setValue('latitude', latitude.toString());
+      setValue('longitude', longitude.toString());
+    },
+    [setError, clearErrors, setValue, t]
+  );
 
   return (
     <CenteredContainer>

--- a/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressForm.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressForm.tsx
@@ -10,10 +10,6 @@ import { useTranslations } from 'next-intl';
 import { Controller, useForm } from 'react-hook-form';
 import {
   ADDRESS_TYPE,
-  fetchAddressDetails,
-  geocoder,
-  getPostalRegex,
-  suggestAddress,
   validationPattern,
 } from '../../../../../../utils/addressManagement';
 import InlineFormDisplayGroup from '../../../../../common/Layout/Forms/InlineFormDisplayGroup';
@@ -24,6 +20,11 @@ import { allCountries } from '../../../../../../utils/constants/countries';
 import AddressFormButtons from './AddressFormButtons';
 import { useDebouncedEffect } from '../../../../../../utils/useDebouncedEffect';
 import PrimaryAddressToggle from './PrimaryAddressToggle';
+import {
+  getAddressDetailsFromText,
+  getAddressSuggestions,
+  getPostalRegex,
+} from '../../../../../../utils/geocoder';
 
 export type AddressFormData = {
   address: string;
@@ -81,14 +82,14 @@ const AddressForm = ({
   const handleSuggestAddress = useCallback(
     async (value: string) => {
       try {
-        const suggestions = await suggestAddress(value, country);
+        const suggestions = await getAddressSuggestions(value, country);
         setAddressSuggestions(suggestions);
       } catch (error) {
         console.error('Failed to fetch address suggestions:', error);
         setAddressSuggestions([]);
       }
     },
-    [geocoder, country]
+    [country]
   );
 
   useDebouncedEffect(
@@ -104,7 +105,7 @@ const AddressForm = ({
   const handleGetAddress = useCallback(
     async (value: string) => {
       try {
-        const details = await fetchAddressDetails(value);
+        const details = await getAddressDetailsFromText(value);
         if (details) {
           setValue('address', details.address, { shouldValidate: true });
           setValue('city', details.city, { shouldValidate: true });
@@ -115,7 +116,7 @@ const AddressForm = ({
         console.error('Failed to fetch address details:', error);
       }
     },
-    [geocoder, setValue]
+    [setValue]
   );
   const handleAddressSelect = (address: string) => {
     handleGetAddress(address);

--- a/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressForm.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressForm.tsx
@@ -78,7 +78,6 @@ const AddressForm = ({
   const handleInputChange = (value: string) => {
     setInputValue(value);
   };
-
   const handleSuggestAddress = useCallback(
     async (value: string) => {
       try {
@@ -94,9 +93,16 @@ const AddressForm = ({
 
   useDebouncedEffect(
     () => {
-      if (inputValue) {
-        handleSuggestAddress(inputValue);
+      const trimmedInput = inputValue.trim();
+
+      // Clear suggestions if input is empty or just whitespace
+      if (trimmedInput === '') {
+        setAddressSuggestions([]);
+        return;
       }
+
+      // Fetch suggestions only if input is meaningful (e.g., length > 3)
+      handleSuggestAddress(trimmedInput);
     },
     700,
     [inputValue]

--- a/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressForm.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressForm.tsx
@@ -23,8 +23,8 @@ import PrimaryAddressToggle from './PrimaryAddressToggle';
 import {
   getAddressDetailsFromText,
   getAddressSuggestions,
-  getPostalRegex,
 } from '../../../../../../utils/geocoder';
+import { getPostalRegex } from '../../../../../../utils/addressManagement';
 
 export type AddressFormData = {
   address: string;

--- a/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressForm.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressForm.tsx
@@ -119,7 +119,7 @@ const AddressForm = ({
     [inputValue]
   );
 
-  const handleGetAddress = useCallback(
+  const selectAndParseAddress = useCallback(
     async (value: string) => {
       try {
         const details = await getAddressDetailsFromText(value);
@@ -136,7 +136,7 @@ const AddressForm = ({
     [setValue]
   );
   const handleAddressSelect = (address: string) => {
-    handleGetAddress(address);
+    selectAndParseAddress(address);
   };
 
   const resetForm = () => {

--- a/src/utils/addressManagement.ts
+++ b/src/utils/addressManagement.ts
@@ -1,4 +1,7 @@
 import type { Address } from '@planet-sdk/common';
+import type { ExtendedCountryCode } from '../features/common/types/country';
+
+import COUNTRY_ADDRESS_POSTALS from './countryZipCode';
 
 export const ADDRESS_TYPE = {
   PRIMARY: 'primary',
@@ -46,4 +49,20 @@ export const findAddressByType = (
   addressType: 'primary' | 'mailing'
 ) => {
   return addresses.find((address) => address.type === addressType);
+};
+
+/**
+ * Retrieves the postal regex for a given country code.
+ *
+ * This function searches the `COUNTRY_ADDRESS_POSTALS` array for the country matching the provided
+ * `country` code and returns the associated postal regex pattern. If no match is found, it returns `undefined`.
+ *
+ * @param country - The country code for which to retrieve the postal regex.
+ * @returns The postal regex pattern for the given country, or `undefined` if no match is found.
+ */
+export const getPostalRegex = (country: ExtendedCountryCode | '') => {
+  const filteredCountry = COUNTRY_ADDRESS_POSTALS.find(
+    (item) => item.abbrev === country
+  );
+  return filteredCountry?.postal;
 };

--- a/src/utils/addressManagement.ts
+++ b/src/utils/addressManagement.ts
@@ -1,153 +1,49 @@
-import type {Address} from '@planet-sdk/common';
-import type {ExtendedCountryCode} from '../features/common/types/country';
-import type {
-    AddressSuggestionsType,
-    AddressType,
-} from '../features/common/types/geocoder';
-
-import GeocoderArcGIs from 'geocoder-arcgis';
-import COUNTRY_ADDRESS_POSTALS from './countryZipCode';
+import type { Address } from '@planet-sdk/common';
 
 export const ADDRESS_TYPE = {
-    PRIMARY: 'primary',
-    MAILING: 'mailing',
-    OTHER: 'other',
+  PRIMARY: 'primary',
+  MAILING: 'mailing',
+  OTHER: 'other',
 } as const;
 
 export const ADDRESS_ACTIONS = {
-    ADD: 'add',
-    EDIT: 'edit',
-    DELETE: 'delete',
-    SET_PRIMARY: 'setPrimary',
-    SET_BILLING: 'setBilling',
-    UNSET_BILLING: 'unsetBilling',
+  ADD: 'add',
+  EDIT: 'edit',
+  DELETE: 'delete',
+  SET_PRIMARY: 'setPrimary',
+  SET_BILLING: 'setBilling',
+  UNSET_BILLING: 'unsetBilling',
 } as const;
 
 export const ADDRESS_FORM_TYPE = {
-    ADD_ADDRESS: 'add',
-    EDIT_ADDRESS: 'edit',
+  ADD_ADDRESS: 'add',
+  EDIT_ADDRESS: 'edit',
 } as const;
 export const addressTypeOrder = ['primary', 'mailing', 'other'];
 
 export const MAX_ADDRESS_LIMIT = 5;
 
 export const getFormattedAddress = (
-    zipCode: string | null,
-    city: string | null,
-    state: string | null,
-    countryName: string
+  zipCode: string | null,
+  city: string | null,
+  state: string | null,
+  countryName: string
 ) => {
-    return [zipCode, city, state, countryName]
-        .filter(Boolean)
-        .join(', ')
-        .replace(/\s+/g, ' ')
-        .trim();
+  return [zipCode, city, state, countryName]
+    .filter(Boolean)
+    .join(', ')
+    .replace(/\s+/g, ' ')
+    .trim();
 };
 
 export const validationPattern = {
-    address: /^[\p{L}\p{N}\sß.,#/-]+$/u,
-    cityState: /^[\p{L}\sß.,()-]+$/u,
+  address: /^[\p{L}\p{N}\sß.,#/-]+$/u,
+  cityState: /^[\p{L}\sß.,()-]+$/u,
 };
 
 export const findAddressByType = (
-    addresses: Address[],
-    addressType: 'primary' | 'mailing'
+  addresses: Address[],
+  addressType: 'primary' | 'mailing'
 ) => {
-    return addresses.find((address) => address.type === addressType);
-};
-
-export const geocoder = new GeocoderArcGIs(
-    process.env.ESRI_CLIENT_SECRET
-        ? {
-            client_id: process.env.ESRI_CLIENT_ID,
-            client_secret: process.env.ESRI_CLIENT_SECRET,
-        }
-        : {}
-);
-
-/**
- * Suggests address options based on user input.
- *
- * This function queries the geocoder's `suggest` method with the provided input value
- * and optional country code to fetch address suggestions categorized as "Address".
- * It filters out suggestions marked as collections (`isCollection`) to ensure only
- * individual address suggestions are returned.
- *
- * @param value - The input string to search for address suggestions.
- * @param country - The optional country code to narrow down the address suggestions.
- * @returns A promise that resolves to an array of valid address suggestions or an empty array.
- */
-
-export const suggestAddress = async (
-    value: string,
-    country: ExtendedCountryCode | ''
-): Promise<AddressSuggestionsType[]> => {
-    if (value.length > 3) {
-        try {
-            const result = await geocoder.suggest(value, {
-                category: 'Address',
-                countryCode: country,
-            });
-            return result.suggestions.filter(
-                (suggestion: AddressSuggestionsType) => !suggestion.isCollection
-            );
-        } catch (error) {
-            console.log(error);
-            return [];
-        }
-    }
-    return [];
-};
-
-/**
- * Fetches detailed address information based on the input value.
- *
- * This function uses the geocoder's `findAddressCandidates` method to search for
- * address candidates and retrieves key information such as formatted address, city,
- * and postal code (ZIP code). If no candidates are found, it returns `null`.
- *
- * @param value - The input string to search for address details.
- * @returns A promise that resolves to an object containing address details (address, city, zipCode)
- *          or `null` if no candidates are found or an error occurs.
- */
-export const fetchAddressDetails = async (
-    value: string
-): Promise<{
-    address: string;
-    city: string;
-    zipCode: string;
-} | null> => {
-    try {
-        const result: AddressType = await geocoder.findAddressCandidates(value, {
-            outfields: '*',
-        });
-        if (result.candidates.length > 0) {
-            const {ShortLabel, City, Postal} = result.candidates[0].attributes;
-            return {
-                address: ShortLabel,
-                city: City,
-                zipCode: Postal,
-            };
-        }
-        return null;
-    } catch (error) {
-        console.log(error);
-        return null;
-    }
-};
-
-/**
- * Retrieves the postal regex for a given country code.
- *
- * This function searches the `COUNTRY_ADDRESS_POSTALS` array for the country matching the provided
- * `country` code and returns the associated postal regex pattern. If no match is found, it returns `undefined`.
- *
- * @param country - The country code for which to retrieve the postal regex.
- * @returns The postal regex pattern for the given country, or `undefined` if no match is found.
- */
-export const getPostalRegex = (country: ExtendedCountryCode | '') => {
-    const filteredCountry = COUNTRY_ADDRESS_POSTALS.find(
-        (item) => item.abbrev === country
-    );
-    return filteredCountry?.postal;
+  return addresses.find((address) => address.type === addressType);
 };

--- a/src/utils/geocoder.ts
+++ b/src/utils/geocoder.ts
@@ -1,0 +1,102 @@
+import type {
+  AddressSuggestionsType,
+  AddressType,
+  ReverseAddress,
+} from '../features/common/types/geocoder';
+import type { ExtendedCountryCode } from '../features/common/types/country';
+
+import GeocoderArcGIS from 'geocoder-arcgis';
+import COUNTRY_ADDRESS_POSTALS from './countryZipCode';
+
+export const geocoder = new GeocoderArcGIS(
+  process.env.ESRI_CLIENT_SECRET
+    ? {
+        client_id: process.env.ESRI_CLIENT_ID,
+        client_secret: process.env.ESRI_CLIENT_SECRET,
+      }
+    : {}
+);
+
+/**
+ * Provides address suggestions for a given input string and country.
+ */
+export const getAddressSuggestions = async (
+  value: string,
+  country: string
+): Promise<AddressSuggestionsType[]> => {
+  if (value.length <= 3) return [];
+  try {
+    const result = await geocoder.suggest(value, {
+      category: 'Address',
+      countryCode: country,
+    });
+    return result.suggestions.filter(
+      (s: AddressSuggestionsType) => !s.isCollection
+    );
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+};
+
+/**
+ * Fetches full address details (short label, city, zip code) for a given input string.
+ */
+export const getAddressDetailsFromText = async (
+  value: string
+): Promise<{
+  address: string;
+  city: string;
+  zipCode: string;
+} | null> => {
+  try {
+    const result: AddressType = await geocoder.findAddressCandidates(value, {
+      outfields: '*',
+    });
+    const candidate = result.candidates[0]?.attributes;
+    if (!candidate) return null;
+    return {
+      address: candidate.ShortLabel,
+      city: candidate.City,
+      zipCode: candidate.Postal,
+    };
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
+};
+
+/**
+ * Performs reverse geocoding to get address details from latitude and longitude.
+ */
+export const getAddressFromCoordinates = async (
+  lat: number,
+  long: number
+): Promise<ReverseAddress | null> => {
+  try {
+    const result = await geocoder.reverse(`${long}, ${lat}`, {
+      maxLocations: 10,
+      distance: 100,
+    });
+    return result;
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
+};
+
+/**
+ * Retrieves the postal regex for a given country code.
+ *
+ * This function searches the `COUNTRY_ADDRESS_POSTALS` array for the country matching the provided
+ * `country` code and returns the associated postal regex pattern. If no match is found, it returns `undefined`.
+ *
+ * @param country - The country code for which to retrieve the postal regex.
+ * @returns The postal regex pattern for the given country, or `undefined` if no match is found.
+ */
+export const getPostalRegex = (country: ExtendedCountryCode | '') => {
+  const filteredCountry = COUNTRY_ADDRESS_POSTALS.find(
+    (item) => item.abbrev === country
+  );
+  return filteredCountry?.postal;
+};

--- a/src/utils/geocoder.ts
+++ b/src/utils/geocoder.ts
@@ -8,7 +8,7 @@ import type { ExtendedCountryCode } from '../features/common/types/country';
 import GeocoderArcGIS from 'geocoder-arcgis';
 import COUNTRY_ADDRESS_POSTALS from './countryZipCode';
 
-export const geocoder = new GeocoderArcGIS(
+const geocoder = new GeocoderArcGIS(
   process.env.ESRI_CLIENT_SECRET
     ? {
         client_id: process.env.ESRI_CLIENT_ID,
@@ -34,7 +34,7 @@ export const getAddressSuggestions = async (
       (s: AddressSuggestionsType) => !s.isCollection
     );
   } catch (error) {
-    console.log(error);
+    console.error('Failed to fetch address suggestions:', error);
     return [];
   }
 };
@@ -61,7 +61,7 @@ export const getAddressDetailsFromText = async (
       zipCode: candidate.Postal,
     };
   } catch (error) {
-    console.log(error);
+    console.error('Failed to fetch address :', error);
     return null;
   }
 };
@@ -73,6 +73,11 @@ export const getAddressFromCoordinates = async (
   lat: number,
   long: number
 ): Promise<ReverseAddress | null> => {
+  if (lat < -90 || lat > 90 || long < -180 || long > 180) {
+    console.error('Invalid coordinates provided:', { lat, long });
+    return null;
+  }
+
   try {
     const result = await geocoder.reverse(`${long}, ${lat}`, {
       maxLocations: 10,
@@ -80,7 +85,7 @@ export const getAddressFromCoordinates = async (
     });
     return result;
   } catch (error) {
-    console.log(error);
+    console.error('Failed to fetch address:', error);
     return null;
   }
 };

--- a/src/utils/geocoder.ts
+++ b/src/utils/geocoder.ts
@@ -39,6 +39,15 @@ export const getAddressSuggestions = async (
 
 /**
  * Fetches full address details (short label, city, zip code) for a given input string.
++ * 
++ * @dependency ArcGIS API Fields - This function uses 3 specific fields from Attributes:
++ * - ShortLabel: The formatted address string  
++ * - City: The city name
++ * - Postal: The postal/zip code
++ * See geocoder.d.ts Attributes interface for all 50+ available fields.
++ *
+ * @param value - The input string to search for address details
+ * @returns Object with address, city, zipCode or null if no results
  */
 export const getAddressDetailsFromText = async (
   value: string
@@ -49,7 +58,7 @@ export const getAddressDetailsFromText = async (
 } | null> => {
   try {
     const result: AddressType = await geocoder.findAddressCandidates(value, {
-      outfields: '*',
+      outfields: 'ShortLabel,City,Postal',
     });
     const candidate = result.candidates[0]?.attributes;
     if (!candidate) return null;

--- a/src/utils/geocoder.ts
+++ b/src/utils/geocoder.ts
@@ -3,13 +3,11 @@ import type {
   AddressType,
   ReverseAddress,
 } from '../features/common/types/geocoder';
-import type { ExtendedCountryCode } from '../features/common/types/country';
 
 import GeocoderArcGIS from 'geocoder-arcgis';
-import COUNTRY_ADDRESS_POSTALS from './countryZipCode';
 
 const geocoder = new GeocoderArcGIS(
-  process.env.ESRI_CLIENT_SECRET
+  process.env.ESRI_CLIENT_ID && process.env.ESRI_CLIENT_SECRET
     ? {
         client_id: process.env.ESRI_CLIENT_ID,
         client_secret: process.env.ESRI_CLIENT_SECRET,
@@ -88,20 +86,4 @@ export const getAddressFromCoordinates = async (
     console.error('Failed to fetch address:', error);
     return null;
   }
-};
-
-/**
- * Retrieves the postal regex for a given country code.
- *
- * This function searches the `COUNTRY_ADDRESS_POSTALS` array for the country matching the provided
- * `country` code and returns the associated postal regex pattern. If no match is found, it returns `undefined`.
- *
- * @param country - The country code for which to retrieve the postal regex.
- * @returns The postal regex pattern for the given country, or `undefined` if no match is found.
- */
-export const getPostalRegex = (country: ExtendedCountryCode | '') => {
-  const filteredCountry = COUNTRY_ADDRESS_POSTALS.find(
-    (item) => item.abbrev === country
-  );
-  return filteredCountry?.postal;
 };


### PR DESCRIPTION
This PR refactors and centralizes `geocoding`-related logic into a reusable utility module. Key changes include:

- Moved address suggestion, detail lookup, and reverse geocoding into a shared `geocoder.ts` utility.
- Replaced direct API calls in components with standardized utility function calls.
- Improved code readability and maintainability across components using geocoding.
- Prepares the codebase for easier service replacement or future enhancements (e.g., switching geocoding providers).


Why :
Previously, geocoding logic was duplicated across multiple components, making it harder to maintain and update. This change improves modularity and encourages reuse of standardized methods.


