### PR TITLE
refactor:  refactor project snippet back button logic

### DIFF
--- a/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
@@ -2,7 +2,7 @@ import type { ImageSectionProps } from '..';
 
 import { useCallback, useContext, useState } from 'react';
 import { useRouter } from 'next/router';
-import { useTranslations, useLocale } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import getImageUrl from '../../../../utils/getImageURL';
 import ProjectBadge from './ProjectBadge';
 import ProjectTypeIcon from '../../../common/ProjectTypeIcon';
@@ -13,7 +13,7 @@ import TopProjectReports from './TopProjectReports';
 import styles from '../styles/ProjectSnippet.module.scss';
 import BackButton from '../../../../../public/assets/images/icons/BackButton';
 import { ParamsContext } from '../../../common/Layout/QueryParamsContext';
-import { getSanitizedLocalizedPath } from '../../../../utils/projectV2';
+import useLocalizedPath from '../../../../hooks/useLocalizedPath';
 
 const MAX_NAME_LENGTH = 32;
 
@@ -38,7 +38,7 @@ const ImageSection = (props: ImageSectionProps) => {
 
   const tProjectsCommon = useTranslations('Project');
   const router = useRouter();
-  const locale = useLocale();
+  const { localizedPath } = useLocalizedPath();
   const { embed, callbackUrl, showBackIcon } = useContext(ParamsContext);
   const isEmbed = embed === 'true';
   const showBackButton =
@@ -48,17 +48,18 @@ const ImageSection = (props: ImageSectionProps) => {
     if (setPreventShallowPush) setPreventShallowPush(true);
 
     const previousPageRoute = sessionStorage.getItem('backNavigationUrl');
-    const defaultRoute = `/${locale}`;
+    const defaultRoute = `/`;
 
     const baseRoute = previousPageRoute || defaultRoute;
     const isAbsoluteUrl =
       baseRoute.startsWith('http://') || baseRoute.startsWith('https://');
 
     // Get the final route, localizing relative path
-    const finalRoute = isAbsoluteUrl
+    const path = isAbsoluteUrl
       ? baseRoute.split('?')[0] // For absolute URLs, just strip query params
-      : getSanitizedLocalizedPath(baseRoute, locale);
+      : localizedPath(baseRoute);
 
+    const pathWithoutQuery = path.split('?')[0];
     // Handle query parameters for the new navigation
     const queryParams = isEmbed
       ? {
@@ -70,7 +71,7 @@ const ImageSection = (props: ImageSectionProps) => {
     // Navigate and clean up
     router
       .push({
-        pathname: finalRoute,
+        pathname: pathWithoutQuery,
         query: isAbsoluteUrl ? {} : queryParams,
       })
       .then(() => sessionStorage.removeItem('backNavigationUrl'))

--- a/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
@@ -59,6 +59,7 @@ const ImageSection = (props: ImageSectionProps) => {
       ? baseRoute.split('?')[0] // For absolute URLs, just strip query params
       : localizedPath(baseRoute);
 
+    // Cleans up internal routing parameters like `locale`, `slug` etc.
     const pathWithoutQuery = path.split('?')[0];
     // Handle query parameters for the new navigation
     const queryParams = isEmbed

--- a/src/utils/getLocalizedPath.ts
+++ b/src/utils/getLocalizedPath.ts
@@ -46,7 +46,7 @@ function isSupportedLocale(locale: string): locale is Locale {
  *   string and hash fragment.
  */
 
-function removeLocaleFromPath(pathname: string): string {
+export function removeLocaleFromPath(pathname: string): string {
   const normalizedPath = pathname.startsWith('/') ? pathname : `/${pathname}`;
   const match = normalizedPath.match(/^([^?#]*)([?#].*)?$/);
   const base = match?.[1] ?? normalizedPath;

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -315,9 +315,9 @@ export const generateProjectLink = (
   projectGuid: string,
   routerAsPath: string //e.g. /en/yucatan, /en
 ) => {
-  const pathWithoutLocale = removeLocaleFromPath(routerAsPath);
+  // just use routerAsPath as-is, let localizedPath handle locale stripping
   return `/${projectGuid}?backNavigationUrl=${encodeURIComponent(
-    pathWithoutLocale
+    routerAsPath
   )}`;
 };
 
@@ -339,53 +339,6 @@ export const areMapCoordsEqual = (
     Math.abs(mapCenter.lng - centroidCoords[0]) < epsilon &&
     Math.abs(mapCenter.lat - centroidCoords[1]) < epsilon
   );
-};
-
-/**
- * Returns a cleaned and localized path by prepending the specified locale,
- * and sanitizing the input path to ensure consistency.
- *
- * - Strips query parameters (e.g., `?foo=bar`)
- * - Trims trailing slashes
- * - Handles root paths (e.g., '/' becomes '/en')
- * - Avoids duplicating locale if it's already present as the first segment
- *
- * @param {string} path - The relative or absolute URL path (e.g., "/about", "/en/contact?ref=home")
- * @param {string} locale - The locale to prepend (e.g., "en", "de")
- * @returns {string} The sanitized and localized path (e.g., "/en/about")
- *
- * @example
- * getSanitizedLocalizedPath('/about?ref=home', 'en'); // returns '/en/about'
- * getSanitizedLocalizedPath('/en/about', 'en');       // returns '/en/about' (unchanged)
- * getSanitizedLocalizedPath('/', 'de');               // returns '/de'
- */
-export const getSanitizedLocalizedPath = (
-  path: string,
-  locale: string
-): string => {
-  // Strip query parameters if present
-  const pathWithoutQuery = path.split('?')[0];
-  // Remove trailing slash if present
-  const cleanPath = pathWithoutQuery.endsWith('/')
-    ? pathWithoutQuery.slice(0, -1)
-    : pathWithoutQuery;
-  // Handle root path special case
-  if (cleanPath === '' || cleanPath === '/' || cleanPath === `/${locale}`) {
-    return `/${locale}`;
-  }
-
-  // If path already contains locale as a segment, return as is
-  const pathSegments = cleanPath.split('/').filter(Boolean);
-  if (pathSegments[0] === locale) {
-    return cleanPath;
-  }
-
-  // Remove leading slash if present for consistent handling
-  const normalizedPath = cleanPath.startsWith('/')
-    ? cleanPath.slice(1)
-    : cleanPath;
-  // Add locale prefix
-  return `/${locale}/${normalizedPath}`;
 };
 
 export const getDeviceType = (): MobileOs => {

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -21,7 +21,6 @@ import type {
 import type { SitesGeoJSON } from '../features/common/types/ProjectPropsContextInterface';
 
 import centroid from '@turf/centroid';
-import { removeLocaleFromPath } from './getLocalizedPath';
 
 type MetaDataValue = {
   value: string;

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -21,6 +21,7 @@ import type {
 import type { SitesGeoJSON } from '../features/common/types/ProjectPropsContextInterface';
 
 import centroid from '@turf/centroid';
+import { removeLocaleFromPath } from './getLocalizedPath';
 
 type MetaDataValue = {
   value: string;
@@ -314,9 +315,9 @@ export const generateProjectLink = (
   projectGuid: string,
   routerAsPath: string //e.g. /en/yucatan, /en
 ) => {
-  // just use routerAsPath as-is, let localizedPath handle locale stripping
+  const pathWithoutLocale = removeLocaleFromPath(routerAsPath);
   return `/${projectGuid}?backNavigationUrl=${encodeURIComponent(
-    routerAsPath
+    pathWithoutLocale
   )}`;
 };
 
@@ -383,7 +384,6 @@ export const getSanitizedLocalizedPath = (
   const normalizedPath = cleanPath.startsWith('/')
     ? cleanPath.slice(1)
     : cleanPath;
-
   // Add locale prefix
   return `/${locale}/${normalizedPath}`;
 };


### PR DESCRIPTION
This PR refactors the back button navigation logic to simplify and improve path handling :

- Removed redundant helper function `getSanitizedLocalizedPath`.
- Replaced with `useLocalizedPath `hook to handle localization of relative routes.
- Cleaned up path processing by splitting query params from the pathname before navigation.
- Default route is now `/ ` instead of `/${locale}`, since localization is handled by the hook.
