### PR TITLE
Improve stability and security in ProjectMarkers

### DIFF
--- a/src/features/projectsV2/ProjectsMap/ProjectMarkers/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/ProjectMarkers/index.tsx
@@ -1,6 +1,13 @@
 import type { MapProject } from '../../../common/types/projectv2';
 
-import { useCallback, useContext, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import ProjectPopup from '../ProjectPopup';
 import SingleMarker from './SingleMarker';
 import { ParamsContext } from '../../../common/Layout/QueryParamsContext';
@@ -31,9 +38,18 @@ type PopupState = ClosedPopupState | OpenPopupState;
 const ProjectMarkers = ({ categorizedProjects, page }: ProjectMarkersProps) => {
   const router = useRouter();
   const { localizedPath } = useLocalizedPath();
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [popupState, setPopupState] = useState<PopupState>({ show: false });
   const { embed, callbackUrl } = useContext(ParamsContext);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearTimer, [clearTimer]);
 
   const visitProject = useCallback(
     (projectSlug: string): void => {
@@ -53,13 +69,6 @@ const ProjectMarkers = ({ categorizedProjects, page }: ProjectMarkersProps) => {
     },
     [localizedPath, embed, callbackUrl]
   );
-
-  const clearTimer = useCallback(() => {
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-      timerRef.current = null;
-    }
-  }, []);
 
   const initiatePopupOpen = useCallback(
     (project: MapProject) => {


### PR DESCRIPTION
Resolves :  [#2671](https://github.com/Plant-for-the-Planet-org/planet-webapp/issues/2671), [#2673](https://github.com/Plant-for-the-Planet-org/planet-webapp/issues/2673)

This PR addresses two key improvements in the `ProjectMarkers` component:

1. Performance fix with useCallback.

-  Wrapped `visitProject`, `initiatePopupOpen`, and `handleMarkerLeave `in `useCallback `to ensure stable references.
- This prevents unnecessary re-creations of these functions on each render and makes `renderMarkers`  `memoization `effective.

2. Security & URL handling fix

- Updated `visitProject `to properly encode `callbackUrl `before appending it to the query string.
- Prevents issues with special characters (&, ?, spaces, etc.) and mitigates potential security risks related to unvalidated query parameters.

Impact: 

- Improved rendering performance by avoiding redundant re-renders of markers.
- Eliminated potential query string injection/malformed URL issues.


