### PR TITLE
Hotfix/zoom to project site validation

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -39,6 +39,7 @@
     "MAXAR",
     "MODIS",
     "MONTHNAME",
+    "moveend",
     "multiday",
     "multipolygons",
     "Oceanforce",

--- a/src/utils/mapsV2/zoomToProjectSite.ts
+++ b/src/utils/mapsV2/zoomToProjectSite.ts
@@ -29,9 +29,13 @@ export function zoomInToProjectSite(
   }
 
   const map = mapRef.current.getMap ? mapRef.current.getMap() : mapRef.current;
-  const feature = geoJson.features[selectedSite];
-  if (!feature) {
-    console.warn(`Selected site ${selectedSite} not found in geoJson`);
+
+  const feature = geoJson.features?.[selectedSite];
+  if (!feature || !feature.geometry) {
+    console.warn(
+      'zoomInToProjectSite: invalid selectedSite or missing geometry',
+      { selectedSite }
+    );
     return;
   }
   // Get the bounding box of the selected site

--- a/src/utils/mapsV2/zoomToProjectSite.ts
+++ b/src/utils/mapsV2/zoomToProjectSite.ts
@@ -34,7 +34,7 @@ export function zoomInToProjectSite(
   if (!feature || !feature.geometry) {
     console.warn(
       'zoomInToProjectSite: invalid selectedSite or missing geometry',
-      { selectedSite }
+      { selectedSite, featuresLength: geoJson.features?.length ?? 0 }
     );
     return;
   }

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -177,8 +177,13 @@ export function getFeaturesAtPoint(mapRef: MapRef, point: PointLike) {
   if (!mapRef.current) return;
   const map = mapRef.current.getMap();
 
+  const availableLayers = INTERACTIVE_LAYERS.filter((layerId) =>
+    map.getLayer(layerId)
+  );
+  if (availableLayers.length === 0) return [];
+
   const features = map.queryRenderedFeatures(point, {
-    layers: INTERACTIVE_LAYERS,
+    layers: availableLayers,
   });
 
   if (features.length === 0) {

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -180,7 +180,11 @@ export function getFeaturesAtPoint(mapRef: MapRef, point: PointLike) {
   const availableLayers = INTERACTIVE_LAYERS.filter((layerId) =>
     map.getLayer(layerId)
   );
-  if (availableLayers.length === 0) return [];
+
+  if (availableLayers.length === 0) {
+    map.getCanvas().style.cursor = '';
+    return [];
+  }
 
   const features = map.queryRenderedFeatures(point, {
     layers: availableLayers,

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -173,16 +173,20 @@ export const isValidClassification = (
  * @returns An array of features under the point, or undefined if the map is not ready. Returns an empty array if no features are found.
  */
 
-export function getFeaturesAtPoint(mapRef: MapRef, point: PointLike) {
+export function getFeaturesAtPoint(
+  mapRef: MapRef,
+  point: PointLike
+): MapGeoJSONFeature[] | undefined {
   if (!mapRef.current) return;
   const map = mapRef.current.getMap();
+  const canvas = map.getCanvas();
 
   const availableLayers = INTERACTIVE_LAYERS.filter((layerId) =>
     map.getLayer(layerId)
   );
 
   if (availableLayers.length === 0) {
-    map.getCanvas().style.cursor = '';
+    canvas.style.cursor = '';
     return [];
   }
 
@@ -191,11 +195,11 @@ export function getFeaturesAtPoint(mapRef: MapRef, point: PointLike) {
   });
 
   if (features.length === 0) {
-    map.getCanvas().style.cursor = '';
+    canvas.style.cursor = '';
     return [];
   }
 
-  map.getCanvas().style.cursor = 'pointer';
+  canvas.style.cursor = 'pointer';
   return features;
 }
 


### PR DESCRIPTION
[Fixes](https://github.com/Plant-for-the-Planet-org/planet-webapp/issues/2652)

Context :
- `zoomInToProjectSite `directly accessed `geoJson.features[selectedSite] `without validating index or geometry, which could lead to runtime errors.
- `getFeaturesAtPoint `queried all `INTERACTIVE_LAYERS`, including ones not yet added to the map, causing` layer does not exist `errors.
<img width="605" height="539" alt="image" src="https://github.com/user-attachments/assets/5f4c4418-2327-4e32-be20-c97747591b94" />


Solutions :
- Added guard clause in `zoomInToProjectSite `to validate `selectedSite `and ensure geometry exists.
- Updated `getFeaturesAtPoint `to filter only layers that exist in the map before querying features.

Result :
- Prevents runtime crashes due to invalid indices or missing geometry.
- Eliminates errors when querying non-existent layers.
