### PR TITLE
Remove null subtitle prop from DashboardView across app

### DIFF
--- a/src/features/common/Layout/DashboardView/index.tsx
+++ b/src/features/common/Layout/DashboardView/index.tsx
@@ -6,7 +6,7 @@ import themeProperties from '../../../../theme/themeProperties';
 
 interface DashboardViewProps {
   title?: string;
-  subtitle?: string | ReactElement | null;
+  subtitle?: string | ReactElement;
   children: ReactNode;
   variant?: 'full-width' | 'compact';
   multiColumn?: boolean;

--- a/src/features/user/RegisterTrees/index.tsx
+++ b/src/features/user/RegisterTrees/index.tsx
@@ -10,7 +10,7 @@ export default function RegisterTrees(): ReactElement | null {
   const t = useTranslations('Me');
 
   return (
-    <DashboardView title={t('registerTrees')} subtitle={null}>
+    <DashboardView title={t('registerTrees')}>
       <SingleColumnView>
         <CenteredContainer>
           <RegisterTreesWidget />

--- a/src/features/user/Settings/DeleteProfile/index.tsx
+++ b/src/features/user/Settings/DeleteProfile/index.tsx
@@ -10,7 +10,7 @@ export default function DonationLink(): ReactElement | null {
   const t = useTranslations('Me');
 
   return (
-    <DashboardView title={t('deleteProfile')} subtitle={null}>
+    <DashboardView title={t('deleteProfile')}>
       <SingleColumnView>
         <CenteredContainer>
           <DeleteProfileForm />

--- a/src/features/user/Settings/EditProfile/index.tsx
+++ b/src/features/user/Settings/EditProfile/index.tsx
@@ -11,7 +11,7 @@ export default function EditProfile(): ReactElement {
   const t = useTranslations('Me');
 
   return (
-    <DashboardView title={t('editProfile')} subtitle={null}>
+    <DashboardView title={t('editProfile')}>
       <SingleColumnView>
         <CenteredContainer>
           <EditProfileForm />

--- a/src/features/user/TreeMapper/Analytics/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/index.tsx
@@ -48,7 +48,7 @@ const Analytics = () => {
   }, []);
 
   return isLoaded ? (
-    <DashboardView title={t('title')} subtitle={null}>
+    <DashboardView title={t('title')}>
       {projectList && projectList.length > 0 ? (
         <>
           <ProjectFilter />

--- a/src/features/user/TreeMapper/MySpecies/index.tsx
+++ b/src/features/user/TreeMapper/MySpecies/index.tsx
@@ -10,7 +10,7 @@ export default function MySpecies(): ReactElement {
   const t = useTranslations('Me');
 
   return (
-    <DashboardView title={t('mySpecies')} subtitle={null} variant="compact">
+    <DashboardView title={t('mySpecies')} variant="compact">
       <CenteredContainer>
         <MySpeciesForm />
       </CenteredContainer>


### PR DESCRIPTION
- Removes the unnecessary `subtitle={null}` prop from all usages of the `DashboardView` component. 
- Updates the`DashboardView` component prop types to remove the option of `subtitle=null`