### PR TITLE
Refactor components to remove FC usage and resolve TypeScript warnings

### DIFF
--- a/src/features/common/Layout/AnalyticsContext.tsx
+++ b/src/features/common/Layout/AnalyticsContext.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 import type { SetState } from '../types/common';
 
 import { useContext, createContext, useMemo, useState } from 'react';
@@ -22,7 +22,7 @@ interface AnalyticsContextInterface {
 
 const AnalyticsContext = createContext<AnalyticsContextInterface | null>(null);
 
-export const AnalyticsProvider: FC = ({ children }) => {
+export const AnalyticsProvider = ({ children }: { children: ReactNode }) => {
   const [projectList, setProjectList] = useState<Project[] | null>(null);
   const [project, setProject] = useState<Project | null>(null);
   const [fromDate, setFromDate] = useState<Date>(subYears(new Date(), 1));

--- a/src/features/common/Layout/BulkCodeContext.tsx
+++ b/src/features/common/Layout/BulkCodeContext.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 import type { SetState } from '../types/common';
 import type { BulkCodeMethods } from '../../../utils/constants/bulkCodeConstants';
 import type {
@@ -55,7 +55,7 @@ interface BulkCodeContextInterface {
 
 const BulkCodeContext = createContext<BulkCodeContextInterface | null>(null);
 
-export const BulkCodeProvider: FC = ({ children }) => {
+export const BulkCodeProvider = ({ children }: { children: ReactNode }) => {
   const [bulkMethod, setBulkMethod] = useState<BulkCodeMethods | null>(null);
   const [planetCashAccount, setPlanetCashAccount] =
     useState<PlanetCashAccount | null>(null);

--- a/src/features/common/Layout/CurrencyContext.tsx
+++ b/src/features/common/Layout/CurrencyContext.tsx
@@ -1,5 +1,5 @@
 import type { APIError, CurrencyCode } from '@planet-sdk/common';
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 
 import { handleError } from '@planet-sdk/common';
 import { createContext, useState, useContext, useEffect } from 'react';
@@ -16,7 +16,7 @@ interface CurrencyContextInterface {
 
 const CurrencyContext = createContext<CurrencyContextInterface | null>(null);
 
-export const CurrencyProvider: FC = ({ children }) => {
+export const CurrencyProvider = ({ children }: { children: ReactNode }) => {
   const { setErrors } = useContext(ErrorHandlingContext);
   const { getApi } = useApi();
   const [supportedCurrencies, setSupportedCurrencies] =

--- a/src/features/common/Layout/DonationReceiptContext.tsx
+++ b/src/features/common/Layout/DonationReceiptContext.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import type { User } from '@planet-sdk/common';
 import type {
   AddressView,
@@ -121,9 +122,11 @@ const DonationReceiptContext =
   createContext<DonationReceiptContextInterface | null>(null);
 
 // Provider component
-export const DonationReceiptProvider: React.FC<{
-  children: React.ReactNode;
-}> = ({ children }) => {
+export const DonationReceiptProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
   const [state, setState] =
     useState<DonationReceiptContextState>(loadStateFromSession);
   // Persist state to sessionStorage

--- a/src/features/common/Layout/ErrorHandlingContext.tsx
+++ b/src/features/common/Layout/ErrorHandlingContext.tsx
@@ -1,4 +1,4 @@
-import type { SetStateAction, Dispatch, FC } from 'react';
+import type { SetStateAction, Dispatch, ReactNode } from 'react';
 import type { SerializedError } from '@planet-sdk/common';
 
 import React, { createContext, useState } from 'react';
@@ -20,7 +20,7 @@ export const ErrorHandlingContext =
     redirect: () => {},
   });
 
-const ErrorHandlingProvider: FC = ({ children }) => {
+const ErrorHandlingProvider = ({ children }: { children: ReactNode }) => {
   const router = useRouter();
   const { localizedPath } = useLocalizedPath();
   const [errors, setErrors] = useState<SerializedError[] | null>(null);

--- a/src/features/common/Layout/MyForestContext.tsx
+++ b/src/features/common/Layout/MyForestContext.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 import type {
   ProjectListResponse,
   MyForestProject,
@@ -57,7 +57,7 @@ interface MyForestContextInterface {
 
 const MyForestContext = createContext<MyForestContextInterface | null>(null);
 
-export const MyForestProvider: FC = ({ children }) => {
+export const MyForestProvider = ({ children }: { children: ReactNode }) => {
   const { setErrors } = useContext(ErrorHandlingContext);
 
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);

--- a/src/features/common/Layout/PayoutsContext.tsx
+++ b/src/features/common/Layout/PayoutsContext.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 import type { BankAccount, PayoutMinAmounts } from '../types/payouts';
 
 import { createContext, useState, useContext } from 'react';
@@ -14,7 +14,7 @@ export const PayoutsContext = createContext<PayoutsContextInterface | null>(
   null
 );
 
-export const PayoutsProvider: FC = ({ children }) => {
+export const PayoutsProvider = ({ children }: { children: ReactNode }) => {
   const [accounts, setAccounts] = useState<BankAccount[] | null>(null);
   const [payoutMinAmounts, setPayoutMinAmounts] =
     useState<PayoutMinAmounts | null>(null);

--- a/src/features/common/Layout/PlanetCashContext.tsx
+++ b/src/features/common/Layout/PlanetCashContext.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 import type { PlanetCashAccount } from '../types/planetcash';
 
 import { createContext, useState, useContext } from 'react';
@@ -13,7 +13,7 @@ interface PlanetCashContextInterface {
 export const PlanetCashContext =
   createContext<PlanetCashContextInterface | null>(null);
 
-export const PlanetCashProvider: FC = ({ children }) => {
+export const PlanetCashProvider = ({ children }: { children: ReactNode }) => {
   const [accounts, setAccounts] = useState<PlanetCashAccount[] | null>(null);
   const [isPlanetCashActive, setIsPlanetCashActive] = useState<boolean>(false);
 

--- a/src/features/common/Layout/ProjectPropsContext.tsx
+++ b/src/features/common/Layout/ProjectPropsContext.tsx
@@ -1,5 +1,5 @@
 // Changes in this file can be ignored as it was just used to get the old time travel feature working
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 import type { MapRef } from 'react-map-gl/src/components/static-map';
 import type {
   TreeProjectExtended,
@@ -47,7 +47,7 @@ export const useProjectProps = (): ProjectPropsContextInterface => {
   return context;
 };
 
-const ProjectPropsProvider: FC = ({ children }) => {
+const ProjectPropsProvider = ({ children }: { children: ReactNode }) => {
   const [projects, setProjects] = useState<MapProject[] | null>(null);
   const [project, setProject] = useState<
     TreeProjectExtended | ConservationProjectExtended | null

--- a/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
+++ b/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 import type { SetState } from '../../types/common';
 
 import { useContext, useEffect, useState } from 'react';
@@ -12,19 +12,20 @@ import { useUserProps } from '../UserPropsContext';
 
 export type ViewMode = 'list' | 'map';
 interface ProjectsLayoutProps {
+  children: ReactNode;
   currencyCode: string;
   setCurrencyCode: SetState<string>;
   page: 'project-list' | 'project-details';
   isMobile: boolean;
 }
 
-const MobileProjectsLayout: FC<ProjectsLayoutProps> = ({
+const MobileProjectsLayout = ({
   children,
   page,
   currencyCode,
   setCurrencyCode,
   isMobile,
-}) => {
+}: ProjectsLayoutProps) => {
   const { embed, showProjectList, showProjectDetails, isContextLoaded } =
     useContext(ParamsContext);
   const isEmbedded = embed === 'true';

--- a/src/features/common/Layout/ProjectsLayout/index.tsx
+++ b/src/features/common/Layout/ProjectsLayout/index.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 import type { SetState } from '../../types/common';
 
 import { useContext, useMemo } from 'react';
@@ -15,16 +15,17 @@ import { useUserProps } from '../UserPropsContext';
 import { ParamsContext } from '../QueryParamsContext';
 
 interface ProjectsLayoutProps {
+  children: ReactNode;
   currencyCode: string;
   setCurrencyCode: SetState<string>;
   page: 'project-list' | 'project-details';
 }
 
-const ProjectsLayoutContent: FC<Omit<ProjectsLayoutProps, 'currencyCode'>> = ({
+const ProjectsLayoutContent = ({
   children,
   setCurrencyCode,
   page,
-}) => {
+}: Omit<ProjectsLayoutProps, 'currencyCode'>) => {
   const { mapOptions, updateMapOption } = useProjectsMap();
   const { isImpersonationModeOn } = useUserProps();
   const { embed, showProjectDetails, showProjectList } =
@@ -78,12 +79,12 @@ const ProjectsLayoutContent: FC<Omit<ProjectsLayoutProps, 'currencyCode'>> = ({
   );
 };
 
-const ProjectsLayout: FC<ProjectsLayoutProps> = ({
+const ProjectsLayout = ({
   children,
   currencyCode,
   setCurrencyCode,
   page,
-}) => {
+}: ProjectsLayoutProps) => {
   const { embed, isContextLoaded } = useContext(ParamsContext);
   const isEmbedded = embed === 'true';
 

--- a/src/features/common/Layout/QueryParamsContext.tsx
+++ b/src/features/common/Layout/QueryParamsContext.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 
 import React, { createContext, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
@@ -29,7 +29,7 @@ export const ParamsContext = createContext<ParamsContextType>({
   page: null,
 });
 
-const QueryParamsProvider: FC = ({ children }) => {
+const QueryParamsProvider = ({ children }: { children: ReactNode }) => {
   const locale = useLocale();
   const [isContextLoaded, setIsContextLoaded] = useState(false);
   const [embed, setEmbed] = useState<QueryParamType>(undefined);

--- a/src/features/common/Layout/TenantContext.tsx
+++ b/src/features/common/Layout/TenantContext.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 import type { SetState } from '../types/common';
 import type { Tenant } from '@planet-sdk/common';
 
@@ -12,13 +12,14 @@ interface TenantContextInterface {
 const TenantContext = createContext<TenantContextInterface | null>(null);
 
 interface TenantProviderProps {
+  children: ReactNode;
   initialTenantConfig: Tenant;
 }
 
-export const TenantProvider: FC<TenantProviderProps> = ({
+export const TenantProvider = ({
   children,
   initialTenantConfig,
-}) => {
+}: TenantProviderProps) => {
   const [tenantConfig, setTenantConfig] = useState<Tenant>(initialTenantConfig);
 
   const value: TenantContextInterface | null = useMemo(

--- a/src/features/common/Layout/UserLayout/IconContainer.tsx
+++ b/src/features/common/Layout/UserLayout/IconContainer.tsx
@@ -1,8 +1,8 @@
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 
 import styles from './UserLayout.module.scss';
 
-const IconContainer: FC = ({ children }) => {
+const IconContainer = ({ children }: { children: ReactNode }) => {
   return <div className={styles.iconContainer}>{children}</div>;
 };
 

--- a/src/features/common/Layout/UserLayout/UserLayout.tsx
+++ b/src/features/common/Layout/UserLayout/UserLayout.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 import type { NavLinkType, SubMenuItemType } from './NavLink';
 
 import { useRouter } from 'next/router';
@@ -26,7 +26,7 @@ import LanguageSwitcher from './LanguageSwitcher';
 import NavLink from './NavLink';
 import useLocalizedPath from '../../../../hooks/useLocalizedPath';
 
-const UserLayout: FC = ({ children }) => {
+const UserLayout = ({ children }: { children: ReactNode }) => {
   const t = useTranslations('Me');
   const locale = useLocale();
   const router = useRouter();

--- a/src/features/common/Layout/UserPropsContext.tsx
+++ b/src/features/common/Layout/UserPropsContext.tsx
@@ -2,7 +2,7 @@ import type {
   User as Auth0User,
   RedirectLoginOptions,
 } from '@auth0/auth0-react';
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 import type { User } from '@planet-sdk/common/build/types/user';
 import type { SetState } from '../types/common';
 import type { ImpersonationData } from '../../../utils/apiRequests/impersonation';
@@ -49,7 +49,7 @@ export const UserPropsContext = createContext<UserPropsContextInterface | null>(
   null
 );
 
-export const UserPropsProvider: FC = ({ children }) => {
+export const UserPropsProvider = ({ children }: { children: ReactNode }) => {
   const {
     isLoading,
     isAuthenticated,

--- a/src/features/common/Layout/index.tsx
+++ b/src/features/common/Layout/index.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 
 import React, { useContext } from 'react';
 import theme from '../../../theme/theme';
@@ -9,7 +9,7 @@ import Header from './Header';
 import Navbar from './Navbar';
 import { ParamsContext } from './QueryParamsContext';
 
-const Layout: FC = ({ children }) => {
+const Layout = ({ children }: { children: ReactNode }) => {
   const { theme: themeType } = useTheme();
   const { embed, page } = useContext(ParamsContext);
 

--- a/src/features/projectsV2/ProjectsContext.tsx
+++ b/src/features/projectsV2/ProjectsContext.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 import type { ExtendedProject, MapProject } from '../common/types/projectv2';
 import type {
   APIError,
@@ -71,6 +71,7 @@ interface ProjectsState {
 const ProjectsContext = createContext<ProjectsState | null>(null);
 
 type ProjectsProviderProps = {
+  children: ReactNode;
   page?: 'project-list' | 'project-details';
   currencyCode?: string;
   setCurrencyCode?: SetState<string> | undefined;
@@ -78,14 +79,14 @@ type ProjectsProviderProps = {
   setSelectedMode?: SetState<ViewMode>;
 };
 
-export const ProjectsProvider: FC<ProjectsProviderProps> = ({
+export const ProjectsProvider = ({
   children,
   page,
   currencyCode,
   setCurrencyCode,
   selectedMode,
   setSelectedMode,
-}) => {
+}: ProjectsProviderProps) => {
   const [projects, setProjects] = useState<MapProject[] | null>(null);
   const [singleProject, setSingleProject] = useState<ExtendedProject | null>(
     null

--- a/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/MapSettings.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/MapSettings.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import type { MapOptions } from '../../ProjectsMapContext';
 import type { SetState } from '../../../common/types/common';
 
@@ -14,12 +13,12 @@ type MapSettingsProps = {
   setIsOpen?: SetState<boolean>;
 };
 
-const MapSettings: FC<MapSettingsProps> = ({
+const MapSettings = ({
   mapOptions,
   updateMapOption,
   isMobile,
   setIsOpen,
-}) => {
+}: MapSettingsProps) => {
   const content = (
     <>
       <MapSettingsSection

--- a/src/features/projectsV2/ProjectsMapContext.tsx
+++ b/src/features/projectsV2/ProjectsMapContext.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import type { ViewState } from 'react-map-gl-v7';
 import type { MapStyle } from 'react-map-gl-v7/maplibre';
 import type { SetState } from '../common/types/common';
@@ -106,11 +106,11 @@ interface ProjectsMapProviderProps {
   isQueryParamsLoaded?: boolean;
 }
 
-export const ProjectsMapProvider: FC<ProjectsMapProviderProps> = ({
+export const ProjectsMapProvider = ({
   children,
   isEmbedded = false,
   isQueryParamsLoaded = false,
-}) => {
+}: ProjectsMapProviderProps) => {
   const [mapState, setMapState] = useState<MapState>(DEFAULT_MAP_STATE);
   const [viewState, setViewState] = useState<ViewState>(DEFAULT_VIEW_STATE);
   const [isSatelliteView, setIsSatelliteView] = useState(false);

--- a/src/features/user/Profile/ProfileOuterContainer/index.tsx
+++ b/src/features/user/Profile/ProfileOuterContainer/index.tsx
@@ -1,8 +1,8 @@
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 
 import styles from './ProfileOuterContainer.module.scss';
 
-const ProfileOuterContainer: FC = ({ children }) => {
+const ProfileOuterContainer = ({ children }: { children: ReactNode }) => {
   return <main className={styles.mainContainer}>{children}</main>;
 };
 

--- a/src/features/user/Profile/PublicProfileOuterContainer/index.tsx
+++ b/src/features/user/Profile/PublicProfileOuterContainer/index.tsx
@@ -1,9 +1,9 @@
-import type { FC } from 'react';
+import type { ReactNode } from 'react';
 
 import styles from './PublicProfileOuterContainer.module.scss';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 
-const PublicProfileOuterContainer: FC = ({ children }) => {
+const PublicProfileOuterContainer = ({ children }: { children: ReactNode }) => {
   const { isImpersonationModeOn } = useUserProps();
   return (
     <main

--- a/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressInput.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressInput.tsx
@@ -23,7 +23,7 @@ interface AddressInputProps {
   onAddressSelect?: (address: string) => void;
 }
 
-const AddressInput: React.FC<AddressInputProps> = ({
+const AddressInput = ({
   name,
   control,
   label,
@@ -33,7 +33,7 @@ const AddressInput: React.FC<AddressInputProps> = ({
   suggestions,
   onInputChange,
   onAddressSelect,
-}) => {
+}: AddressInputProps) => {
   const validationRules = {
     ...(required && { required: validationMessages.required }),
     ...(validationPattern && {


### PR DESCRIPTION
Refactor components to eliminate the use of `FC` in favor of explicit typing for children, addressing TypeScript warnings throughout the codebase.