### PR TITLE
Fix division by zero in area and density calculations

### DIFF
--- a/src/features/projects/components/Intervention/InterventionDetails.tsx
+++ b/src/features/projects/components/Intervention/InterventionDetails.tsx
@@ -70,7 +70,7 @@ export default function InterventionDetails({
       activeIntervention.type === 'multi-tree-registration'
     ) {
       const calculatedArea = area(activeIntervention.geometry);
-      setPlantationArea(calculatedArea / 10000);
+      setPlantationArea(calculatedArea > 0 ? calculatedArea / 10000 : 0);
     }
   }, [activeIntervention]);
 

--- a/src/features/projects/components/maps/Interventions.tsx
+++ b/src/features/projects/components/maps/Interventions.tsx
@@ -76,7 +76,7 @@ export default function Interventions(): ReactElement {
   const getPlArea = (pl: MultiTreeRegistration) => {
     if (pl && pl.type === 'multi-tree-registration') {
       const calculatedArea = area(pl.geometry);
-      return calculatedArea / 10000;
+      return calculatedArea > 0 ? calculatedArea / 10000 : 0;
     } else {
       return 0;
     }
@@ -85,7 +85,7 @@ export default function Interventions(): ReactElement {
   const getPolygonColor = (pl: MultiTreeRegistration) => {
     const treeCount = getPlTreeCount(pl);
     const plantationArea = getPlArea(pl);
-    const density = treeCount / plantationArea;
+    const density = plantationArea > 0 ? treeCount / plantationArea : 0;
     if (density > 2500) {
       return 0.5;
     } else if (density > 2000) {

--- a/src/features/projectsV2/ProjectDetails/components/MultiTreeInfo.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/MultiTreeInfo.tsx
@@ -35,7 +35,7 @@ const MultiTreeInfo = ({
       0
     );
     const calculatedArea = area(activeMultiTree.geometry);
-    const hectaresCovered = calculatedArea / 10000;
+    const hectaresCovered = calculatedArea > 0 ? calculatedArea / 10000 : 0;
     return { totalTreesCount, hectaresCovered };
   }, [
     activeMultiTree.geometry,

--- a/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/index.tsx
@@ -66,7 +66,7 @@ const ProjectSiteDropdown = ({
     if (!projectSites) return [];
     return projectSites.map((site, index: number) => ({
       siteName: site.properties.name,
-      siteArea: area(site) / 10000,
+      siteArea: area(site) > 0 ? area(site) / 10000 : 0,
       id: index,
     }));
   }, [projectSites]);

--- a/src/features/projectsV2/ProjectsMap/microComponents/InterventionLayers.tsx
+++ b/src/features/projectsV2/ProjectsMap/microComponents/InterventionLayers.tsx
@@ -120,7 +120,7 @@ export default function InterventionLayers(): React.ReactElement {
   const getPolygonColor = (multiTree: MultiTreeRegistration) => {
     const treeCount = getTreeCount(multiTree);
     const plantationArea = getPlantationArea(multiTree);
-    const density = treeCount / plantationArea;
+    const density = plantationArea > 0 ? treeCount / plantationArea : 0;
     if (density > 2500) {
       return 0.5;
     } else if (density > 2000) {

--- a/src/features/user/TreeMapper/Analytics/components/Map/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Map/index.tsx
@@ -265,7 +265,8 @@ export const MapContainer = () => {
           // Calculate the area based on the feature's coordinates using Turf.js
           const polygonAreaSqMeters = area(intervention.geometry);
           const treeCount = intervention.properties.treeCount;
-          const density = treeCount / polygonAreaSqMeters;
+          const density =
+            polygonAreaSqMeters > 0 ? treeCount / polygonAreaSqMeters : 0;
 
           // Add the calculated density to the feature properties
           return {

--- a/src/features/user/TreeMapper/components/Map.tsx
+++ b/src/features/user/TreeMapper/components/Map.tsx
@@ -98,7 +98,7 @@ export default function MyTreesMap({
   const getPlantationArea = (mt: MultiTreeRegistration) => {
     if (mt && mt.type === 'multi-tree-registration') {
       const polygonAreaSqMeters = area(mt.geometry);
-      return polygonAreaSqMeters / 10000;
+      return polygonAreaSqMeters > 0 ? polygonAreaSqMeters / 10000 : 0;
     } else {
       return 0;
     }
@@ -107,7 +107,7 @@ export default function MyTreesMap({
   const getPolygonColor = (mt: MultiTreeRegistration) => {
     const treeCount = getTreeCount(mt);
     const plantationArea = getPlantationArea(mt);
-    const density = treeCount / plantationArea;
+    const density = plantationArea > 0 ? treeCount / plantationArea : 0;
     if (density > 2500) {
       return 0.5;
     } else if (density > 2000) {

--- a/src/features/user/TreeMapper/components/TreemapperIntervention.tsx
+++ b/src/features/user/TreeMapper/components/TreemapperIntervention.tsx
@@ -60,7 +60,7 @@ function TreemapperIntervention({
   React.useEffect(() => {
     if (intervention.type === 'multi-tree-registration') {
       const calculatedArea = area(intervention.geometry);
-      setPlantationArea(calculatedArea / 10000);
+      setPlantationArea(calculatedArea > 0 ? calculatedArea / 10000 : 0);
     }
   }, [intervention]);
 


### PR DESCRIPTION
[Resolves](https://github.com/Plant-for-the-Planet-org/planet-webapp/issues/2651)

Description : 
This PR adds runtime guards to prevent division by zero and invalid calculations in area- and density-related code. Following the Turf.js import refactor in PR #2648, several places in the codebase were identified where area() could return 0 for degenerate geometries, leading to potential Infinity, NaN, or incorrect values in the UI.