### PR TITLE
refactor: extract metadata formatting into reusable helpers

### DIFF
--- a/src/features/common/types/intervention.d.ts
+++ b/src/features/common/types/intervention.d.ts
@@ -89,8 +89,8 @@ export interface SampleTreeRegistration extends InterventionBase {
 
 export interface Metadata {
   app: App;
-  public: unknown[];
-  private?: unknown[];
+  public: unknown;
+  private: unknown;
 }
 
 export interface App {

--- a/src/features/projectsV2/ProjectDetails/components/MultiTreeInfo.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/MultiTreeInfo.tsx
@@ -4,7 +4,7 @@ import type {
 } from '../../../common/types/intervention';
 import type { SetState } from '../../../common/types/common';
 
-import { useMemo } from 'react';
+import { Fragment, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import * as turf from '@turf/turf';
 import styles from '../styles/InterventionInfo.module.scss';
@@ -62,7 +62,7 @@ const MultiTreeInfo = ({
     sampleInterventionSpeciesImages.length > 0;
 
   const content = [
-    <>
+    <Fragment key="headerAndImage">
       <MultiTreeInfoHeader
         key="multiTreeInfoHeader"
         hid={activeMultiTree.hid}
@@ -79,7 +79,7 @@ const MultiTreeInfo = ({
           allowFullView={!isMobile}
         />
       )}
-    </>,
+    </Fragment>,
     <PlantingDetails
       key="plantingDetails"
       plantingDensity={plantingDensity}

--- a/src/features/projectsV2/ProjectDetails/components/OtherInterventionInfo.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/OtherInterventionInfo.tsx
@@ -4,7 +4,7 @@ import type {
 } from '../../../common/types/intervention';
 import type { SetState } from '../../../common/types/common';
 
-import { useMemo } from 'react';
+import { useMemo, Fragment } from 'react';
 import { useTranslations } from 'next-intl';
 import styles from '../styles/InterventionInfo.module.scss';
 import SpeciesPlanted from './microComponents/SpeciesPlanted';
@@ -68,7 +68,7 @@ const OtherInterventionInfo = ({
     sampleInterventionSpeciesImages?.length > 0;
 
   const content = [
-    <>
+    <Fragment key="interventionHeaderAndImage">
       <OtherInterventionInfoHeader
         hid={interventionInfo.hid}
         interventionType={interventionInfo.type}
@@ -85,7 +85,7 @@ const OtherInterventionInfo = ({
           allowFullView={!isMobile}
         />
       )}
-    </>,
+    </Fragment>,
     hasInterventionMetadata && (
       <OtherInterventionMetadata
         key="plantingDetails"

--- a/src/features/projectsV2/ProjectDetails/components/OtherInterventionInfo.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/OtherInterventionInfo.tsx
@@ -14,7 +14,7 @@ import ImageSlider from './ImageSlider';
 import MobileInfoSwiper from '../../MobileInfoSwiper';
 import OtherInterventionMetadata from './microComponents/OtherInterventionMetadata';
 import OtherInterventionInfoHeader from './microComponents/OtherInterventionInfoHeader';
-import { createCardData } from '../../../../utils/projectV2';
+import { prepareInterventionMetadata } from '../../../../utils/projectV2';
 
 interface Props {
   hoveredIntervention?: OtherInterventions | null;
@@ -31,12 +31,15 @@ const OtherInterventionInfo = ({
 }: Props) => {
   const interventionInfo = hoveredIntervention || activeIntervention;
   if (!interventionInfo) return null;
+  const tProjectDetails = useTranslations('ProjectDetails');
+  const interventionMetadata = prepareInterventionMetadata(interventionInfo);
+
   const sampleTrees = interventionInfo.sampleInterventions || [];
   const plantedSpecies = interventionInfo.plantedSpecies || [];
   const hasSampleTrees = sampleTrees.length > 0;
   const hasPlantedSpecies = plantedSpecies.length > 0;
+  const hasInterventionMetadata = interventionMetadata.length > 0;
 
-  const tProjectDetails = useTranslations('ProjectDetails');
   const { totalTreesCount } = useMemo(() => {
     const totalTreesCount = hasPlantedSpecies
       ? plantedSpecies.reduce(
@@ -64,8 +67,6 @@ const OtherInterventionInfo = ({
     sampleInterventionSpeciesImages !== undefined &&
     sampleInterventionSpeciesImages?.length > 0;
 
-  const cleanedPublicMetadata = createCardData(interventionInfo);
-
   const content = [
     <>
       <OtherInterventionInfoHeader
@@ -85,10 +86,10 @@ const OtherInterventionInfo = ({
         />
       )}
     </>,
-    cleanedPublicMetadata.length > 0 && (
+    hasInterventionMetadata && (
       <OtherInterventionMetadata
         key="plantingDetails"
-        metadata={cleanedPublicMetadata}
+        metadata={interventionMetadata}
         plantDate={interventionInfo.interventionStartDate}
         type={interventionInfo.type}
       />


### PR DESCRIPTION
[Resolves](https://github.com/Plant-for-the-Planet-org/planet-webapp/issues/2646)

This PR refactors the metadata processing logic from `createCardData ` into smaller, well-defined helper functions. The goal is to improve readability, maintainability, and type safety.


1. Replaced `isJsonString `with `tryParseJson`
      - Prevents thrown exceptions when parsing JSON strings
      - Returns null for invalid JSON instead of false
2. Added `isProcessableMetadata `type guard to check metadata is a non array object before processing
3. Extracted `formatMetadataEntry `to handle:
      - Skipping excluded keys from `nonDisplayPublicMetadataKeys`
      - Direct string value handling
      - Parsing JSON strings inside value
      - Returning consistent { key, value } objects or null if invalid
4. Updated main function to `prepareInterventionMetadata`
     - Uses Object.entries + map + filter for a cleaner transformation pipeline
5. Improved type safety by leveraging TypeScript type guards and narrowing

Benefits :

- Readability: Core logic is now split into small, self-explanatory functions
- Maintainability: Easier to modify parsing or filtering rules without touching the main function
- Type Safety: Reduced reliance on type assertions, added explicit type checks
- Error Handling: No risk of unhandled exceptions during JSON parsing