### PR TITLE
Switch to bundled turf imports for `getPointCoordinates` to resolve Vercel deployment failures

### DIFF
--- a/src/utils/getPointCoordinates.ts
+++ b/src/utils/getPointCoordinates.ts
@@ -1,7 +1,6 @@
 import type { Point, Polygon, Position } from 'geojson';
 
-import centerOfMass from '@turf/center-of-mass';
-import { multiPoint } from '@turf/helpers';
+import { centerOfMass, multiPoint } from '@turf/turf';
 
 /**
  * Converts a GeoJSON Polygon or Point geometry to a Point geometry


### PR DESCRIPTION
### Problem
tRPC endpoints using `getPointCoordinates` were failing on Vercel with ESM compatibility errors:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module /var/task/node_modules/concaveman/index.js not supported
```

### Root Cause
- `@turf/center-of-mass` depends on `@turf/convex@5.1.5`
- Node.js resolved to `@turf/convex`'s CommonJS build (`main.js`) which uses `require('concaveman')`
- `concaveman@2.0.0` is ESM-only 
- Node.js 22 strictly prohibits CommonJS `require()` of ESM modules

### Solution
Use the bundled `@turf/turf` import instead of individual packages for `getPointCoordinates`. The bundle properly handles module compatibility and avoids the problematic dependency chain.

### Changes
- Replace individual turf imports with bundled import in `getPointCoordinates.ts`
- No functional changes to the code logic
- Resolves server-side deployment issues while maintaining identical functionality