### PR TITLE
Fix theme provider to respect darkModeEnabled configuration

### DIFF
--- a/src/theme/themeContext.tsx
+++ b/src/theme/themeContext.tsx
@@ -1,25 +1,33 @@
 import type { ReactNode } from 'react';
+import type { SetState } from '../features/common/types/common';
 
-import React from 'react';
+import { useEffect, useState, createContext, useContext } from 'react';
 import { useTenant } from '../features/common/Layout/TenantContext';
 
-export const ThemeContext = React.createContext({
+type Theme = 'theme-light' | 'theme-dark';
+
+export const ThemeContext = createContext<{
+  theme: Theme;
+  setTheme: SetState<Theme>;
+}>({
   theme: 'theme-light',
-  setTheme: (theme: any) => theme,
+  setTheme: () => {},
 });
 
 export default function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = React.useState('theme-light');
+  const [theme, setTheme] = useState<Theme>('theme-light');
   const { tenantConfig } = useTenant();
 
-  React.useEffect(() => {
-    if (typeof window !== 'undefined' && tenantConfig.config.darkModeEnabled) {
-      if (localStorage.getItem('theme')) {
-        if (localStorage.getItem('theme') === 'theme-light') {
-          setTheme('theme-light');
-        } else {
-          setTheme('theme-dark');
-        }
+  useEffect(() => {
+    if (tenantConfig.config.darkModeEnabled !== true) {
+      setTheme('theme-light');
+      return;
+    }
+
+    if (typeof window !== 'undefined') {
+      const storedTheme = localStorage.getItem('theme');
+      if (storedTheme) {
+        setTheme(storedTheme === 'theme-light' ? 'theme-light' : 'theme-dark');
       } else {
         if (
           window.matchMedia &&
@@ -33,9 +41,9 @@ export default function ThemeProvider({ children }: { children: ReactNode }) {
         }
       }
     }
-  }, []);
+  }, [tenantConfig.config.darkModeEnabled]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (typeof window !== 'undefined') {
       localStorage.setItem('theme', theme);
     }
@@ -49,5 +57,5 @@ export default function ThemeProvider({ children }: { children: ReactNode }) {
 }
 
 export function useTheme() {
-  return React.useContext(ThemeContext);
+  return useContext(ThemeContext);
 }


### PR DESCRIPTION
### Problem
At times, the theme was incorrectly being set to dark mode even when `tenantConfig.config.darkModeEnabled` was false, causing UI issues on systems where users had dark mode as their system preference.

### Solution
- Added early return in useEffect when `darkModeEnabled !== true` to force light theme
- Added `tenantConfig.config.darkModeEnabled` to dependency array to handle config changes
- Optimized localStorage calls by storing result in variable
- Improved TypeScript types using custom `SetState<Theme>` type

### Changes
- Theme will always be `theme-light` when dark mode is disabled in the tenant config
- localStorage and system preference detection only runs when dark mode is enabled
- Maintains existing localStorage behavior for future dark mode rollout