### PR TITLE
Refactor React imports to specific hooks/imports

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 Fixes #
 
 Check this list and then dismiss it:
+
 - **Localization**
   - Have you added translation resources?
   - Have you localized numbers, dates and other stuff?
@@ -13,11 +14,11 @@ Check this list and then dismiss it:
   - Have you defined interfaces for new components?
   - Have you added a source file not using TypeScript?
   - Have you checked if your newly introduced modules or functions are not already existing?
-  - Is your `React.useEffect` using the right dependencies?
+  - Is your `useEffect` using the right dependencies?
   - Check your code if it matches the existing code formatting.
 
-Changes in this pull request:
--
+## Changes in this pull request:
+
 -
 -
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,7 @@ import { CacheProvider } from '@emotion/react';
 import createEmotionCache from '../src/createEmotionCache';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import 'mapbox-gl-compare/dist/mapbox-gl-compare.css';
-import React, { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import TagManager from 'react-gtm-module';
 import Router from 'next/router';
 import App from 'next/app';
@@ -151,9 +151,9 @@ const PlanetWeb = ({
   emotionCache = clientSideEmotionCache,
 }: AppPropsWithLayout) => {
   const router = useRouter();
-  const [isMap, setIsMap] = React.useState(false);
-  const [currencyCode, setCurrencyCode] = React.useState('');
-  const [browserCompatible, setBrowserCompatible] = React.useState(false);
+  const [isMap, setIsMap] = useState(false);
+  const [currencyCode, setCurrencyCode] = useState('');
+  const [browserCompatible, setBrowserCompatible] = useState(false);
 
   const { tenantConfig } = pageProps;
 
@@ -169,11 +169,11 @@ const PlanetWeb = ({
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     storeConfig(tenantConfig);
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.pathname.includes('projects-archive')) {
       setIsMap(true);
     } else {
@@ -181,13 +181,13 @@ const PlanetWeb = ({
     }
   }, [router]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (process.env.NEXT_PUBLIC_GA_TRACKING_ID) {
       TagManager.initialize(tagManagerArgs);
     }
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setBrowserCompatible(browserNotCompatible());
   }, []);
 
@@ -203,16 +203,16 @@ const PlanetWeb = ({
     isMobile,
   };
 
-  const [showVideo, setshowVideo] = React.useState(true);
+  const [showVideo, setshowVideo] = useState(true);
 
   // if localShowVideo is undefined
   // set localShowVideo is true and show the video
   // if localShowVideo is true show the video
   // if localShowVideo is false hide the video
 
-  const [localShowVideo, setLocalShowVideo] = React.useState(false);
+  const [localShowVideo, setLocalShowVideo] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.pathname.endsWith('projects-archive')) {
       if (typeof window !== 'undefined') {
         if (localStorage.getItem('showVideo')) {
@@ -231,7 +231,7 @@ const PlanetWeb = ({
     }
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setshowVideo(localShowVideo);
   }, [localShowVideo]);
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,3 +1,4 @@
+import type { ComponentType } from 'react';
 import type { EmotionCache } from '@emotion/react';
 import type { AppType } from 'next/app';
 import type { DocumentContext, DocumentInitialProps } from 'next/document';
@@ -5,7 +6,6 @@ import type { DocumentContext, DocumentInitialProps } from 'next/document';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
 import createEmotionServer from '@emotion/server/create-instance';
 import createEmotionCache from '../src/createEmotionCache';
-import React from 'react';
 
 class MyDocument extends Document {
   static async getInitialProps(
@@ -57,7 +57,7 @@ MyDocument.getInitialProps = async (ctx) => {
   ctx.renderPage = () =>
     originalRenderPage({
       enhanceApp:
-        (App: AppType | React.ComponentType<{ emotionCache: EmotionCache }>) =>
+        (App: AppType | ComponentType<{ emotionCache: EmotionCache }>) =>
         (props) => {
           return <App emotionCache={cache} {...props} />;
         },

--- a/pages/sites/[slug]/[locale]/all.tsx
+++ b/pages/sites/[slug]/[locale]/all.tsx
@@ -13,7 +13,7 @@ import type {
 } from 'next';
 import type { AbstractIntlMessages } from 'next-intl';
 
-import React from 'react';
+import { useContext, useEffect, useState } from 'react';
 import LeaderBoard from '../../../../src/tenants/planet/LeaderBoard';
 import GetLeaderboardMeta from '../../../../src/utils/getMetaTags/GetLeaderboardMeta';
 import { ErrorHandlingContext } from '../../../../src/features/common/Layout/ErrorHandlingContext';
@@ -33,22 +33,20 @@ interface Props {
 }
 
 export default function Home({ pageProps }: Props) {
-  const [leaderboard, setLeaderboard] = React.useState<LeaderBoardList | null>(
-    null
-  );
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const [leaderboard, setLeaderboard] = useState<LeaderBoardList | null>(null);
+  const { setErrors } = useContext(ErrorHandlingContext);
 
   const router = useRouter();
   const { setTenantConfig } = useTenant();
   const { getApi } = useApi();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(pageProps.tenantConfig);
     }
   }, [router.isReady]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     async function loadLeaderboard() {
       try {
         const newLeaderboard = await getApi<LeaderBoardList>(
@@ -62,11 +60,9 @@ export default function Home({ pageProps }: Props) {
     loadLeaderboard();
   }, []);
 
-  const [tenantScore, setTenantScore] = React.useState<TenantScore | null>(
-    null
-  );
+  const [tenantScore, setTenantScore] = useState<TenantScore | null>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     async function loadTenantScore() {
       try {
         const newTenantScore = await getApi<TenantScore>(
@@ -80,11 +76,9 @@ export default function Home({ pageProps }: Props) {
     loadTenantScore();
   }, []);
 
-  const [treesDonated, setTreesDonated] = React.useState<TreesDonated | null>(
-    null
-  );
+  const [treesDonated, setTreesDonated] = useState<TreesDonated | null>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     async function loadTreesDonated() {
       try {
         const newTreesDonated = await getApi<TreesDonated>(

--- a/pages/sites/[slug]/[locale]/claim/[type]/[code].tsx
+++ b/pages/sites/[slug]/[locale]/claim/[type]/[code].tsx
@@ -10,7 +10,7 @@ import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 import type { APIError, SerializedError } from '@planet-sdk/common';
 import type { RedeemedCodeData } from '../../../../../../src/features/common/types/redeem';
 
-import React from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import useLocalizedPath from '../../../../../../src/hooks/useLocalizedPath';
 import { useTranslations } from 'next-intl';
@@ -47,19 +47,19 @@ function ClaimDonation({ pageProps }: Props): ReactElement {
   const { setTenantConfig } = useTenant();
   const { user, contextLoaded, loginWithRedirect } = useUserProps();
   const { postApiAuthenticated } = useApi();
-  const { errors, setErrors } = React.useContext(ErrorHandlingContext);
-  const [code, setCode] = React.useState<string>('');
-  const [redeemedCodeData, setRedeemedCodeData] = React.useState<
+  const { errors, setErrors } = useContext(ErrorHandlingContext);
+  const [code, setCode] = useState<string>('');
+  const [redeemedCodeData, setRedeemedCodeData] = useState<
     RedeemedCodeData | undefined
   >(undefined);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(pageProps.tenantConfig);
     }
   }, [router.isReady]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (
       router &&
       router.query.type &&
@@ -127,14 +127,14 @@ function ClaimDonation({ pageProps }: Props): ReactElement {
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.query.code && typeof router.query.code === 'string') {
       setCode(router.query.code);
     }
   }, [router.query.code]);
 
   // // Check if the user is logged in or not.
-  React.useEffect(() => {
+  useEffect(() => {
     // If the user is not logged in - send the user to log in page, store the claim redirect link in the localstorage.
     // When the user logs in, redirect user to the claim link from the localstorage and clear the localstorage.
     // For this  fetch the link from the storage, clears the storage and then redirects the user using the link
@@ -150,7 +150,7 @@ function ClaimDonation({ pageProps }: Props): ReactElement {
     }
   }, [contextLoaded, user]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     //redeem code using route
     if (user && contextLoaded) {
       if (

--- a/pages/sites/[slug]/[locale]/complete-signup.tsx
+++ b/pages/sites/[slug]/[locale]/complete-signup.tsx
@@ -7,7 +7,7 @@ import type {
 } from 'next';
 import type { AbstractIntlMessages } from 'next-intl';
 
-import React from 'react';
+import { useEffect } from 'react';
 import CompleteSignup from '../../../../src/features/user/CompleteSignup';
 import Head from 'next/head';
 import {
@@ -27,7 +27,7 @@ export default function UserProfile({ pageProps }: Props) {
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(pageProps.tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/home.tsx
+++ b/pages/sites/[slug]/[locale]/home.tsx
@@ -12,9 +12,9 @@ import type {
 } from 'next';
 import type { AbstractIntlMessages } from 'next-intl';
 
+import { useEffect, useState, useContext } from 'react';
 import { useRouter } from 'next/router';
 import useLocalizedPath from '../../../../src/hooks/useLocalizedPath';
-import React from 'react';
 import SalesforceHome from '../../../../src/tenants/salesforce/Home';
 import SternHome from '../../../../src/tenants/stern/Home';
 import BasicHome from '../../../../src/tenants/common/Home';
@@ -39,23 +39,19 @@ export default function Home({ pageProps }: Props) {
   const { localizedPath } = useLocalizedPath();
   const { getApi } = useApi();
 
-  const [leaderboard, setLeaderboard] = React.useState<LeaderBoardList | null>(
-    null
-  );
-  const [tenantScore, setTenantScore] = React.useState<TenantScore | null>(
-    null
-  );
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const [leaderboard, setLeaderboard] = useState<LeaderBoardList | null>(null);
+  const [tenantScore, setTenantScore] = useState<TenantScore | null>(null);
+  const { setErrors } = useContext(ErrorHandlingContext);
 
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(pageProps.tenantConfig);
     }
   }, [router.isReady]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     async function loadTenantScore() {
       try {
         const newTenantScore = await getApi<TenantScore>('/app/tenantScore');
@@ -67,7 +63,7 @@ export default function Home({ pageProps }: Props) {
     loadTenantScore();
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     async function loadLeaderboard() {
       try {
         const newLeaderBoard = await getApi<LeaderBoardList>(

--- a/pages/sites/[slug]/[locale]/login.tsx
+++ b/pages/sites/[slug]/[locale]/login.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'next';
 import type { AbstractIntlMessages } from 'next-intl';
 
-import React from 'react';
+import { useEffect } from 'react';
 import { UserProfileLoader } from '../../../../src/features/common/ContentLoaders/UserProfile/UserProfile';
 import { useRouter } from 'next/router';
 import { useUserProps } from '../../../../src/features/common/Layout/UserPropsContext';
@@ -30,7 +30,7 @@ export default function Login({ pageProps }: Props): ReactElement {
   const { localizedPath } = useLocalizedPath();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(pageProps.tenantConfig);
     }
@@ -47,7 +47,7 @@ export default function Login({ pageProps }: Props): ReactElement {
     auth0Error,
   } = useUserProps();
 
-  React.useEffect(() => {
+  useEffect(() => {
     async function loadFunction() {
       // redirect
       if (user) {

--- a/pages/sites/[slug]/[locale]/mangrove-challenge.tsx
+++ b/pages/sites/[slug]/[locale]/mangrove-challenge.tsx
@@ -11,7 +11,7 @@ import type {
   GetStaticPropsResult,
 } from 'next';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import SalesforceCampaign from '../../../../src/tenants/salesforce/OceanforceCampaign';
 import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
 import { getTenantConfig } from '../../../../src/utils/multiTenancy/helpers';

--- a/pages/sites/[slug]/[locale]/mangroves.tsx
+++ b/pages/sites/[slug]/[locale]/mangroves.tsx
@@ -7,7 +7,7 @@ import type {
   GetStaticPropsResult,
 } from 'next';
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
 import Mangroves from '../../../../src/tenants/salesforce/Mangroves';
 import { getTenantConfig } from '../../../../src/utils/multiTenancy/helpers';

--- a/pages/sites/[slug]/[locale]/profile/api-key.tsx
+++ b/pages/sites/[slug]/[locale]/profile/api-key.tsx
@@ -8,8 +8,8 @@ import type {
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 import type { AbstractIntlMessages } from 'next-intl';
 
+import { useEffect } from 'react';
 import Head from 'next/head';
-import React from 'react';
 import { useTranslations } from 'next-intl';
 import ApiKey from '../../../../../src/features/user/Settings/ApiKey';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
@@ -31,7 +31,7 @@ function EditProfilePage({ pageProps: { tenantConfig } }: Props): ReactElement {
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/bulk-codes/[method]/[id].tsx
+++ b/pages/sites/[slug]/[locale]/profile/bulk-codes/[method]/[id].tsx
@@ -10,7 +10,7 @@ import type { APIError } from '@planet-sdk/common';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 import type { PaymentOptions } from '../../../../../../../src/features/user/BulkCodes/BulkCodesTypes';
 
-import React, { useEffect, useCallback, useContext } from 'react';
+import { useEffect, useCallback, useContext } from 'react';
 import UserLayout from '../../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import BulkCodes, {
   BulkCodeSteps,
@@ -110,7 +110,7 @@ export default function BulkCodeIssueCodesPage({
     }
   }, [router.isReady, planetCashAccount, token, contextLoaded, projectList]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(pageProps.tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/bulk-codes/[method]/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/bulk-codes/[method]/index.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import UserLayout from '../../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import BulkCodes, {
   BulkCodeSteps,
@@ -41,7 +41,7 @@ export default function BulkCodeSelectProjectPage({
   const { bulkMethod, setBulkMethod } = useBulkCode();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(pageProps.tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/bulk-codes/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/bulk-codes/index.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React from 'react';
+import { useEffect } from 'react';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import BulkCodes, {
   BulkCodeSteps,
@@ -33,7 +33,7 @@ export default function BulkCodePage({ pageProps }: Props): ReactElement {
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(pageProps.tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/delete-account.tsx
+++ b/pages/sites/[slug]/[locale]/profile/delete-account.tsx
@@ -9,7 +9,7 @@ import type {
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
 import Head from 'next/head';
-import React from 'react';
+import { useEffect } from 'react';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import { useTranslations } from 'next-intl';
 import DeleteProfile from '../../../../../src/features/user/Settings/DeleteProfile';
@@ -33,7 +33,7 @@ function DeleteProfilePage({
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/donation-link.tsx
+++ b/pages/sites/[slug]/[locale]/profile/donation-link.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React from 'react';
+import { useEffect } from 'react';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import DonationLink from '../../../../../src/features/user/Widget/DonationLink';
 import Head from 'next/head';
@@ -33,7 +33,7 @@ export default function DonationLinkPage({
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/giftfund/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/giftfund/index.tsx
@@ -8,7 +8,7 @@ import type {
 import type { AbstractIntlMessages } from 'next-intl';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React from 'react';
+import { useEffect } from 'react';
 import GiftFunds from '../../../../../../src/features/user/GiftFunds';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
@@ -34,7 +34,7 @@ export default function Register({
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/history.tsx
+++ b/pages/sites/[slug]/[locale]/profile/history.tsx
@@ -7,7 +7,7 @@ import type {
   PaymentHistory,
 } from '../../../../../src/features/common/types/payments';
 
-import React from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { useTranslations } from 'next-intl';
 import TopProgressBar from '../../../../../src/features/common/ContentLoaders/TopProgressBar';
 import History from '../../../../../src/features/user/Account/History';
@@ -43,19 +43,21 @@ function AccountHistory({ pageProps }: Props): ReactElement {
   const router = useRouter();
   const { setTenantConfig } = useTenant();
   const { getApiAuthenticated } = useApi();
-  const [progress, setProgress] = React.useState(0);
-  const [isDataLoading, setIsDataLoading] = React.useState(false);
-  const [filter, setFilter] = React.useState<string | null>(null);
-  const [paymentHistory, setPaymentHistory] =
-    React.useState<PaymentHistory | null>(null);
-  const [accountingFilters, setAccountingFilters] =
-    React.useState<Filters | null>(null);
+  const [progress, setProgress] = useState(0);
+  const [isDataLoading, setIsDataLoading] = useState(false);
+  const [filter, setFilter] = useState<string | null>(null);
+  const [paymentHistory, setPaymentHistory] = useState<PaymentHistory | null>(
+    null
+  );
+  const [accountingFilters, setAccountingFilters] = useState<Filters | null>(
+    null
+  );
 
-  const { redirect, setErrors } = React.useContext(ErrorHandlingContext);
+  const { redirect, setErrors } = useContext(ErrorHandlingContext);
 
   const { tenantConfig } = pageProps;
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }
@@ -117,7 +119,7 @@ function AccountHistory({ pageProps }: Props): ReactElement {
     }, 1000);
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (contextLoaded && token) fetchPaymentHistory();
   }, [filter, contextLoaded, token]);
 

--- a/pages/sites/[slug]/[locale]/profile/payouts/add-bank-details.tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/add-bank-details.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React from 'react';
+import { useEffect } from 'react';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import ManagePayouts, {
@@ -38,7 +38,7 @@ export default function AddBankDetailsPage({
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/payouts/edit-bank-details/[id].tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/edit-bank-details/[id].tsx
@@ -8,7 +8,7 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React from 'react';
+import { useEffect } from 'react';
 import UserLayout from '../../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import ManagePayouts, {
@@ -36,7 +36,7 @@ export default function EditBankDetailsPage({
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/payouts/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/index.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React, { useState } from 'react';
+import { useEffect, useState } from 'react';
 import TopProgressBar from '../../../../../../src/features/common/ContentLoaders/TopProgressBar';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
@@ -40,7 +40,7 @@ export default function OverviewPage({
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/payouts/schedule.tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/schedule.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React from 'react';
+import { useEffect } from 'react';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import ManagePayouts, {
@@ -39,7 +39,7 @@ export default function PayoutSchedulePage({
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/planetcash/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/planetcash/index.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import TopProgressBar from '../../../../../../src/features/common/ContentLoaders/TopProgressBar';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
@@ -37,7 +37,7 @@ export default function PlanetCashPage({
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/planetcash/new.tsx
+++ b/pages/sites/[slug]/[locale]/profile/planetcash/new.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import TopProgressBar from '../../../../../../src/features/common/ContentLoaders/TopProgressBar';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
@@ -38,7 +38,7 @@ export default function PlanetCashCreatePage({
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/planetcash/transactions.tsx
+++ b/pages/sites/[slug]/[locale]/profile/planetcash/transactions.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import TopProgressBar from '../../../../../../src/features/common/ContentLoaders/TopProgressBar';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
@@ -38,7 +38,7 @@ export default function PlanetCashTransactionsPage({
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/projects/[id].tsx
+++ b/pages/sites/[slug]/[locale]/profile/projects/[id].tsx
@@ -10,7 +10,7 @@ import type {
   GetStaticPropsResult,
 } from 'next';
 
-import React, { useEffect } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { useRouter } from 'next/router';
 import ManageProjects from '../../../../../../src/features/user/ManageProjects';
 import GlobeContentLoader from '../../../../../../src/features/common/ContentLoaders/Projects/GlobeLoader';
@@ -40,19 +40,19 @@ function ManageSingleProject({
   pageProps: { tenantConfig },
 }: Props): ReactElement {
   const t = useTranslations('Common');
-  const [projectGUID, setProjectGUID] = React.useState<string | null>(null);
-  const [ready, setReady] = React.useState<boolean>(false);
+  const [projectGUID, setProjectGUID] = useState<string | null>(null);
+  const [ready, setReady] = useState<boolean>(false);
   const router = useRouter();
   const { setTenantConfig } = useTenant();
   const { getApiAuthenticated } = useApi();
-  const [accessDenied, setAccessDenied] = React.useState<boolean>(false);
-  const [setupAccess, setSetupAccess] = React.useState<boolean>(false);
+  const [accessDenied, setAccessDenied] = useState<boolean>(false);
+  const [setupAccess, setSetupAccess] = useState<boolean>(false);
   const [project, setProject] =
-    React.useState<ExtendedProfileProjectProperties | null>(null);
+    useState<ExtendedProfileProjectProperties | null>(null);
   const { user, contextLoaded, token } = useUserProps();
-  const { setErrors, redirect } = React.useContext(ErrorHandlingContext);
+  const { setErrors, redirect } = useContext(ErrorHandlingContext);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/projects/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/projects/index.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React from 'react';
+import { useEffect } from 'react';
 import ProjectsContainer from '../../../../../../src/features/user/ManageProjects/ProjectsContainer';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
@@ -36,7 +36,7 @@ export default function Register({
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/projects/new-project.tsx
+++ b/pages/sites/[slug]/[locale]/profile/projects/new-project.tsx
@@ -8,8 +8,8 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
+import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
-import React from 'react';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import ManageProjects from '../../../../../../src/features/user/ManageProjects';
 import { useUserProps } from '../../../../../../src/features/common/Layout/UserPropsContext';
@@ -33,19 +33,19 @@ export default function AddProjectType({
   pageProps: { tenantConfig },
 }: Props): ReactElement {
   const t = useTranslations('ManageProjects');
-  const [accessDenied, setAccessDenied] = React.useState<boolean>(false);
-  const [setupAccess, setSetupAccess] = React.useState<boolean>(false);
+  const [accessDenied, setAccessDenied] = useState<boolean>(false);
+  const [setupAccess, setSetupAccess] = useState<boolean>(false);
   const { user, contextLoaded, token, loginWithRedirect } = useUserProps();
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }
   }, [router.isReady]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     async function loadUserData() {
       const usertype = user?.type;
       if (usertype === 'tpo') {

--- a/pages/sites/[slug]/[locale]/profile/recurrency.tsx
+++ b/pages/sites/[slug]/[locale]/profile/recurrency.tsx
@@ -10,7 +10,7 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React from 'react';
+import { useEffect, useState, useContext } from 'react';
 import TopProgressBar from '../../../../../src/features/common/ContentLoaders/TopProgressBar';
 import { useUserProps } from '../../../../../src/features/common/Layout/UserPropsContext';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
@@ -42,13 +42,13 @@ function RecurrentDonations({
   const { token, contextLoaded } = useUserProps();
   const { getApiAuthenticated } = useApi();
 
-  const [progress, setProgress] = React.useState(0);
-  const [isDataLoading, setIsDataLoading] = React.useState(false);
-  const [recurrencies, setrecurrencies] = React.useState<Subscription[]>();
+  const [progress, setProgress] = useState(0);
+  const [isDataLoading, setIsDataLoading] = useState(false);
+  const [recurrencies, setrecurrencies] = useState<Subscription[]>();
 
-  const { setErrors, redirect } = React.useContext(ErrorHandlingContext);
+  const { setErrors, redirect } = useContext(ErrorHandlingContext);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }
@@ -90,7 +90,7 @@ function RecurrentDonations({
     setTimeout(() => setProgress(0), 1000);
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (contextLoaded && token) fetchRecurrentDonations();
   }, [contextLoaded, token]);
 

--- a/pages/sites/[slug]/[locale]/profile/register-trees.tsx
+++ b/pages/sites/[slug]/[locale]/profile/register-trees.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React from 'react';
+import { useEffect } from 'react';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import { useTranslations } from 'next-intl';
@@ -33,7 +33,7 @@ export default function Register({
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/treemapper/data-explorer.tsx
+++ b/pages/sites/[slug]/[locale]/profile/treemapper/data-explorer.tsx
@@ -9,7 +9,7 @@ import type {
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
 import Head from 'next/head';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Analytics from '../../../../../../src/features/user/TreeMapper/Analytics';
 import { useTranslations } from 'next-intl';
@@ -37,7 +37,7 @@ function TreeMapperAnalytics({
   const { localizedPath } = useLocalizedPath();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/treemapper/import.tsx
+++ b/pages/sites/[slug]/[locale]/profile/treemapper/import.tsx
@@ -8,8 +8,8 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
+import { useEffect } from 'react';
 import Head from 'next/head';
-import React from 'react';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import { useTranslations } from 'next-intl';
 import ImportData from '../../../../../../src/features/user/TreeMapper/Import';
@@ -36,7 +36,7 @@ export default function Import({
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/treemapper/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/treemapper/index.tsx
@@ -8,8 +8,8 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
+import { useEffect } from 'react';
 import Head from 'next/head';
-import React from 'react';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import TreeMapper from '../../../../../../src/features/user/TreeMapper';
 import { useTranslations } from 'next-intl';
@@ -31,7 +31,7 @@ function TreeMapperPage({ pageProps: { tenantConfig } }: Props): ReactElement {
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/treemapper/my-species.tsx
+++ b/pages/sites/[slug]/[locale]/profile/treemapper/my-species.tsx
@@ -8,8 +8,8 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
+import { useEffect } from 'react';
 import Head from 'next/head';
-import React from 'react';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import MySpecies from '../../../../../../src/features/user/TreeMapper/MySpecies';
 import { useTranslations } from 'next-intl';
@@ -36,7 +36,7 @@ export default function MySpeciesPage({
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/profile/widgets.tsx
+++ b/pages/sites/[slug]/[locale]/profile/widgets.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'next';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 
-import React from 'react';
+import { useState, useEffect } from 'react';
 import { useUserProps } from '../../../../../src/features/common/Layout/UserPropsContext';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import EmbedModal from '../../../../../src/features/user/Widget/EmbedModal';
@@ -33,16 +33,16 @@ function ProfilePage({ pageProps: { tenantConfig } }: Props): ReactElement {
   const router = useRouter();
   const { setTenantConfig } = useTenant();
   const { user } = useUserProps();
-  const [embedModalOpen, setEmbedModalOpen] = React.useState(false);
+  const [embedModalOpen, setEmbedModalOpen] = useState(false);
   const embedModalProps = { embedModalOpen, setEmbedModalOpen, user };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }
   }, [router.isReady]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (user && user.isPrivate) {
       setEmbedModalOpen(true);
     }

--- a/pages/sites/[slug]/[locale]/projects-archive/[p].tsx
+++ b/pages/sites/[slug]/[locale]/projects-archive/[p].tsx
@@ -15,9 +15,9 @@ import type {
   ProjectExtended,
 } from '@planet-sdk/common';
 
+import { useEffect, useState, useContext } from 'react';
 import { useRouter } from 'next/router';
 import useLocalizedPath from '../../../../../src/hooks/useLocalizedPath';
-import React from 'react';
 import { ErrorHandlingContext } from '../../../../../src/features/common/Layout/ErrorHandlingContext';
 import { useProjectProps } from '../../../../../src/features/common/Layout/ProjectPropsContext';
 import Credits from '../../../../../src/features/projectsV2/ProjectsMap/Credits';
@@ -51,10 +51,10 @@ export default function Donate({
   const router = useRouter();
   const { getApi } = useApi();
   const { localizedPath } = useLocalizedPath();
-  const [internalCurrencyCode, setInternalCurrencyCode] = React.useState<
+  const [internalCurrencyCode, setInternalCurrencyCode] = useState<
     string | undefined | null
   >(undefined);
-  const [internalLanguage, setInternalLanguage] = React.useState('');
+  const [internalLanguage, setInternalLanguage] = useState('');
   const locale = useLocale();
   const {
     geoJson,
@@ -71,19 +71,19 @@ export default function Donate({
 
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(pageProps.tenantConfig);
     }
   }, [router.isReady]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setZoomLevel(2);
   }, []);
 
-  const { redirect, setErrors } = React.useContext(ErrorHandlingContext);
+  const { redirect, setErrors } = useContext(ErrorHandlingContext);
 
-  React.useEffect(() => {
+  useEffect(() => {
     async function loadProject() {
       if (
         !internalCurrencyCode ||
@@ -131,7 +131,7 @@ export default function Donate({
     }
   }, [router.query.p, currencyCode, locale]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     async function loadPl(
       project: ConservationProjectExtended | TreeProjectExtended
     ) {
@@ -153,7 +153,7 @@ export default function Donate({
     }
   }, [project]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (
       geoJson?.features[0].properties.id &&
       !router.query.site &&
@@ -177,7 +177,7 @@ export default function Donate({
     }
   }, [project?.slug, router.query.site, router.query.ploc, locale, geoJson]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     //for selecting one of the site of project if user use link  to directly visit to site from home page
     if (project && geoJson && router.query.site) {
       const siteIndex: number = geoJson?.features.findIndex((singleSite) => {
@@ -191,7 +191,7 @@ export default function Donate({
     }
   }, [setSelectedSite, geoJson, project]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     //for selecting one of the intervention . if user use link  to directly visit to intervention from home page
     if (geoJson && router.query.ploc && interventions && project) {
       const singleIntervention: Intervention | undefined = interventions?.find(

--- a/pages/sites/[slug]/[locale]/projects-archive/index.tsx
+++ b/pages/sites/[slug]/[locale]/projects-archive/index.tsx
@@ -12,7 +12,7 @@ import type {
 } from 'next';
 
 import { useRouter } from 'next/router';
-import React from 'react';
+import { useEffect, useState, useContext } from 'react';
 import ProjectsList from '../../../../../src/features/projects/screens/Projects';
 import ProjectsListMeta from '../../../../../src/utils/getMetaTags/ProjectsListMeta';
 import getStoredCurrency from '../../../../../src/utils/countryCurrency/getStoredCurrency';
@@ -58,32 +58,32 @@ export default function Donate({
   // Set tenent
   // set local storage
 
-  const { redirect, setErrors } = React.useContext(ErrorHandlingContext);
+  const { redirect, setErrors } = useContext(ErrorHandlingContext);
   const locale = useLocale();
   const router = useRouter();
   const { getApi } = useApi();
   const { localizedPath } = useLocalizedPath();
-  const [internalCurrencyCode, setInternalCurrencyCode] = React.useState('');
-  const [directGift, setDirectGift] = React.useState<DirectGiftI | null>(null);
-  const [showDirectGift, setShowDirectGift] = React.useState(true);
-  const [internalLanguage, setInternalLanguage] = React.useState('');
+  const [internalCurrencyCode, setInternalCurrencyCode] = useState('');
+  const [directGift, setDirectGift] = useState<DirectGiftI | null>(null);
+  const [showDirectGift, setShowDirectGift] = useState(true);
+  const [internalLanguage, setInternalLanguage] = useState('');
 
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(pageProps.tenantConfig);
     }
   }, [router.isReady]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const getdirectGift = localStorage.getItem('directGift');
     if (getdirectGift) {
       setDirectGift(JSON.parse(getdirectGift));
     }
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (directGift) {
       if (directGift.show === false) {
         setShowDirectGift(false);
@@ -92,21 +92,21 @@ export default function Donate({
   }, [directGift]);
 
   // Deprecation Notice: This route will be removed in next major version
-  React.useEffect(() => {
+  useEffect(() => {
     if (typeof router.query.p === 'string') {
       const safePath = encodeURIComponent(router.query.p);
       router.push(localizedPath(encodeURI(`/projects-archive/${safePath}`)));
     }
   }, [router]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setShowSingleProject(false);
     setProject(null);
     setZoomLevel(1);
   }, []);
 
   // Load all projects
-  React.useEffect(() => {
+  useEffect(() => {
     async function loadProjects() {
       if (
         !internalCurrencyCode ||

--- a/pages/sites/[slug]/[locale]/s/[id].tsx
+++ b/pages/sites/[slug]/[locale]/s/[id].tsx
@@ -9,7 +9,7 @@ import type { APIError, UserPublicProfile } from '@planet-sdk/common';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 import type { AbstractIntlMessages } from 'next-intl';
 
-import React from 'react';
+import { useEffect, useContext } from 'react';
 import { useRouter } from 'next/router';
 import useLocalizedPath from '../../../../../src/hooks/useLocalizedPath';
 import { ErrorHandlingContext } from '../../../../../src/features/common/Layout/ErrorHandlingContext';
@@ -35,9 +35,9 @@ export default function DirectGift({
   const { localizedPath } = useLocalizedPath();
   const { setTenantConfig } = useTenant();
   const { getApi } = useApi();
-  const { redirect, setErrors } = React.useContext(ErrorHandlingContext);
+  const { redirect, setErrors } = useContext(ErrorHandlingContext);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(tenantConfig);
     }
@@ -66,7 +66,7 @@ export default function DirectGift({
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady && router.query.id) {
       loadPublicUserData();
     }

--- a/pages/sites/[slug]/[locale]/verify-email.tsx
+++ b/pages/sites/[slug]/[locale]/verify-email.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'next';
 import type { AbstractIntlMessages } from 'next-intl';
 
-import React from 'react';
+import { useEffect } from 'react';
 import Footer from '../../../../src/features/common/Layout/Footer';
 import LandingSection from '../../../../src/features/common/Layout/LandingSection';
 import VerifyEmailComponent from '../../../../src/features/common/VerifyEmail/VerifyEmail';
@@ -29,7 +29,7 @@ export default function VerifyEmail({ pageProps }: Props): ReactElement {
   const router = useRouter();
   const { setTenantConfig } = useTenant();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       setTenantConfig(pageProps.tenantConfig);
     }

--- a/pages/sites/[slug]/[locale]/vto-fitness-challenge-2023.tsx
+++ b/pages/sites/[slug]/[locale]/vto-fitness-challenge-2023.tsx
@@ -11,7 +11,7 @@ import type {
   GetStaticPropsResult,
 } from 'next';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import SalesforceCampaign from '../../../../src/tenants/salesforce/VTOCampaign2023';
 import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
 import { defaultTenant } from '../../../../tenant.config';

--- a/pages/sites/[slug]/[locale]/vto-fitness-challenge-2024.tsx
+++ b/pages/sites/[slug]/[locale]/vto-fitness-challenge-2024.tsx
@@ -11,7 +11,7 @@ import type {
   GetStaticPropsResult,
 } from 'next';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import SalesforceCampaign from '../../../../src/tenants/salesforce/VTOCampaign2024';
 import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
 import { getTenantConfig } from '../../../../src/utils/multiTenancy/helpers';

--- a/pages/sites/[slug]/[locale]/vto-fitness-challenge.tsx
+++ b/pages/sites/[slug]/[locale]/vto-fitness-challenge.tsx
@@ -11,7 +11,7 @@ import type {
   GetStaticPropsResult,
 } from 'next';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import SalesforceCampaign from '../../../../src/tenants/salesforce/VTOCampaign2025';
 import GetHomeMeta from '../../../../src/utils/getMetaTags/GetHomeMeta';
 import { getTenantConfig } from '../../../../src/utils/multiTenancy/helpers';

--- a/public/assets/images/Custom404Image.tsx
+++ b/public/assets/images/Custom404Image.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function Custom404Image() {
   return (
     <svg

--- a/public/assets/images/NotFound.tsx
+++ b/public/assets/images/NotFound.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../src/features/common/types/common';
 
-import React from 'react';
-
 function NotFound({ className }: IconProps) {
   return (
     <svg

--- a/public/assets/images/PlanetLogo.tsx
+++ b/public/assets/images/PlanetLogo.tsx
@@ -1,8 +1,6 @@
 import type { ReactElement } from 'react';
 import type { IconProps } from '../../../src/features/common/types/common';
 
-import React from 'react';
-
 export default function PlanetLogo({
   width = '40px',
   className,

--- a/public/assets/images/footer/AppStore.tsx
+++ b/public/assets/images/footer/AppStore.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function AppStore() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">

--- a/public/assets/images/footer/GooglePlay.tsx
+++ b/public/assets/images/footer/GooglePlay.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function GooglePlay() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/public/assets/images/footer/MoonIcon.tsx
+++ b/public/assets/images/footer/MoonIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function MoonIcon() {
   return (
     <svg

--- a/public/assets/images/footer/PlanetCJLogo.tsx
+++ b/public/assets/images/footer/PlanetCJLogo.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function PlanetCJLogo() {
   return (
     <svg

--- a/public/assets/images/footer/SunIcon.tsx
+++ b/public/assets/images/footer/SunIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function SunIcon() {
   return (
     <svg

--- a/public/assets/images/footer/UNDecadeLogo.tsx
+++ b/public/assets/images/footer/UNDecadeLogo.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function UNDecadeLogo() {
   return (
     <svg

--- a/public/assets/images/footer/UNEPLogo.tsx
+++ b/public/assets/images/footer/UNEPLogo.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function UNEPLogo() {
   return (
     <svg

--- a/public/assets/images/footer/World.tsx
+++ b/public/assets/images/footer/World.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function World() {
   return (
     <svg

--- a/public/assets/images/icons/AcceptIcon.tsx
+++ b/public/assets/images/icons/AcceptIcon.tsx
@@ -1,8 +1,6 @@
 import type { ReactElement } from 'react';
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 export default function AcceptIcon({
   color = '#333',
   width = '16px',

--- a/public/assets/images/icons/AccountListLoader.tsx
+++ b/public/assets/images/icons/AccountListLoader.tsx
@@ -2,8 +2,6 @@ import type { ReactElement } from 'react';
 
 import themeProperties from '../../../../src/theme/themeProperties';
 
-import React from 'react';
-
 function AccountListLoader(): ReactElement {
   return (
     <svg

--- a/public/assets/images/icons/AddIcon.tsx
+++ b/public/assets/images/icons/AddIcon.tsx
@@ -1,8 +1,6 @@
 import type { ReactElement } from 'react';
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 export default function AddIcon({
   color = '#333',
   width = '16px',

--- a/public/assets/images/icons/BackButton.tsx
+++ b/public/assets/images/icons/BackButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import themeProperties from '../../../../src/theme/themeProperties';
 
 function BackButton() {

--- a/public/assets/images/icons/BankAccountLoader.tsx
+++ b/public/assets/images/icons/BankAccountLoader.tsx
@@ -1,7 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
-
 function BankAccountListLoader(): ReactElement {
   return (
     <svg

--- a/public/assets/images/icons/CancelIcon.tsx
+++ b/public/assets/images/icons/CancelIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function CancelIcon({ width }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" width={width}>

--- a/public/assets/images/icons/CheckCircle.tsx
+++ b/public/assets/images/icons/CheckCircle.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function CheckCircle({ width, color }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width={width}>

--- a/public/assets/images/icons/CloseIcon.tsx
+++ b/public/assets/images/icons/CloseIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function CloseIcon({ color = 'black' }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/public/assets/images/icons/CopyIcon.tsx
+++ b/public/assets/images/icons/CopyIcon.tsx
@@ -1,7 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
-
 export default function CopyIcon(): ReactElement {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">

--- a/public/assets/images/icons/DeleteIcon.tsx
+++ b/public/assets/images/icons/DeleteIcon.tsx
@@ -1,8 +1,6 @@
 import type { ReactElement } from 'react';
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 export default function DeleteIcon({
   color = '#333',
   width = '16px',

--- a/public/assets/images/icons/DownArrow.tsx
+++ b/public/assets/images/icons/DownArrow.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function Icon({ color = '#87b738' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/EditIcon.tsx
+++ b/public/assets/images/icons/EditIcon.tsx
@@ -3,8 +3,6 @@ import type { IconProps } from '../../../../src/features/common/types/common';
 
 import themeProperties from '../../../../src/theme/themeProperties';
 
-import React from 'react';
-
 export default function EditIcon({
   color = themeProperties.designSystem.colors.coreText,
   width = '16px',

--- a/public/assets/images/icons/ExpandIcon.tsx
+++ b/public/assets/images/icons/ExpandIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function ExpandIcon({ color = '#2f3336' }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">

--- a/public/assets/images/icons/ExploreIcon.tsx
+++ b/public/assets/images/icons/ExploreIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { IconProps } from '../../../../src/features/common/types/common';
 
 function ExploreIcon({ color = '#2f3336' }: IconProps) {

--- a/public/assets/images/icons/EyeDisabled.tsx
+++ b/public/assets/images/icons/EyeDisabled.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function EyeDisabled({ color = '#2f3336' }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">

--- a/public/assets/images/icons/EyeIcon.tsx
+++ b/public/assets/images/icons/EyeIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function EyeIcon({ color = '#2f3336' }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512">

--- a/public/assets/images/icons/FileAttachedIcon.tsx
+++ b/public/assets/images/icons/FileAttachedIcon.tsx
@@ -1,8 +1,6 @@
 import type { ReactElement } from 'react';
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function FileAttachedIcon({ color = '#2f3336' }: IconProps): ReactElement {
   return (
     <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/public/assets/images/icons/FileProcessingIcon.tsx
+++ b/public/assets/images/icons/FileProcessingIcon.tsx
@@ -1,8 +1,6 @@
 import type { ReactElement } from 'react';
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function FileProcessingIcon({ color = '#2f3336' }: IconProps): ReactElement {
   return (
     <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/public/assets/images/icons/FileUploadIcon.tsx
+++ b/public/assets/images/icons/FileUploadIcon.tsx
@@ -1,8 +1,6 @@
 import type { ReactElement } from 'react';
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function FileUploadIcon({ color = '#2f3336' }: IconProps): ReactElement {
   return (
     <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/public/assets/images/icons/FilterIcon.tsx
+++ b/public/assets/images/icons/FilterIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function FilterIcon({ color = '#2f3336' }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/public/assets/images/icons/FilterInlineLoader.tsx
+++ b/public/assets/images/icons/FilterInlineLoader.tsx
@@ -1,7 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
-
 function FilterInlineLoader(): ReactElement {
   return (
     <svg

--- a/public/assets/images/icons/FilterLoader.tsx
+++ b/public/assets/images/icons/FilterLoader.tsx
@@ -1,7 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
-
 function FilterLoader(): ReactElement {
   return (
     <svg

--- a/public/assets/images/icons/FireIcon.tsx
+++ b/public/assets/images/icons/FireIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 const FireIcon = ({ width }: IconProps) => {
   return (
     <svg

--- a/public/assets/images/icons/FirePopupIcon.tsx
+++ b/public/assets/images/icons/FirePopupIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 const FirePopupIcon = ({ width }: IconProps) => {
   return (
     <svg

--- a/public/assets/images/icons/Globe.tsx
+++ b/public/assets/images/icons/Globe.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function GlobeLoader() {
   return (
     <svg

--- a/public/assets/images/icons/ImportIcon.tsx
+++ b/public/assets/images/icons/ImportIcon.tsx
@@ -1,7 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
-
 export default function ImportIcon(): ReactElement {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/public/assets/images/icons/InfoIcon.tsx
+++ b/public/assets/images/icons/InfoIcon.tsx
@@ -1,6 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
 import themeProperties from '../../../../src/theme/themeProperties';
 
 const defaultColor = themeProperties.designSystem.colors.coreText;

--- a/public/assets/images/icons/LayerDisabled.tsx
+++ b/public/assets/images/icons/LayerDisabled.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function LayerDisabled() {
   return (
     <svg

--- a/public/assets/images/icons/LayerIcon.tsx
+++ b/public/assets/images/icons/LayerIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function LayerIcon() {
   return (
     <svg

--- a/public/assets/images/icons/LeftIcon.tsx
+++ b/public/assets/images/icons/LeftIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function CancelIcon({ color = 'black' }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 512">

--- a/public/assets/images/icons/LocationIcon.tsx
+++ b/public/assets/images/icons/LocationIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function LocationIcon({ color }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/public/assets/images/icons/MinusIcon.tsx
+++ b/public/assets/images/icons/MinusIcon.tsx
@@ -1,7 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
-
 export default function MinusIcon(): ReactElement {
   return (
     <svg

--- a/public/assets/images/icons/OpenLink.tsx
+++ b/public/assets/images/icons/OpenLink.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function OpenLink() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/public/assets/images/icons/PlayIcon.tsx
+++ b/public/assets/images/icons/PlayIcon.tsx
@@ -1,7 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
-
 export default function PlayIcon(): ReactElement {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">

--- a/public/assets/images/icons/PlusIcon.tsx
+++ b/public/assets/images/icons/PlusIcon.tsx
@@ -1,8 +1,6 @@
 import type { ReactElement } from 'react';
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 export default function PlusIcon({
   color = '#333',
   width = '29',

--- a/public/assets/images/icons/PolygonIcon.tsx
+++ b/public/assets/images/icons/PolygonIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function PolygonIcon({ color = '#2F3336' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/RejectIcon.tsx
+++ b/public/assets/images/icons/RejectIcon.tsx
@@ -1,8 +1,6 @@
 import type { ReactElement } from 'react';
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 export default function RejectIcon({
   color = '#333',
   width = '16px',

--- a/public/assets/images/icons/ResearchIcon.tsx
+++ b/public/assets/images/icons/ResearchIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function ResearchIcon({ color }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/public/assets/images/icons/RightIcon.tsx
+++ b/public/assets/images/icons/RightIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function CancelIcon({ color }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 512">

--- a/public/assets/images/icons/SatelliteIcon.tsx
+++ b/public/assets/images/icons/SatelliteIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function SatelliteIcon({ color }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/public/assets/images/icons/SearchIcon.tsx
+++ b/public/assets/images/icons/SearchIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function SearchIcon(): JSX.Element {
   return (
     <svg

--- a/public/assets/images/icons/SearchIcon.tsx
+++ b/public/assets/images/icons/SearchIcon.tsx
@@ -1,4 +1,4 @@
-function SearchIcon(): JSX.Element {
+function SearchIcon() {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/public/assets/images/icons/Sidebar/DonateIcon.tsx
+++ b/public/assets/images/icons/Sidebar/DonateIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function DonateIcon({ color = '#000' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/Sidebar/GiftIcon.tsx
+++ b/public/assets/images/icons/Sidebar/GiftIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function GiftIcon({ color = '#000' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/Sidebar/Globe.tsx
+++ b/public/assets/images/icons/Sidebar/Globe.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function GlobeIcon({ color = '#000' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/Sidebar/LogoutIcon.tsx
+++ b/public/assets/images/icons/Sidebar/LogoutIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function LogoutIcon({ color = '#000' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/Sidebar/MapIcon.tsx
+++ b/public/assets/images/icons/Sidebar/MapIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function MapIcon({ color = '#000' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/Sidebar/MenuIcon.tsx
+++ b/public/assets/images/icons/Sidebar/MenuIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function MenuIcon() {
   return (
     <svg

--- a/public/assets/images/icons/Sidebar/NotionLinkIcon.tsx
+++ b/public/assets/images/icons/Sidebar/NotionLinkIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 const NotionLinkIcon = ({ color = '#5f6368' }: IconProps) => {
   return (
     <svg

--- a/public/assets/images/icons/Sidebar/PlanetCashIcon.tsx
+++ b/public/assets/images/icons/Sidebar/PlanetCashIcon.tsx
@@ -1,8 +1,6 @@
 import type { ReactElement } from 'react';
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function PlanetCashIcon({ color = '#000' }: IconProps): ReactElement {
   return (
     <svg

--- a/public/assets/images/icons/Sidebar/RegisterIcon.tsx
+++ b/public/assets/images/icons/Sidebar/RegisterIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function RegisterTreeIcon() {
   return (
     <svg

--- a/public/assets/images/icons/Sidebar/SettingsIcon.tsx
+++ b/public/assets/images/icons/Sidebar/SettingsIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function SettingsIcon() {
   return (
     <svg

--- a/public/assets/images/icons/Sidebar/TreeMapperIcon.tsx
+++ b/public/assets/images/icons/Sidebar/TreeMapperIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function Icon() {
   return (
     <svg

--- a/public/assets/images/icons/Sidebar/UserIcon.tsx
+++ b/public/assets/images/icons/Sidebar/UserIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function UserIcon({ color = '#000' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/Sidebar/Widget.tsx
+++ b/public/assets/images/icons/Sidebar/Widget.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function WidgetIcon({ color = '#000' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/SourceIcon.tsx
+++ b/public/assets/images/icons/SourceIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function SourceIcon({ color = '#2F3336' }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/public/assets/images/icons/ThreeDotIcon.tsx
+++ b/public/assets/images/icons/ThreeDotIcon.tsx
@@ -1,7 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
-
 export default function ThreeDotIcon(): ReactElement {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512">

--- a/public/assets/images/icons/TransactionIcon.tsx
+++ b/public/assets/images/icons/TransactionIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function CancelIcon({ width, color = '#2f3336' }: IconProps) {
   return (
     <svg width={width} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">

--- a/public/assets/images/icons/TransactionsNotFound.tsx
+++ b/public/assets/images/icons/TransactionsNotFound.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function TransactionsNotFound() {
   return (
     <svg

--- a/public/assets/images/icons/TreeIcon.tsx
+++ b/public/assets/images/icons/TreeIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function TreeIcon({ color = '#68B030', width, height }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/TreesIcon.tsx
+++ b/public/assets/images/icons/TreesIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function TreesIcon({ color = '#68B030', width, height }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/UnderMaintenance.tsx
+++ b/public/assets/images/icons/UnderMaintenance.tsx
@@ -1,7 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
-
 export default function UnderMaintenanceImage(): ReactElement {
   return (
     <svg

--- a/public/assets/images/icons/VerifyEmail.tsx
+++ b/public/assets/images/icons/VerifyEmail.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function VerifyEmailIcon() {
   return (
     <svg

--- a/public/assets/images/icons/donation/PaymentFailed.tsx
+++ b/public/assets/images/icons/donation/PaymentFailed.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function PaymentFailedIllustration() {
   return (
     <svg

--- a/public/assets/images/icons/donation/PaymentPending.tsx
+++ b/public/assets/images/icons/donation/PaymentPending.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function PaymentPendingIllustration() {
   return (
     <svg

--- a/public/assets/images/icons/headerIcons/BackArrow.tsx
+++ b/public/assets/images/icons/headerIcons/BackArrow.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function BackArrow() {
   return (
     <svg

--- a/public/assets/images/icons/headerIcons/Close.tsx
+++ b/public/assets/images/icons/headerIcons/Close.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function Close({ color = '#1e2225' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/headerIcons/Me.tsx
+++ b/public/assets/images/icons/headerIcons/Me.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const Me = () => {
   return (
     <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/public/assets/images/icons/manageProjects/AccessDenied.tsx
+++ b/public/assets/images/icons/manageProjects/AccessDenied.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function AccessDenied({
   width = '1145.572px',
   height = '819.907px',

--- a/public/assets/images/icons/manageProjects/AddProject.tsx
+++ b/public/assets/images/icons/manageProjects/AddProject.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function AddProject() {
   return (
     <svg

--- a/public/assets/images/icons/manageProjects/Cross.tsx
+++ b/public/assets/images/icons/manageProjects/Cross.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function CrossIcon() {
   return (
     <svg

--- a/public/assets/images/icons/manageProjects/Delete.tsx
+++ b/public/assets/images/icons/manageProjects/Delete.tsx
@@ -1,6 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
 import themeProperties from '../../../../../src/theme/themeProperties';
 
 const defaultColor = themeProperties.designSystem.colors.coreText;

--- a/public/assets/images/icons/manageProjects/Expand.tsx
+++ b/public/assets/images/icons/manageProjects/Expand.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function Expand({ color = '#2f3336' }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">

--- a/public/assets/images/icons/manageProjects/Info.tsx
+++ b/public/assets/images/icons/manageProjects/Info.tsx
@@ -1,3 +1,4 @@
+import { useContext } from 'react';
 import { ThemeContext } from '../../../../../src/theme/themeContext';
 import themeProperties from '../../../../../src/theme/themeProperties';
 

--- a/public/assets/images/icons/manageProjects/Info.tsx
+++ b/public/assets/images/icons/manageProjects/Info.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import { ThemeContext } from '../../../../../src/theme/themeContext';
 import themeProperties from '../../../../../src/theme/themeProperties';
 
 function InfoIcon() {
-  const { theme } = React.useContext(ThemeContext);
+  const { theme } = useContext(ThemeContext);
 
   return (
     <svg

--- a/public/assets/images/icons/manageProjects/NotReviewed.tsx
+++ b/public/assets/images/icons/manageProjects/NotReviewed.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function NotReviewed() {
   return (
     <svg

--- a/public/assets/images/icons/manageProjects/PDFIcon.tsx
+++ b/public/assets/images/icons/manageProjects/PDFIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function PDFIcon({ color = 'currentColor' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/manageProjects/PDFRed.tsx
+++ b/public/assets/images/icons/manageProjects/PDFRed.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function PDFRed() {
   return (
     <svg

--- a/public/assets/images/icons/manageProjects/Pencil.tsx
+++ b/public/assets/images/icons/manageProjects/Pencil.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function EditIcon({ color = '#848484' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/manageProjects/Polygon.tsx
+++ b/public/assets/images/icons/manageProjects/Polygon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function PolygonIcon({ color = 'currentColor' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/manageProjects/Star.tsx
+++ b/public/assets/images/icons/manageProjects/Star.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function Icon({ color = '#2f3336', className }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/manageProjects/SubmitForReviewImage.tsx
+++ b/public/assets/images/icons/manageProjects/SubmitForReviewImage.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function SubmitForReviewImage() {
   return (
     <svg

--- a/public/assets/images/icons/manageProjects/Trash.tsx
+++ b/public/assets/images/icons/manageProjects/Trash.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function TrashIcon() {
   return (
     <svg

--- a/public/assets/images/icons/manageProjects/UnderReview.tsx
+++ b/public/assets/images/icons/manageProjects/UnderReview.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function UnderReview() {
   return (
     <svg

--- a/public/assets/images/icons/manageProjects/changeChocolate.tsx
+++ b/public/assets/images/icons/manageProjects/changeChocolate.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function ChangeChocolateIcon() {
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 255.12 255.12">
     <g id="Ebene_1" data-name="Ebene 1">

--- a/public/assets/images/icons/manageProjects/stopTalkingStartPlanting.tsx
+++ b/public/assets/images/icons/manageProjects/stopTalkingStartPlanting.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function StopTalkingStartPlanting() {
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 255.12 255.12">
     <g id="Ebene_1" data-name="Ebene 1">

--- a/public/assets/images/icons/megaMenuIcons/changeChocolate.tsx
+++ b/public/assets/images/icons/megaMenuIcons/changeChocolate.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function ChangeChocolateIcon() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 255.12 255.12">

--- a/public/assets/images/icons/megaMenuIcons/childrenAndYouth.tsx
+++ b/public/assets/images/icons/megaMenuIcons/childrenAndYouth.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function ChildrenYouthIcon() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 255.12 255.12">

--- a/public/assets/images/icons/megaMenuIcons/overview.tsx
+++ b/public/assets/images/icons/megaMenuIcons/overview.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function OverviewIcon() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 255.12 255.12">

--- a/public/assets/images/icons/megaMenuIcons/partners.tsx
+++ b/public/assets/images/icons/megaMenuIcons/partners.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function PartnerIcon() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 255.12 255.12">

--- a/public/assets/images/icons/megaMenuIcons/stoptalkingstartplanting.tsx
+++ b/public/assets/images/icons/megaMenuIcons/stoptalkingstartplanting.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function StopTalkingStartPlantingIcon() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 255.12 255.12">

--- a/public/assets/images/icons/megaMenuIcons/trillionTrees.tsx
+++ b/public/assets/images/icons/megaMenuIcons/trillionTrees.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function TrillionTreesIcon() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 255.12 255.12">

--- a/public/assets/images/icons/megaMenuIcons/yucatan.tsx
+++ b/public/assets/images/icons/megaMenuIcons/yucatan.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function YucatanIcon() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 255.12 255.12">

--- a/public/assets/images/icons/project/Agroforestry.tsx
+++ b/public/assets/images/icons/project/Agroforestry.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const Agroforestry = () => {
   return (
     <svg viewBox="0 0 37 31" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/public/assets/images/icons/project/BlackTree.tsx
+++ b/public/assets/images/icons/project/BlackTree.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
 function BlackTree({ color = '#4d5153' }: IconProps) {

--- a/public/assets/images/icons/project/Car.tsx
+++ b/public/assets/images/icons/project/Car.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function Car() {
   return (
     <svg

--- a/public/assets/images/icons/project/Conservation.tsx
+++ b/public/assets/images/icons/project/Conservation.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const Conservation = () => {
   return (
     <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/public/assets/images/icons/project/Email.tsx
+++ b/public/assets/images/icons/project/Email.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
 function Email({ color = '#4d5153' }: IconProps) {

--- a/public/assets/images/icons/project/Location.tsx
+++ b/public/assets/images/icons/project/Location.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function Location({ color = '#4d5153' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/project/ManagedRegeneration.tsx
+++ b/public/assets/images/icons/project/ManagedRegeneration.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const ManagedRegeneration = () => {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 15" fill="none">

--- a/public/assets/images/icons/project/Mangroves.tsx
+++ b/public/assets/images/icons/project/Mangroves.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const Mangroves = () => {
   return (
     <svg viewBox="0 0 44 37" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/public/assets/images/icons/project/NaturalRegeneration.tsx
+++ b/public/assets/images/icons/project/NaturalRegeneration.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const NaturalRegeneration = () => {
   return (
     <svg viewBox="0 0 34 29" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/public/assets/images/icons/project/Plane.tsx
+++ b/public/assets/images/icons/project/Plane.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function Plane() {
   return (
     <svg

--- a/public/assets/images/icons/project/RubberDuck.tsx
+++ b/public/assets/images/icons/project/RubberDuck.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function RubberDuck() {
   return (
     <svg

--- a/public/assets/images/icons/project/TreePlanting.tsx
+++ b/public/assets/images/icons/project/TreePlanting.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const TreePlanting = () => {
   return (
     <svg viewBox="0 0 32 33" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/public/assets/images/icons/project/UrbanRestoration.tsx
+++ b/public/assets/images/icons/project/UrbanRestoration.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const UrbanRestoration = () => {
   return (
     <svg viewBox="0 0 32 34" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/public/assets/images/icons/project/WorldWeb.tsx
+++ b/public/assets/images/icons/project/WorldWeb.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function WorldWeb({ color = '#4d5153' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/projectV2/DownloadIcon.tsx
+++ b/public/assets/images/icons/projectV2/DownloadIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
 const DownloadIcon = ({ width, color }: IconProps) => {

--- a/public/assets/images/icons/projectV2/DownloadReportIcon.tsx
+++ b/public/assets/images/icons/projectV2/DownloadReportIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
 const DownloadReportIcon = ({ width, color }: IconProps) => {

--- a/public/assets/images/icons/projectV2/ExpandIcon.tsx
+++ b/public/assets/images/icons/projectV2/ExpandIcon.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 const ExpandIcon = () => (
   <svg xmlns="http://www.w3.org/2000/svg" width={16} height={17} fill="none">
     <path

--- a/public/assets/images/icons/projectV2/FieldReviewedIcon.tsx
+++ b/public/assets/images/icons/projectV2/FieldReviewedIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
 const FieldReviewedIcon = ({ width }: IconProps) => {

--- a/public/assets/images/icons/projectV2/ListIcon.tsx
+++ b/public/assets/images/icons/projectV2/ListIcon.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
 const ListIcon = ({ color, height }: IconProps) => (

--- a/public/assets/images/icons/projectV2/LocationIconSolid.tsx
+++ b/public/assets/images/icons/projectV2/LocationIconSolid.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
 const LocationIconSolid = ({ width }: IconProps) => {

--- a/public/assets/images/icons/projectV2/MailIcon.tsx
+++ b/public/assets/images/icons/projectV2/MailIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
 const MailIcon = ({ width, color }: IconProps) => {

--- a/public/assets/images/icons/projectV2/OffSiteReviewedIcon.tsx
+++ b/public/assets/images/icons/projectV2/OffSiteReviewedIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
 const OffSiteReviewedIcon = ({ width }: IconProps) => {

--- a/public/assets/images/icons/projectV2/PlayButtonIcon.tsx
+++ b/public/assets/images/icons/projectV2/PlayButtonIcon.tsx
@@ -1,5 +1,4 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
-import React from 'react';
 
 const PlayButtonIcon = ({ width }: IconProps) => {
   return (

--- a/public/assets/images/icons/projectV2/RightArrowIcon.tsx
+++ b/public/assets/images/icons/projectV2/RightArrowIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
 const RightArrowIcon = ({ width, color }: IconProps) => {

--- a/public/assets/images/icons/projectV2/SiteIcon.tsx
+++ b/public/assets/images/icons/projectV2/SiteIcon.tsx
@@ -1,5 +1,4 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
-import React from 'react';
 
 const SiteIcon = ({ width, color }: IconProps) => {
   return (

--- a/public/assets/images/icons/projectV2/TopProjectIcon.tsx
+++ b/public/assets/images/icons/projectV2/TopProjectIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
 const TopProjectIcon = ({ width }: IconProps) => {

--- a/public/assets/images/icons/projectV2/ViewProfileIcon.tsx
+++ b/public/assets/images/icons/projectV2/ViewProfileIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
 export const ViewProfileIcon = ({ width, color }: IconProps) => {

--- a/public/assets/images/icons/projectV2/WebsiteLinkIcon.tsx
+++ b/public/assets/images/icons/projectV2/WebsiteLinkIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
 const WebsiteLinkIcon = ({ width, color }: IconProps) => {

--- a/public/assets/images/icons/share/Download.tsx
+++ b/public/assets/images/icons/share/Download.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function Icon({ color = 'black' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/share/DownloadSolid.tsx
+++ b/public/assets/images/icons/share/DownloadSolid.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function Icon({ color = 'black' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/share/Email.tsx
+++ b/public/assets/images/icons/share/Email.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function Icon({ color = 'black' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/share/EmailSolid.tsx
+++ b/public/assets/images/icons/share/EmailSolid.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function Icon({ color = 'black' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/share/Instagram.tsx
+++ b/public/assets/images/icons/share/Instagram.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function Icon({ color = 'black' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/userProfileIcons/Camera.tsx
+++ b/public/assets/images/icons/userProfileIcons/Camera.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import themeProperties from '../../../../../src/theme/themeProperties';
 
 function Camera() {

--- a/public/assets/images/icons/userProfileIcons/CameraWhite.tsx
+++ b/public/assets/images/icons/userProfileIcons/CameraWhite.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function Icon() {
   return (
     <svg

--- a/public/assets/images/icons/userProfileIcons/Redeem.tsx
+++ b/public/assets/images/icons/userProfileIcons/Redeem.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function Icon({ color = 'black' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/userProfileIcons/ScrollDown.tsx
+++ b/public/assets/images/icons/userProfileIcons/ScrollDown.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function Icon({ color = '#87b738' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/userProfileIcons/Settings.tsx
+++ b/public/assets/images/icons/userProfileIcons/Settings.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function Icon({ color = 'black' }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/userProfileIcons/Share.tsx
+++ b/public/assets/images/icons/userProfileIcons/Share.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../../../../src/features/common/types/common';
 
-import React from 'react';
-
 function Share({ width, height, color, solid }: IconProps) {
   return (
     <svg

--- a/public/assets/images/icons/userProfileIcons/Shovel.tsx
+++ b/public/assets/images/icons/userProfileIcons/Shovel.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function Icon({ color }) {
   return (
     <svg

--- a/public/assets/images/icons/userProfileIcons/Support.tsx
+++ b/public/assets/images/icons/userProfileIcons/Support.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export default function Support(props) {
   return (
     <svg

--- a/public/assets/images/navigation/Moon.tsx
+++ b/public/assets/images/navigation/Moon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function Moon() {
   return (
     <svg

--- a/public/assets/images/navigation/Sun.tsx
+++ b/public/assets/images/navigation/Sun.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function Sun() {
   return (
     <svg

--- a/src/features/common/CarouselSlider/index.tsx
+++ b/src/features/common/CarouselSlider/index.tsx
@@ -1,7 +1,7 @@
-import type { ReactElement } from 'react';
+import type { Dispatch, ReactElement, ReactNode, SetStateAction } from 'react';
 import type { InnerSlider, Settings } from 'react-slick';
 
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
@@ -14,7 +14,7 @@ import styles from './CarouselSlider.module.scss';
 
 interface ExtendedInnerSlider extends InnerSlider {
   props: Settings & {
-    children: React.ReactNode[]; // Override the type of children in Settings
+    children: ReactNode[]; // Override the type of children in Settings
   };
 }
 
@@ -53,7 +53,7 @@ interface CarouselSliderProps {
   carouselData: ReactElement[];
   settings: Settings;
   currentSlide: number;
-  setCurrentSlide: React.Dispatch<React.SetStateAction<number>>;
+  setCurrentSlide: Dispatch<SetStateAction<number>>;
   totalSlides: number;
 }
 

--- a/src/features/common/ContentLoaders/ButtonLoader.tsx
+++ b/src/features/common/ContentLoaders/ButtonLoader.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 function ButtonLoader() {
   return (
     <svg

--- a/src/features/common/ContentLoaders/LeaderboardLoader.tsx
+++ b/src/features/common/ContentLoaders/LeaderboardLoader.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function LeaderboardLoader() {
   return (
     <svg

--- a/src/features/common/ContentLoaders/Projects/AccessDeniedLoader.tsx
+++ b/src/features/common/ContentLoaders/Projects/AccessDeniedLoader.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import AccessDenied from '../../../../../public/assets/images/icons/manageProjects/AccessDenied';
 
 function AccessDeniedLoader(): ReactElement {

--- a/src/features/common/ContentLoaders/Projects/GlobeLoader.tsx
+++ b/src/features/common/ContentLoaders/Projects/GlobeLoader.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 
 import { motion } from 'framer-motion';
-import React from 'react';
+
 import GlobeLoader from '../../../../../public/assets/images/icons/Globe';
 
 function GlobeContentLoader(): ReactElement {

--- a/src/features/common/ContentLoaders/Projects/ProjectLoader.tsx
+++ b/src/features/common/ContentLoaders/Projects/ProjectLoader.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import ContentLoader from 'react-content-loader';
 
 function ProjectLoader(): ReactElement {

--- a/src/features/common/ContentLoaders/Projects/ProjectLoaderDetails.tsx
+++ b/src/features/common/ContentLoaders/Projects/ProjectLoaderDetails.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import ContentLoader from 'react-content-loader';
 
 function ProjectLoaderDetails(): ReactElement {

--- a/src/features/common/ContentLoaders/TopProgressBar.tsx
+++ b/src/features/common/ContentLoaders/TopProgressBar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import themeProperties from '../../../theme/themeProperties';
 import { LinearProgress, styled } from '@mui/material';
 

--- a/src/features/common/ContentLoaders/UserProfile/UserProfile.tsx
+++ b/src/features/common/ContentLoaders/UserProfile/UserProfile.tsx
@@ -1,6 +1,6 @@
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
-import React from 'react';
+
 import styles from './UserProfileLoader.module.scss';
 
 export const UserProfileLoader = () => {

--- a/src/features/common/CopyToClipboard/index.tsx
+++ b/src/features/common/CopyToClipboard/index.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, SyntheticEvent } from 'react';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import CopyIcon from '../../../../public/assets/images/icons/CopyIcon';
 import styles from './styles.module.scss';
 import Snackbar from '@mui/material/Snackbar';

--- a/src/features/common/InputTypes/MaterialButton.tsx
+++ b/src/features/common/InputTypes/MaterialButton.tsx
@@ -1,7 +1,5 @@
 import type { ReactNode, MouseEventHandler } from 'react';
 
-import React from 'react';
-
 type Props = {
   children: ReactNode;
   onClick?: MouseEventHandler<HTMLButtonElement> | undefined;

--- a/src/features/common/LandingVideo/PlayButton.tsx
+++ b/src/features/common/LandingVideo/PlayButton.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useRouter } from 'next/router';
 import PlayIcon from '../../../../public/assets/images/icons/PlayIcon';
 import styles from './styles.module.scss';

--- a/src/features/common/LandingVideo/index.tsx
+++ b/src/features/common/LandingVideo/index.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import styles from './styles.module.scss';
 import { useTranslations } from 'next-intl';
 import ReactPlayer from 'react-player/lazy';

--- a/src/features/common/Layout/CookiePolicy/index.tsx
+++ b/src/features/common/Layout/CookiePolicy/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import CloseIcon from '../../../../../public/assets/images/icons/CloseIcon';
 import styles from './CookiePolicy.module.scss';
 import { useUserProps } from '../UserPropsContext';

--- a/src/features/common/Layout/CustomModal/index.tsx
+++ b/src/features/common/Layout/CustomModal/index.tsx
@@ -1,5 +1,5 @@
 import Modal from '@mui/material/Modal';
-import React from 'react';
+
 import { useTranslations } from 'next-intl';
 import styles from './CustomModal.module.scss';
 

--- a/src/features/common/Layout/DarkModeSwitch.tsx/index.tsx
+++ b/src/features/common/Layout/DarkModeSwitch.tsx/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import MoonIcon from '../../../../../public/assets/images/footer/MoonIcon';
 import SunIcon from '../../../../../public/assets/images/footer/SunIcon';
 import { ThemeContext } from '../../../../theme/themeContext';

--- a/src/features/common/Layout/DonationReceiptContext.tsx
+++ b/src/features/common/Layout/DonationReceiptContext.tsx
@@ -12,7 +12,7 @@ import type {
   UnissuedReceiptDataAPI,
 } from '../../user/DonationReceipt/donationReceiptTypes';
 
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import { RECEIPT_STATUS } from '../../user/DonationReceipt/donationReceiptTypes';
 import {
   transformAddress,

--- a/src/features/common/Layout/ErrorHandlingContext.tsx
+++ b/src/features/common/Layout/ErrorHandlingContext.tsx
@@ -1,7 +1,7 @@
 import type { SetStateAction, Dispatch, ReactNode } from 'react';
 import type { SerializedError } from '@planet-sdk/common';
 
-import React, { createContext, useState } from 'react';
+import { createContext, useState } from 'react';
 import useLocalizedPath from '../../../hooks/useLocalizedPath';
 import { useRouter } from 'next/router';
 

--- a/src/features/common/Layout/ErrorPopup/index.tsx
+++ b/src/features/common/Layout/ErrorPopup/index.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 
-import React, { useContext, useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import CloseIcon from '../../../../../public/assets/images/icons/CloseIcon';
 import styles from './ErrorPopup.module.scss';
 import { useTranslations } from 'next-intl';

--- a/src/features/common/Layout/Footer/SelectLanguageAndCountry.tsx
+++ b/src/features/common/Layout/Footer/SelectLanguageAndCountry.tsx
@@ -8,7 +8,7 @@ import {
   FormControlLabel,
   RadioGroup,
 } from '@mui/material';
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import {
   getCountryDataBy,
   sortCountriesByTranslation,

--- a/src/features/common/Layout/Footer/index.tsx
+++ b/src/features/common/Layout/Footer/index.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import UNEPLogo from '../../../../../public/assets/images/footer/UNEPLogo';
 import World from '../../../../../public/assets/images/footer/World';
 import getLanguageName from '../../../../utils/language/getLanguageName';

--- a/src/features/common/Layout/Navbar/microComponents/Archive/getSubMenu.tsx
+++ b/src/features/common/Layout/Navbar/microComponents/Archive/getSubMenu.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import ChildrenYouthIcon from '../../../../../../../public/assets/images/icons/megaMenuIcons/childrenAndYouth';
 import OverviewIcon from '../../../../../../../public/assets/images/icons/megaMenuIcons/overview';
 import PartnerIcon from '../../../../../../../public/assets/images/icons/megaMenuIcons/partners';

--- a/src/features/common/Layout/Navbar/microComponents/NavbarMenuItem.tsx
+++ b/src/features/common/Layout/Navbar/microComponents/NavbarMenuItem.tsx
@@ -1,5 +1,5 @@
 import type { MenuItemDescription, MenuItemTitle } from '../tenant';
-import type { JSX } from 'react';
+import type { ReactElement } from 'react';
 import type { MenuItem } from '@planet-sdk/common';
 
 import { useMemo } from 'react';
@@ -34,7 +34,7 @@ import { doesLinkMatchPath } from '../../../../../utils/navbarUtils';
 import { useRouter } from 'next/router';
 import useLocalizedPath from '../../../../../hooks/useLocalizedPath';
 
-const navbarMenuIcons: Record<MenuItemTitle, JSX.Element> = {
+const navbarMenuIcons: Record<MenuItemTitle, ReactElement> = {
   platform: <PlatformIcon />,
   redeemCode: <RedeemCodeIcon />,
   support: <SupportIcon />,

--- a/src/features/common/Layout/ProjectPropsContext.tsx
+++ b/src/features/common/Layout/ProjectPropsContext.tsx
@@ -23,13 +23,7 @@ import type {
   SampleTreeRegistration,
 } from '../types/intervention';
 
-import React, {
-  useState,
-  createContext,
-  useRef,
-  useContext,
-  useEffect,
-} from 'react';
+import { useState, createContext, useRef, useContext, useEffect } from 'react';
 import { getTimeTravelConfig } from '../../../utils/mapsV2/timeTravel';
 import { ParamsContext } from './QueryParamsContext';
 

--- a/src/features/common/Layout/QueryParamsContext.tsx
+++ b/src/features/common/Layout/QueryParamsContext.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-import React, { createContext, useEffect, useState } from 'react';
+import { createContext, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useLocale } from 'next-intl';
 

--- a/src/features/common/Layout/RedeemPopup/index.tsx
+++ b/src/features/common/Layout/RedeemPopup/index.tsx
@@ -1,5 +1,5 @@
 // unused component
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import CloseIcon from '../../../../../public/assets/images/icons/CloseIcon';
 import styles from './RedeemPopup.module.scss';
 import { useTranslations } from 'next-intl';

--- a/src/features/common/Layout/TabbedView/TabSteps.tsx
+++ b/src/features/common/Layout/TabbedView/TabSteps.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement, SyntheticEvent } from 'react';
 import type { TabItem } from './TabbedViewTypes';
 
-import React from 'react';
 import { Tab, Tabs } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import useLocalizedPath from '../../../../hooks/useLocalizedPath';

--- a/src/features/common/Layout/UnderMaintenance/index.tsx
+++ b/src/features/common/Layout/UnderMaintenance/index.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import { useTranslations } from 'next-intl';
 import UnderMaintenanceImage from '../../../../../public/assets/images/icons/UnderMaintenance';
 import styles from './UnderMaintenance.module.scss';

--- a/src/features/common/Layout/UserLayout/UserLayout.tsx
+++ b/src/features/common/Layout/UserLayout/UserLayout.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import type { NavLinkType, SubMenuItemType } from './NavLink';
 
 import { useRouter } from 'next/router';
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import MenuIcon from '../../../../../public/assets/images/icons/Sidebar/MenuIcon';
 import BackArrow from '../../../../../public/assets/images/icons/headerIcons/BackArrow';

--- a/src/features/common/Layout/index.tsx
+++ b/src/features/common/Layout/index.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import theme from '../../../theme/theme';
 import { useTheme } from '../../../theme/themeContext';
 import CookiePolicy from './CookiePolicy';

--- a/src/features/common/ProjectTypeIcon/index.tsx
+++ b/src/features/common/ProjectTypeIcon/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Agroforestry from '../../../../public/assets/images/icons/project/Agroforestry';
 import Mangroves from '../../../../public/assets/images/icons/project/Mangroves';
 import NaturalRegeneration from '../../../../public/assets/images/icons/project/NaturalRegeneration';

--- a/src/features/common/RedeemCode/EnterRedeemCode.tsx
+++ b/src/features/common/RedeemCode/EnterRedeemCode.tsx
@@ -7,7 +7,6 @@ import { Controller, useForm } from 'react-hook-form';
 import CancelIcon from '../../../../public/assets/images/icons/CancelIcon';
 import styles from '../../../../src/features/common/RedeemCode/style/RedeemModal.module.scss';
 import Button from '@mui/material/Button';
-import React from 'react';
 
 export interface EnterRedeemCodeProps {
   isLoading: boolean;

--- a/src/features/common/TreeCounter/TreeCounter.tsx
+++ b/src/features/common/TreeCounter/TreeCounter.tsx
@@ -1,7 +1,7 @@
 import type { CircularProgressProps } from '@mui/material/CircularProgress';
 
 import MuiCircularProgress from '@mui/material/CircularProgress';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import treeCounterStyles from './TreeCounter.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
 import { localizedAbbreviatedNumber } from '../../../utils/getFormattedNumber';

--- a/src/features/common/VerifyEmail/VerifyEmail.tsx
+++ b/src/features/common/VerifyEmail/VerifyEmail.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import styles from './VerifyEmail.module.scss';
 import { useTranslations } from 'next-intl';
 import VerifyEmailIcon from '../../../../public/assets/images/icons/VerifyEmail';

--- a/src/features/common/types/map.d.ts
+++ b/src/features/common/types/map.d.ts
@@ -1,6 +1,6 @@
 import type Supercluster from 'supercluster';
 import type { User } from '@planet-sdk/common';
-import type { MutableRefObject } from 'react';
+import type { Dispatch, SetStateAction, MutableRefObject } from 'react';
 import type { UserPublicProfile } from '@planet-sdk/common';
 import type { ContributionProps } from '../../user/RegisterTrees/RegisterTrees/SingleContribution';
 import type { FlyToInterpolator } from 'react-map-gl';
@@ -137,11 +137,9 @@ export interface RegisteredTreesGeometry {
 }
 
 export interface RegisterTreesFormProps {
-  setContributionGUID: React.Dispatch<React.SetStateAction<string>>;
-  setContributionDetails: React.Dispatch<
-    React.SetStateAction<ContributionProps | null>
-  >;
-  setRegistered: React.Dispatch<React.SetStateAction<boolean>>;
+  setContributionGUID: Dispatch<SetStateAction<string>>;
+  setContributionDetails: Dispatch<SetStateAction<ContributionProps | null>>;
+  setRegistered: Dispatch<SetStateAction<boolean>>;
 }
 
 // Map styling

--- a/src/features/donations/components/DirectGift.tsx
+++ b/src/features/donations/components/DirectGift.tsx
@@ -1,6 +1,5 @@
 import type { SetState } from '../../common/types/common';
 
-import React from 'react';
 import styles from '../styles/DirectGift.module.scss';
 import CancelIcon from '../../../../public/assets/images/icons/CancelIcon';
 import { useTranslations } from 'next-intl';

--- a/src/features/projects/components/Intervention/InterventionDetails.tsx
+++ b/src/features/projects/components/Intervention/InterventionDetails.tsx
@@ -5,7 +5,7 @@ import type {
 } from '../../../common/types/intervention';
 import type { SliderImage } from './ImageSlider';
 
-import React from 'react';
+import { useEffect, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import styles from '../../styles/Intervention.module.scss';
 import { localizedAbbreviatedNumber } from '../../../../utils/getFormattedNumber';
@@ -39,13 +39,11 @@ export default function InterventionDetails({
     useProjectProps();
   const t = useTranslations('Maps');
   const locale = useLocale();
-  const [treeCount, setTreeCount] = React.useState(1);
-  const [plantationArea, setPlantationArea] = React.useState(0);
-  const [sampleTreeImages, setSampleTreeImages] = React.useState<SliderImage[]>(
-    []
-  );
+  const [treeCount, setTreeCount] = useState(1);
+  const [plantationArea, setPlantationArea] = useState(0);
+  const [sampleTreeImages, setSampleTreeImages] = useState<SliderImage[]>([]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     let count = 0;
     if (
       activeIntervention &&
@@ -74,7 +72,7 @@ export default function InterventionDetails({
     }
   }, [activeIntervention]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (
       activeIntervention &&
       activeIntervention.type === 'multi-tree-registration' &&

--- a/src/features/projects/components/PopupProject.tsx
+++ b/src/features/projects/components/PopupProject.tsx
@@ -3,8 +3,8 @@ import type {
   ConservationProjectConcise,
   TreeProjectConcise,
 } from '@planet-sdk/common/build/types/project/map';
-import React from 'react';
 
+import { useContext } from 'react';
 import getImageUrl from '../../../utils/getImageURL';
 import { useLocale, useTranslations } from 'next-intl';
 import getFormatedCurrency from '../../../utils/countryCurrency/getFormattedCurrency';
@@ -41,7 +41,7 @@ export default function PopupProject({
   const tManageProjects = useTranslations('ManageProjects');
   const locale = useLocale();
   const { token } = useUserProps();
-  const { embed } = React.useContext(ParamsContext);
+  const { embed } = useContext(ParamsContext);
   const { tenantConfig } = useTenant();
 
   const ImageSource = project.image

--- a/src/features/projects/components/ProjectSnippet.tsx
+++ b/src/features/projects/components/ProjectSnippet.tsx
@@ -6,7 +6,7 @@ import type {
   TreeProjectExtended,
 } from '@planet-sdk/common';
 
-import React from 'react';
+import { useContext } from 'react';
 import getImageUrl from '../../../utils/getImageURL';
 import { useLocale, useTranslations } from 'next-intl';
 import getFormatedCurrency from '../../../utils/countryCurrency/getFormattedCurrency';
@@ -60,7 +60,7 @@ export default function ProjectSnippet({
   const tCountry = useTranslations('Country');
   const tManageProjects = useTranslations('ManageProjects');
   const storedCampaign = sessionStorage.getItem('campaign');
-  const { embed, callbackUrl } = React.useContext(ParamsContext);
+  const { embed, callbackUrl } = useContext(ParamsContext);
   const ImageSource = project.image
     ? getImageUrl('project', 'medium', project.image)
     : '';

--- a/src/features/projects/components/ProjectsMap.tsx
+++ b/src/features/projects/components/ProjectsMap.tsx
@@ -3,7 +3,7 @@ import type { PopupData } from './maps/Markers';
 import type { Intervention } from '../../common/types/intervention';
 import type { ReactElement } from 'react';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import MapGL, { NavigationControl, Popup } from 'react-map-gl';
 import getMapStyle from '../../../utils/maps/getMapStyle';
 import styles from '../styles/ProjectsMap.module.scss';
@@ -51,7 +51,7 @@ export default function ProjectsMap(): ReactElement {
   } = useProjectProps();
 
   const t = useTranslations('Maps');
-  const { embed, showProjectList } = React.useContext(ParamsContext);
+  const { embed, showProjectList } = useContext(ParamsContext);
   //Map
   const _onStateChange = (state: any) => setMapState({ ...state });
   const _onViewportChange = (view: any) => setViewPort({ ...view });
@@ -71,7 +71,7 @@ export default function ProjectsMap(): ReactElement {
     loadMapStyle();
   }, []);
 
-  const [showDetails, setShowDetails] = React.useState<ShowDetailsProps>({
+  const [showDetails, setShowDetails] = useState<ShowDetailsProps>({
     coordinates: null,
     show: false,
   });
@@ -135,13 +135,13 @@ export default function ProjectsMap(): ReactElement {
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (zoomLevel !== 2) {
       setShowDetails({ ...showDetails, show: false });
     }
   }, [zoomLevel]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (embed === 'true' && showProjectList === 'false') {
       const newViewport = {
         ...viewport,

--- a/src/features/projects/components/maps/Explore.tsx
+++ b/src/features/projects/components/maps/Explore.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
+import type { ChangeEvent } from 'react';
 
-import React from 'react';
+import { useEffect, useContext } from 'react';
 import styles from '../../styles/ProjectsMap.module.scss';
 import CancelIcon from '../../../../../public/assets/images/icons/CancelIcon';
 import ExploreIcon from '../../../../../public/assets/images/icons/ExploreIcon';
@@ -63,8 +64,8 @@ export default function Explore(): ReactElement {
   const router = useRouter();
   const { localizedPath } = useLocalizedPath();
 
-  const { theme } = React.useContext(ThemeContext);
-  const { embed, callbackUrl } = React.useContext(ParamsContext);
+  const { theme } = useContext(ThemeContext);
+  const { embed, callbackUrl } = useContext(ParamsContext);
   const { isImpersonationModeOn } = useUserProps();
 
   const handleModalClose = () => {
@@ -80,7 +81,7 @@ export default function Explore(): ReactElement {
     setExplorePotential(event.target.checked);
   }; */
   const handleExploreDeforestationChange = (
-    event: React.ChangeEvent<HTMLInputElement>
+    event: ChangeEvent<HTMLInputElement>
   ) => {
     setExploreDeforestation(event.target.checked);
   };
@@ -140,7 +141,7 @@ export default function Explore(): ReactElement {
   };
 
   const handleExploreProjectsChange = (
-    event: React.ChangeEvent<HTMLInputElement>
+    event: ChangeEvent<HTMLInputElement>
   ) => {
     setExploreProjects(event.target.checked);
     setShowProjects(event.target.checked);
@@ -189,7 +190,7 @@ export default function Explore(): ReactElement {
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     document.addEventListener('mousedown', (event) => {
       if (exploreExpanded) {
         if (
@@ -205,7 +206,7 @@ export default function Explore(): ReactElement {
     });
   });
 
-  // React.useEffect(() => {
+  // useEffect(() => {
   //   if (exploreExpanded) {
   //     setMapState({ ...mapState, dragPan: false });
   //   } else {

--- a/src/features/projects/components/maps/ExploreInfoModal.tsx
+++ b/src/features/projects/components/maps/ExploreInfoModal.tsx
@@ -2,7 +2,7 @@ import type { ReactElement, RefObject } from 'react';
 import type { ExploreOption } from '../../../common/types/ProjectPropsContextInterface';
 import type { SetState } from '../../../common/types/common';
 
-import React from 'react';
+import { forwardRef } from 'react';
 import styles from '../../styles/ProjectsMap.module.scss';
 import { useTranslations } from 'next-intl';
 import OpenLink from '../../../../../public/assets/images/icons/OpenLink';
@@ -115,6 +115,4 @@ function ExploreInfoModal({
   );
 }
 
-export default React.forwardRef((props: Props) => (
-  <ExploreInfoModal {...props} />
-));
+export default forwardRef((props: Props) => <ExploreInfoModal {...props} />);

--- a/src/features/projects/components/maps/ExploreLayers.tsx
+++ b/src/features/projects/components/maps/ExploreLayers.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import { Layer, Source } from 'react-map-gl';
 import { useProjectProps } from '../../../common/Layout/ProjectPropsContext';
 import { LayerManager, Layer as LayerM } from 'layer-manager/dist/components';

--- a/src/features/projects/components/maps/Home.tsx
+++ b/src/features/projects/components/maps/Home.tsx
@@ -6,8 +6,8 @@ import type {
 } from '../../../common/types/ProjectPropsContextInterface';
 import type { SetState } from '../../../common/types/common';
 
+import { useEffect } from 'react';
 import { FlyToInterpolator } from 'react-map-gl';
-import React from 'react';
 import Markers from './Markers';
 import { easeCubic } from 'd3-ease';
 
@@ -32,7 +32,7 @@ export default function Home({
   setViewPort,
   defaultZoom,
 }: Props): ReactElement {
-  React.useEffect(() => {
+  useEffect(() => {
     const newViewport = {
       ...viewport,
       latitude: defaultMapCenter[0],

--- a/src/features/projects/components/maps/ImageDropdown.tsx
+++ b/src/features/projects/components/maps/ImageDropdown.tsx
@@ -1,12 +1,12 @@
-import type { ReactElement } from 'react';
+import type { ReactElement, ChangeEvent } from 'react';
 import type {
   Imagery,
   RasterData,
 } from '../../../common/types/ProjectPropsContextInterface';
 import type { SetState } from '../../../common/types/common';
 
+import { useContext, useState } from 'react';
 import { FormControl, NativeSelect } from '@mui/material';
-import React from 'react';
 import BootstrapInput from '../../../common/InputTypes/BootstrapInput';
 import styles from '../../styles/VegetationChange.module.scss';
 import sources from '../../../../../public/data/maps/sources.json';
@@ -38,28 +38,26 @@ export default function ImageDropdown({
   setSelectedSource2,
   isMobile,
 }: Props): ReactElement {
-  const { embed, showProjectDetails } = React.useContext(ParamsContext);
+  const { embed, showProjectDetails } = useContext(ParamsContext);
 
-  const [isSource1MenuOpen, setIsSource1MenuOpen] = React.useState(
+  const [isSource1MenuOpen, setIsSource1MenuOpen] = useState(
     isMobile ? false : true
   );
-  const [isSource2MenuOpen, setIsSource2MenuOpen] = React.useState(
+  const [isSource2MenuOpen, setIsSource2MenuOpen] = useState(
     isMobile ? false : true
   );
 
-  const handleChangeYear1 = (event: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleChangeYear1 = (event: ChangeEvent<HTMLSelectElement>) => {
     setSelectedYear1(event.target.value);
   };
-  const handleChangeYear2 = (event: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleChangeYear2 = (event: ChangeEvent<HTMLSelectElement>) => {
     setSelectedYear2(event.target.value);
   };
-  const handleChangeSource1 = (event: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleChangeSource1 = (event: ChangeEvent<HTMLSelectElement>) => {
     setSelectedSource1(event.target.value as keyof Imagery);
     if (isMobile) setIsSource1MenuOpen(false);
   };
-  const handleChangeSource2 = (
-    event: React.ChangeEvent<{ value: unknown }>
-  ) => {
+  const handleChangeSource2 = (event: ChangeEvent<{ value: unknown }>) => {
     setSelectedSource2(event.target.value as keyof Imagery);
     if (isMobile) setIsSource2MenuOpen(false);
   };

--- a/src/features/projects/components/maps/Interventions.tsx
+++ b/src/features/projects/components/maps/Interventions.tsx
@@ -7,7 +7,6 @@ import type {
 } from '../../../common/types/intervention';
 import type { Feature, Point, Polygon } from 'geojson';
 
-import React from 'react';
 import { Layer, Marker } from 'react-map-gl';
 import { Source } from 'react-map-gl';
 import { useProjectProps } from '../../../common/Layout/ProjectPropsContext';

--- a/src/features/projects/components/maps/Location.tsx
+++ b/src/features/projects/components/maps/Location.tsx
@@ -5,7 +5,6 @@ import type {
   TreeProjectExtended,
 } from '@planet-sdk/common/build/types/project/extended';
 
-import React from 'react';
 import { Marker } from 'react-map-gl';
 import styles from '../../styles/ProjectsMap.module.scss';
 

--- a/src/features/projects/components/maps/Markers.tsx
+++ b/src/features/projects/components/maps/Markers.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import type { SetState } from '../../../common/types/common';
 import type { MapProject } from '../../../common/types/ProjectPropsContextInterface';
 
-import React from 'react';
+import { useState, useContext, useRef } from 'react';
 import { Marker, Popup } from 'react-map-gl';
 import PopupProject from '../PopupProject';
 import styles from '../../styles/ProjectsMap.module.scss';
@@ -36,9 +36,9 @@ export default function Markers({
   let timer: NodeJS.Timeout;
   const router = useRouter();
   const { localizedPath } = useLocalizedPath();
-  const [open, setOpen] = React.useState(false);
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
-  const { embed, callbackUrl } = React.useContext(ParamsContext);
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const { embed, callbackUrl } = useContext(ParamsContext);
   const handleClose = () => {
     setOpen(false);
   };

--- a/src/features/projects/components/maps/Project.tsx
+++ b/src/features/projects/components/maps/Project.tsx
@@ -12,7 +12,7 @@ import type {
 import type { SetState } from '../../../common/types/common';
 import type { Position } from 'geojson';
 
-import React from 'react';
+import { useEffect, useState } from 'react';
 import { getRasterData } from '../../../../utils/apiRequests/api';
 import zoomToLocation from '../../../../utils/maps/zoomToLocation';
 import zoomToProjectSite from '../../../../utils/maps/zoomToProjectSite';
@@ -47,7 +47,7 @@ export default function Project({
   const router = useRouter();
   const { localizedPath } = useLocalizedPath();
 
-  const [plantPolygonCoordinates, setPlantPolygonCoordinates] = React.useState<
+  const [plantPolygonCoordinates, setPlantPolygonCoordinates] = useState<
     Position[] | null
   >(null);
 
@@ -94,7 +94,7 @@ export default function Project({
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (
       interventions &&
       selectedPl &&
@@ -111,7 +111,7 @@ export default function Project({
       );
   }, [selectedPl]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (selectedPl) {
       if (selectedPl.geometry.type === 'Polygon') {
         const locationCoordinates = selectedPl.geometry.coordinates[0];

--- a/src/features/projects/components/maps/ProjectPolygon.tsx
+++ b/src/features/projects/components/maps/ProjectPolygon.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from 'react';
 import type { FeatureCollection } from 'geojson';
 
-import React from 'react';
 import { Layer, Source } from 'react-map-gl';
 import { useProjectProps } from '../../../common/Layout/ProjectPropsContext';
 

--- a/src/features/projects/components/maps/ProjectTabs.tsx
+++ b/src/features/projects/components/maps/ProjectTabs.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
+import { useContext } from 'react';
 import { useRouter } from 'next/router';
 import { useTranslations } from 'next-intl';
 import LocationIcon from '../../../../../public/assets/images/icons/LocationIcon';
@@ -12,7 +12,7 @@ import { ParamsContext } from '../../../common/Layout/QueryParamsContext';
 import themeProperties from '../../../../theme/themeProperties';
 
 export default function ProjectTabs(): ReactElement {
-  const { embed, showProjectDetails } = React.useContext(ParamsContext);
+  const { embed, showProjectDetails } = useContext(ParamsContext);
   const router = useRouter();
   const t = useTranslations('Maps');
   const { selectedMode, setSelectedMode, rasterData } = useProjectProps();

--- a/src/features/projects/components/maps/SatelliteLayer.tsx
+++ b/src/features/projects/components/maps/SatelliteLayer.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import { Layer, Source } from 'react-map-gl';
 
 interface Props {

--- a/src/features/projects/components/maps/Sites.tsx
+++ b/src/features/projects/components/maps/Sites.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
+import { useEffect } from 'react';
 import zoomToProjectSite from '../../../../utils/maps/zoomToProjectSite';
 import { useProjectProps } from '../../../common/Layout/ProjectPropsContext';
 import SatelliteLayer from './SatelliteLayer';
@@ -21,7 +21,7 @@ export default function Sites(): ReactElement {
     interventionsLoaded,
   } = useProjectProps();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!hoveredPl && !selectedPl) {
       zoomToProjectSite(
         geoJson,

--- a/src/features/projects/components/maps/SitesDropdown.tsx
+++ b/src/features/projects/components/maps/SitesDropdown.tsx
@@ -1,11 +1,11 @@
-import type { ReactElement } from 'react';
+import type { ReactElement, ChangeEvent } from 'react';
 import type {
   ConservationProjectExtended,
   TreeProjectExtended,
 } from '@planet-sdk/common/build/types/project/extended';
 import type { SitesGeoJSON } from '../../../common/types/ProjectPropsContextInterface';
 
-import React from 'react';
+import { useContext } from 'react';
 import { FormControl, NativeSelect } from '@mui/material';
 import { useRouter } from 'next/router';
 import PolygonIcon from '../../../../../public/assets/images/icons/PolygonIcon';
@@ -26,11 +26,11 @@ export default function SitesDropdown(): ReactElement {
     isPolygonMenuOpen,
     setIsPolygonMenuOpen,
   } = useProjectProps();
-  const { embed } = React.useContext(ParamsContext);
+  const { embed } = useContext(ParamsContext);
   const router = useRouter();
   const { localizedPath } = useLocalizedPath();
   const handleChangeSite = (
-    event: React.ChangeEvent<HTMLSelectElement>,
+    event: ChangeEvent<HTMLSelectElement>,
     project: TreeProjectExtended | ConservationProjectExtended,
     geoJson: SitesGeoJSON
   ) => {

--- a/src/features/projects/components/maps/TimeTravel.tsx
+++ b/src/features/projects/components/maps/TimeTravel.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import type { Map } from 'mapbox-gl';
 import type { Imagery } from '../../../common/types/ProjectPropsContextInterface';
 
-import React from 'react';
+import { useEffect, useState } from 'react';
 import mapboxgl from 'mapbox-gl';
 import MapboxCompare from 'mapbox-gl-compare';
 import ImageDropdown from './ImageDropdown';
@@ -13,14 +13,12 @@ export default function TimeTravel(): ReactElement {
   const { mapRef, geoJson, rasterData, isMobile, siteViewPort, selectedMode } =
     useProjectProps();
 
-  const [before, setBefore] = React.useState<Map>();
-  const [after, setAfter] = React.useState<Map>();
-  const [selectedSource1, setSelectedSource1] =
-    React.useState<keyof Imagery>('esri');
-  const [selectedSource2, setSelectedSource2] =
-    React.useState<keyof Imagery>('esri');
-  const [selectedYear1, setSelectedYear1] = React.useState('2014');
-  const [selectedYear2, setSelectedYear2] = React.useState('2021');
+  const [before, setBefore] = useState<Map>();
+  const [after, setAfter] = useState<Map>();
+  const [selectedSource1, setSelectedSource1] = useState<keyof Imagery>('esri');
+  const [selectedSource2, setSelectedSource2] = useState<keyof Imagery>('esri');
+  const [selectedYear1, setSelectedYear1] = useState('2014');
+  const [selectedYear2, setSelectedYear2] = useState('2021');
 
   const EMPTY_STYLE = {
     version: 8,
@@ -28,7 +26,7 @@ export default function TimeTravel(): ReactElement {
     layers: [],
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (typeof window !== 'undefined' && mapRef.current) {
       const center = mapRef.current.getMap().getCenter();
       const zoom = mapRef.current.getMap().getZoom();
@@ -80,14 +78,14 @@ export default function TimeTravel(): ReactElement {
     }
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (before && siteViewPort) {
       before.setCenter(siteViewPort.center);
       before.setZoom(siteViewPort.zoom);
     }
   }, [selectedMode, geoJson]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     function loadLayers() {
       // Planet Labs
       if (before && after) {

--- a/src/features/projects/components/maps/VegetationChange.tsx
+++ b/src/features/projects/components/maps/VegetationChange.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import { Layer, Source } from 'react-map-gl';
 
 interface Props {

--- a/src/features/projects/components/maps/ZoomButtons.tsx
+++ b/src/features/projects/components/maps/ZoomButtons.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import MinusIcon from '../../../../../public/assets/images/icons/MinusIcon';
 import PlusIcon from '../../../../../public/assets/images/icons/PlusIcon';
 import styles from '../../styles/ZoomButtons.module.scss';

--- a/src/features/projects/components/projectDetails/ProjectContactDetails.tsx
+++ b/src/features/projects/components/projectDetails/ProjectContactDetails.tsx
@@ -4,9 +4,9 @@ import type {
   TreeProjectExtended,
 } from '@planet-sdk/common';
 
+import { useContext } from 'react';
 import Link from 'next/link';
 import { ParamsContext } from '../../../common/Layout/QueryParamsContext';
-import React from 'react';
 import styles from './../../styles/ProjectDetails.module.scss';
 import { useTranslations } from 'next-intl';
 import BlackTree from '../../../../../public/assets/images/icons/project/BlackTree';
@@ -22,7 +22,7 @@ interface Props {
 function ProjectContactDetails({ project }: Props): ReactElement | null {
   const t = useTranslations('Donate');
   const tCountry = useTranslations('Country');
-  const { embed } = React.useContext(ParamsContext);
+  const { embed } = useContext(ParamsContext);
   const { darkGrey } = themeProperties.designSystem.colors;
   const contactAddress =
     project.tpo && project.tpo.address

--- a/src/features/projects/components/projectDetails/ProjectInfo.tsx
+++ b/src/features/projects/components/projectDetails/ProjectInfo.tsx
@@ -4,7 +4,7 @@ import type {
   TreeProjectExtended,
 } from '@planet-sdk/common/build/types/project/extended';
 
-import React from 'react';
+import { useEffect, useState, Fragment } from 'react';
 import styles from './../../styles/ProjectDetails.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
 import { getPDFFile } from '../../../../utils/getImageURL';
@@ -68,8 +68,8 @@ function ProjectInfo({ project }: Props): ReactElement {
       value: 'other',
     },
   ];
-  const [ownerTypes, setOwnerTypes] = React.useState<string[]>([]);
-  React.useEffect(() => {
+  const [ownerTypes, setOwnerTypes] = useState<string[]>([]);
+  useEffect(() => {
     if (
       project.purpose === 'trees' &&
       project.metadata.siteOwnerType &&
@@ -91,7 +91,7 @@ function ProjectInfo({ project }: Props): ReactElement {
     }
   }, [locale]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (
       project.purpose === 'conservation' &&
       project.metadata.landOwnershipType &&
@@ -228,7 +228,7 @@ function ProjectInfo({ project }: Props): ReactElement {
               {project.metadata.activitySeasons.map(
                 (season, index, activitySeasons) => {
                   return (
-                    <React.Fragment key={seasons[season - 1].title}>
+                    <Fragment key={seasons[season - 1].title}>
                       {seasons[season - 1].title}
                       {index === activitySeasons.length - 2 ? (
                         <> {tManageProjects('and')} </>
@@ -237,7 +237,7 @@ function ProjectInfo({ project }: Props): ReactElement {
                       ) : (
                         ', '
                       )}
-                    </React.Fragment>
+                    </Fragment>
                   );
                 }
               )}
@@ -256,7 +256,7 @@ function ProjectInfo({ project }: Props): ReactElement {
               {project.metadata.plantingSeasons.map(
                 (season, index, plantingSeasons) => {
                   return (
-                    <React.Fragment key={seasons[season - 1].title}>
+                    <Fragment key={seasons[season - 1].title}>
                       {seasons[season - 1].title}
                       {index === plantingSeasons.length - 2 ? (
                         <> {tManageProjects('and')} </>
@@ -265,7 +265,7 @@ function ProjectInfo({ project }: Props): ReactElement {
                       ) : (
                         ', '
                       )}
-                    </React.Fragment>
+                    </Fragment>
                   );
                 }
               )}
@@ -310,7 +310,7 @@ function ProjectInfo({ project }: Props): ReactElement {
               <div className={styles.infoText}>
                 {ownerTypes.map((ownerType, index) => {
                   return (
-                    <React.Fragment key={ownerType}>
+                    <Fragment key={ownerType}>
                       {ownerType}
                       {index === ownerTypes.length - 2 ? (
                         <> {tManageProjects('and')} </>
@@ -319,7 +319,7 @@ function ProjectInfo({ project }: Props): ReactElement {
                       ) : (
                         ', '
                       )}
-                    </React.Fragment>
+                    </Fragment>
                   );
                 })}
               </div>
@@ -356,7 +356,7 @@ function ProjectInfo({ project }: Props): ReactElement {
               <div className={styles.infoText}>
                 {ownerTypes.map((ownerType, index) => {
                   return (
-                    <React.Fragment key={ownerType}>
+                    <Fragment key={ownerType}>
                       {ownerType}
                       {index === ownerTypes.length - 2 ? (
                         <> {tManageProjects('and')} </>
@@ -365,7 +365,7 @@ function ProjectInfo({ project }: Props): ReactElement {
                       ) : (
                         ', '
                       )}
-                    </React.Fragment>
+                    </Fragment>
                   );
                 })}
               </div>

--- a/src/features/projects/components/projectDetails/TopProjectReports.tsx
+++ b/src/features/projects/components/projectDetails/TopProjectReports.tsx
@@ -1,6 +1,5 @@
 import type { Review } from '@planet-sdk/common/build/types/project/common';
 
-import React from 'react';
 import styles from './../../styles/ProjectDetails.module.scss';
 import VerifiedIcon from '@mui/icons-material/Verified';
 import { getPDFFile } from '../../../../utils/getImageURL';

--- a/src/features/projects/components/projects/Filters.tsx
+++ b/src/features/projects/components/projects/Filters.tsx
@@ -1,7 +1,7 @@
-import type { ReactElement } from 'react';
+import type { ChangeEvent, ReactElement } from 'react';
 import type { TreeProjectClassification } from '@planet-sdk/common/build/types/project/common';
 
-import React, { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import styles from '../../styles/Filters.module.scss';
 import { useTranslations } from 'next-intl';
 import { FormControlLabel, FormGroup } from '@mui/material';
@@ -17,7 +17,7 @@ export default function Filters(): ReactElement {
   const { projects, setFilteredProjects, filtersOpen, setFilterOpen } =
     useProjectProps();
 
-  const [type, setType] = React.useState<Record<string, boolean>>({
+  const [type, setType] = useState<Record<string, boolean>>({
     'natural-regeneration': true,
     'managed-regeneration': true,
     'large-scale-planting': true,
@@ -27,9 +27,9 @@ export default function Filters(): ReactElement {
     mangroves: true,
   });
 
-  const [filters, setFilters] = React.useState<string[] | null>(null);
+  const [filters, setFilters] = useState<string[] | null>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     function filterProjects() {
       const filteredProjects = projects
         ? projects.filter((project) => {
@@ -55,7 +55,7 @@ export default function Filters(): ReactElement {
     }
   }, [projects, type]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     function getFilters() {
       const filters =
         projects !== null
@@ -81,7 +81,7 @@ export default function Filters(): ReactElement {
     }
   }, [projects]);
 
-  const handleTypeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleTypeChange = (event: ChangeEvent<HTMLInputElement>) => {
     setType({ ...type, [event.target.name]: event.target.checked });
   };
 

--- a/src/features/projects/components/projects/Header.tsx
+++ b/src/features/projects/components/projects/Header.tsx
@@ -2,7 +2,6 @@ import type { ReactElement } from 'react';
 import type { SetState } from '../../../common/types/common';
 import type { MapProject } from '../../../common/types/ProjectPropsContextInterface';
 
-import React from 'react';
 import SearchIcon from '../../../../../public/assets/images/icons/SearchIcon';
 import { useTranslations } from 'next-intl';
 

--- a/src/features/projects/components/projects/SearchBar.tsx
+++ b/src/features/projects/components/projects/SearchBar.tsx
@@ -1,6 +1,5 @@
 import type { RefObject } from 'react';
 
-import React from 'react';
 import { useTranslations } from 'next-intl';
 import CancelIcon from '../../../../../public/assets/images/icons/CancelIcon';
 import SearchIcon from '../../../../../public/assets/images/icons/SearchIcon';

--- a/src/features/projects/screens/Projects.tsx
+++ b/src/features/projects/screens/Projects.tsx
@@ -4,7 +4,7 @@ import type { MapProject } from '../../common/types/ProjectPropsContextInterface
 import type { APIError } from '@planet-sdk/common';
 import type { Tenant } from '@planet-sdk/common';
 
-import React from 'react';
+import { useEffect, useContext, useState, useRef, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import MuiButton from '../../common/InputTypes/MuiButton';
 import ProjectLoader from '../../common/ContentLoaders/Projects/ProjectLoader';
@@ -45,25 +45,25 @@ function ProjectsList({
   const screenHeight = window.innerHeight;
   const isMobile = screenWidth <= 767;
   const { getApi } = useApi();
-  const { embed, showProjectList } = React.useContext(ParamsContext);
+  const { embed, showProjectList } = useContext(ParamsContext);
   const { isImpersonationModeOn } = useUserProps();
   const isEmbed = embed === 'true';
-  const [scrollY, setScrollY] = React.useState(0);
-  const [hideSidebar, setHideSidebar] = React.useState(isEmbed);
+  const [scrollY, setScrollY] = useState(0);
+  const [hideSidebar, setHideSidebar] = useState(isEmbed);
   const tDonate = useTranslations('Donate');
   const tCountry = useTranslations('Country');
   const tMaps = useTranslations('Maps');
-  const [selectedTab, setSelectedTab] = React.useState<'all' | 'top'>('all');
-  const [searchMode, setSearchMode] = React.useState(false);
-  const [searchValue, setSearchValue] = React.useState('');
-  const [trottledSearchValue, setTrottledSearchValue] = React.useState('');
-  const [searchProjectResults, setSearchProjectResults] = React.useState<
+  const [selectedTab, setSelectedTab] = useState<'all' | 'top'>('all');
+  const [searchMode, setSearchMode] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
+  const [trottledSearchValue, setTrottledSearchValue] = useState('');
+  const [searchProjectResults, setSearchProjectResults] = useState<
     MapProject[] | undefined
   >();
-  const [shouldSortProjectList, setShouldSortProjectList] = React.useState<
+  const [shouldSortProjectList, setShouldSortProjectList] = useState<
     boolean | null
   >(null);
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const { setErrors } = useContext(ErrorHandlingContext);
   const { tenantConfig } = useTenant();
 
   useDebouncedEffect(
@@ -74,7 +74,7 @@ function ProjectsList({
     [searchValue]
   );
 
-  const searchRef = React.useRef(null);
+  const searchRef = useRef(null);
 
   function getProjects(
     projects: MapProject[],
@@ -155,7 +155,7 @@ function ProjectsList({
     }
   }
 
-  const allProjects = React.useMemo(() => {
+  const allProjects = useMemo(() => {
     if (shouldSortProjectList !== null) {
       if (!shouldSortProjectList) {
         return getProjects(projects, 'all_sorted');
@@ -165,7 +165,7 @@ function ProjectsList({
     }
   }, [projects, shouldSortProjectList]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const _searchProjectResults = getSearchProjects(
       projects,
       trottledSearchValue
@@ -173,7 +173,7 @@ function ProjectsList({
     setSearchProjectResults(_searchProjectResults);
   }, [trottledSearchValue, projects]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     async function setListOrder() {
       try {
         const res = await getApi<Tenant>(`/app/tenants/${tenantConfig.id}`);
@@ -185,17 +185,14 @@ function ProjectsList({
     setListOrder();
   }, []);
 
-  const topProjects = React.useMemo(
-    () => getProjects(projects, 'top'),
-    [projects]
-  );
+  const topProjects = useMemo(() => getProjects(projects, 'top'), [projects]);
 
   const showTopProjectsList =
     tenantConfig.config.slug !== 'salesforce' &&
     topProjects !== undefined &&
     topProjects.length > 0;
 
-  React.useEffect(() => {
+  useEffect(() => {
     showTopProjectsList ? setSelectedTab('top') : null;
   }, []);
 

--- a/src/features/projects/screens/SingleProjectDetails.tsx
+++ b/src/features/projects/screens/SingleProjectDetails.tsx
@@ -1,10 +1,11 @@
 import type { ReactElement } from 'react';
 
+import { useEffect } from 'react';
 import Modal from '@mui/material/Modal';
 import MuiButton from '../../common/InputTypes/MuiButton';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
-import React, { useState, useContext } from 'react';
+import { useState, useContext } from 'react';
 import ReactPlayer from 'react-player/lazy';
 import ReadMoreReact from 'read-more-react';
 import BackButton from '../../../../public/assets/images/icons/BackButton';
@@ -60,10 +61,10 @@ function SingleProjectDetails(): ReactElement {
   const isEmbed = embed === 'true';
   const [hideProjectContainer, setHideProjectContainer] = useState(isEmbed);
 
-  React.useEffect(() => {
+  useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
-  const [openModal, setModalOpen] = React.useState(false);
+  const [openModal, setModalOpen] = useState(false);
   const handleModalClose = () => {
     setModalOpen(false);
   };

--- a/src/features/projectsV2/ProjectDetails/components/ProjectReviews.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/ProjectReviews.tsx
@@ -1,6 +1,5 @@
 import type { Review } from '@planet-sdk/common';
 
-import React from 'react';
 import { useTranslations } from 'next-intl';
 import styles from '../styles/ProjectReviews.module.scss';
 import SingleReview from './microComponents/SingleReview';

--- a/src/features/projectsV2/ProjectDetails/components/VideoPlayer.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/VideoPlayer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import styles from '../styles/VideoPlayer.module.scss';
 import PlayButtonIcon from '../../../../../public/assets/images/icons/projectV2/PlayButtonIcon';
 import ReactPlayer from 'react-player/lazy';

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/DownloadButton.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/DownloadButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import DownloadIcon from '../../../../../../public/assets/images/icons/projectV2/DownloadIcon';
 import styles from '../../styles/ProjectInfo.module.scss';
 import themeProperties from '../../../../../theme/themeProperties';

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/DownloadsLabel.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/DownloadsLabel.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import type { ReactNode } from 'react';
+
 import styles from '../../styles/ProjectInfo.module.scss';
 
 interface Props {
-  children: React.JSX.Element;
+  children: ReactNode;
 }
 
 const DownloadsLabel = ({ children }: Props) => {

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/ImageCarousel.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/ImageCarousel.tsx
@@ -1,6 +1,6 @@
 import type { SetState } from '../../../../common/types/common';
 
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import Stories from 'react-insta-stories';
 import getImageUrl from '../../../../../utils/getImageURL';
 import { SingleCarouselImage } from './SingleCarouselImage';

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/InfoIconPopup.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/InfoIconPopup.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { ReactNode } from 'react';
+
 import NewInfoIcon from '../../../../../../public/assets/images/icons/projectV2/NewInfoIcon';
 import { bindHover, bindPopover } from 'material-ui-popup-state';
 import HoverPopover from 'material-ui-popup-state/HoverPopover';
@@ -8,7 +9,7 @@ interface Props {
   height: number;
   width: number;
   color: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 const InfoIconPopup = ({ height, width, color, children }: Props) => {

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/InterventionSeason.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/InterventionSeason.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useTranslations } from 'next-intl';
 
 interface Props {

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/ProgressReportItem.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/ProgressReportItem.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styles from '../../styles/ProjectInfo.module.scss';
 import DownloadsLabel from './DownloadsLabel';
 

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/ProjectCertificates.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/ProjectCertificates.tsx
@@ -1,6 +1,5 @@
 import type { Certificate } from '@planet-sdk/common';
 
-import React from 'react';
 import styles from '../../styles/ProjectInfo.module.scss';
 import DownloadsLabel from './DownloadsLabel';
 import DownloadButton from './DownloadButton';

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/ProjectExpenseReports.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/ProjectExpenseReports.tsx
@@ -1,6 +1,5 @@
 import type { ProjectExpense } from '@planet-sdk/common';
 
-import React from 'react';
 import styles from '../../styles/ProjectInfo.module.scss';
 import getFormatedCurrency from '../../../../../utils/countryCurrency/getFormattedCurrency';
 import { useLocale } from 'next-intl';

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/SingleContactDetail.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/SingleContactDetail.tsx
@@ -1,10 +1,12 @@
-import React, { useMemo } from 'react';
+import type { ReactNode } from 'react';
+
+import { useMemo } from 'react';
 import styles from '../../styles/ProjectInfo.module.scss';
 import RightArrowIcon from '../../../../../../public/assets/images/icons/projectV2/RightArrowIcon';
 
 interface Props {
   contactInfo: {
-    icon: React.JSX.Element;
+    icon: ReactNode;
     title: string | null;
     link: string | null;
     shouldOpenNewTab: boolean;

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/SingleProjectInfoItem.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/SingleProjectInfoItem.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import type { ReactElement } from 'react';
+
 import styles from '../../styles/ProjectInfo.module.scss';
 
 interface Props {
-  title: React.ReactElement | string;
-  children: React.ReactElement;
+  title: ReactElement | string;
+  children: ReactElement;
 }
 
 const SingleProjectInfoItem = ({ title, children }: Props) => {

--- a/src/features/projectsV2/ProjectListControls/ProjectListControlForMobile.tsx
+++ b/src/features/projectsV2/ProjectListControls/ProjectListControlForMobile.tsx
@@ -5,7 +5,7 @@ import type { MapProject } from '../../common/types/projectv2';
 import type { ViewMode } from '../../common/Layout/ProjectsLayout/MobileProjectsLayout';
 import type { MapOptions } from '../ProjectsMapContext';
 
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import styles from './styles/ProjectListControls.module.scss';
 import ProjectListTabForMobile from './microComponents/ProjectListTabForMobile';

--- a/src/features/projectsV2/ProjectListControls/microComponents/ProjectListTabForMobile.tsx
+++ b/src/features/projectsV2/ProjectListControls/microComponents/ProjectListTabForMobile.tsx
@@ -1,6 +1,6 @@
+import type { ReactNode } from 'react';
 import type { ProjectTabs } from '..';
 
-import React from 'react';
 import { useTranslations } from 'next-intl';
 import StarIcon from '../../../../../public/assets/images/icons/projectV2/StarIcon';
 import styles from '../styles/ProjectListControls.module.scss';
@@ -14,8 +14,8 @@ interface ProjectListTabForMobileProps {
 }
 interface TabItemProps {
   selectedTab: ProjectTabs;
-  icon?: React.ReactNode | undefined;
-  label: React.ReactNode;
+  icon?: ReactNode | undefined;
+  label: ReactNode;
 }
 const ProjectListTabForMobile = ({
   projectCount,

--- a/src/features/projectsV2/ProjectListControls/microComponents/ProjectListTabLargeScreen.tsx
+++ b/src/features/projectsV2/ProjectListControls/microComponents/ProjectListTabLargeScreen.tsx
@@ -1,3 +1,4 @@
+import type { SyntheticEvent } from 'react';
 import type { SetState } from '../../../common/types/common';
 import type { ProjectTabs } from '..';
 
@@ -25,7 +26,7 @@ const ProjectListTabLargeScreen = ({
 }: ProjectListTabLargeScreenProps) => {
   const t = useTranslations('AllProjects');
   const { colors } = themeProperties.designSystem;
-  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+  const handleChange = (event: SyntheticEvent, newValue: number) => {
     setTabSelected(newValue === 0 ? 'topProjects' : 'allProjects');
     setIsFilterOpen(false);
   };

--- a/src/features/projectsV2/ProjectListControls/microComponents/ViewModeTabs.tsx
+++ b/src/features/projectsV2/ProjectListControls/microComponents/ViewModeTabs.tsx
@@ -1,7 +1,7 @@
+import type { ReactNode } from 'react';
 import type { SetState } from '../../../common/types/common';
 import type { ViewMode } from '../../../common/Layout/ProjectsLayout/MobileProjectsLayout';
 
-import React from 'react';
 import { useTranslations } from 'next-intl';
 import themeProperties from '../../../../theme/themeProperties';
 import styles from '../styles/ProjectListControls.module.scss';
@@ -17,7 +17,7 @@ interface ViewModeTabsProps {
 
 interface TabItemProps {
   selectedTab: ViewMode;
-  icon: React.ReactNode;
+  icon: ReactNode;
   label: string | undefined;
 }
 const getIconColor = (mode: ViewMode, selectMode: ViewMode) => {

--- a/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
@@ -91,7 +91,7 @@ const ImageSection = (props: ImageSectionProps) => {
   const isTouchDevice =
     typeof window !== 'undefined' && 'ontouchstart' in window;
   const handleClick = useCallback(
-    (e: React.MouseEvent) => {
+    (e: MouseEvent) => {
       if (isTouchDevice) {
         e.stopPropagation();
         e.preventDefault();

--- a/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from 'react';
 import type { ImageSectionProps } from '..';
 
 import { useCallback, useContext, useState } from 'react';

--- a/src/features/projectsV2/ProjectSnippet/microComponents/ProjectBadge.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/ProjectBadge.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, JSX } from 'react';
+import type { ReactElement } from 'react';
 
 import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
@@ -28,7 +28,7 @@ interface TitleAndIconReturnType {
     | 'offSiteReviewed';
 }
 interface BadgeLabelProps {
-  icon: JSX.Element;
+  icon: ReactElement;
   title: string;
   isInteractive: boolean;
 }

--- a/src/features/projectsV2/ProjectSnippet/microComponents/TopProjectReports.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/TopProjectReports.tsx
@@ -1,6 +1,5 @@
 import type { Review } from '@planet-sdk/common/build/types/project/common';
 
-import React from 'react';
 import styles from '../styles/ProjectSnippet.module.scss';
 import VerifiedIcon from '@mui/icons-material/Verified';
 import { getPDFFile } from '../../../../utils/getImageURL';

--- a/src/features/projectsV2/ProjectsMap/Credits/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/Credits/index.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
-import React from 'react';
+
+import { useEffect, useState, useContext } from 'react';
 import styles from './Credits.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
 import SelectLanguageAndCountry from '../../../common/Layout/Footer/SelectLanguageAndCountry';
@@ -19,19 +20,19 @@ export default function Credits({
   const tCommon = useTranslations('Common');
   const tMaps = useTranslations('Maps');
   const locale = useLocale();
-  const [selectedCurrency, setSelectedCurrency] = React.useState('EUR');
-  const [selectedCountry, setSelectedCountry] = React.useState('DE');
-  const [openLanguageModal, setLanguageModalOpen] = React.useState(false);
+  const [selectedCurrency, setSelectedCurrency] = useState('EUR');
+  const [selectedCountry, setSelectedCountry] = useState('DE');
+  const [openLanguageModal, setLanguageModalOpen] = useState(false);
 
   const handleLanguageModalClose = () => {
     setLanguageModalOpen(false);
   };
 
-  const { embed } = React.useContext(ParamsContext);
+  const { embed } = useContext(ParamsContext);
 
   const isEmbed = embed === 'true';
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (typeof Storage !== 'undefined') {
       //fetching currencycode from browser's localstorage
       if (localStorage.getItem('currencyCode')) {

--- a/src/features/projectsV2/ProjectsMap/FirePopup/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/FirePopup/index.tsx
@@ -1,10 +1,12 @@
+import type { SetStateAction } from 'react';
 import type { FireFeature } from '../../../common/types/fireLocation';
 import type { PopperProps } from '@mui/material';
 import type { Modifier } from '@popperjs/core';
 
+import { useState, useRef } from 'react';
 import { Popper } from '@mui/material';
 import { useTranslations } from 'next-intl';
-import React, { useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import RightArrowIcon from '../../../../../public/assets/images/icons/projectV2/RightArrowIcon';
 import InfoIconPopup from '../../ProjectDetails/components/microComponents/InfoIconPopup';
 import FireIcon from '../../../../../public/assets/images/icons/FireIcon';
@@ -22,7 +24,7 @@ type ConfidencesType =
   | 'lowAlertConfidenceText';
 
 function popperModifiers(options: {
-  arrowRef: React.SetStateAction<HTMLElement | null>;
+  arrowRef: SetStateAction<HTMLElement | null>;
   clippingBoundary: HTMLElement | null;
 }): Partial<Modifier<any, any>>[] | undefined {
   return [
@@ -58,12 +60,12 @@ function popperModifiers(options: {
 }
 
 export default function FirePopup({ isOpen, feature }: Props) {
-  const anchorRef = React.useRef(null);
-  const popperRef = React.useRef<HTMLDivElement>(null);
-  const [arrowRef, setArrowRef] = React.useState<HTMLElement | null>(null);
-  const [showPopup, setShowPopup] = React.useState(isOpen);
+  const anchorRef = useRef(null);
+  const popperRef = useRef<HTMLDivElement>(null);
+  const [arrowRef, setArrowRef] = useState<HTMLElement | null>(null);
+  const [showPopup, setShowPopup] = useState(isOpen);
   const [popperPlacement, setPopperPlacement] =
-    React.useState<PopperProps['placement']>('top');
+    useState<PopperProps['placement']>('top');
   const tProjectDetails = useTranslations('ProjectDetails');
 
   useEffect(() => {

--- a/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/index.tsx
@@ -1,6 +1,6 @@
 import type { MapOptions } from '../../ProjectsMapContext';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Modal } from '@mui/material';
 import { ExploreIcon } from '../../../../../public/assets/images/icons/projectV2/ExploreIcon';

--- a/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/microComponents/SingleLayerOption.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/microComponents/SingleLayerOption.tsx
@@ -37,7 +37,7 @@ const SingleLayerOption = ({
   const isLegendVisible = isOptionSelected && isLegendAvailable;
 
   const handleMouseEnter = useCallback(
-    (e: React.MouseEvent<HTMLParagraphElement>) => {
+    (e: MouseEvent<HTMLParagraphElement>) => {
       setAnchor(e.currentTarget);
     },
     []

--- a/src/features/projectsV2/ProjectsMap/ProjectMapTabs/SingleTab.tsx
+++ b/src/features/projectsV2/ProjectsMap/ProjectMapTabs/SingleTab.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import type { ReactNode } from 'react';
+
 import styles from './ProjectMapTabs.module.scss';
 
 interface SingleTabProps {
-  icon: React.JSX.Element;
+  icon: ReactNode;
   title: string;
   isSelected: boolean;
   onClickHandler: () => void;

--- a/src/features/projectsV2/ProjectsMap/microComponents/InterventionLayers.tsx
+++ b/src/features/projectsV2/ProjectsMap/microComponents/InterventionLayers.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import type { ReactElement, MouseEvent } from 'react';
 import type {
   Intervention,
   MultiTreeRegistration,

--- a/src/features/projectsV2/ProjectsMap/microComponents/InterventionLayers.tsx
+++ b/src/features/projectsV2/ProjectsMap/microComponents/InterventionLayers.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type {
   Intervention,
   MultiTreeRegistration,
@@ -6,7 +7,6 @@ import type {
 } from '../../../common/types/intervention';
 import type { Feature, Point, Polygon } from 'geojson';
 
-import React from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import { Layer, Source, Marker } from 'react-map-gl-v7/maplibre';
 import area from '@turf/area';
@@ -22,7 +22,7 @@ interface SampleTreeMarkerProps {
   sampleTree: SampleTreeRegistration;
   selectedSampleTree: SampleTreeRegistration | null;
   toggleSampleTree: (
-    e: React.MouseEvent<HTMLDivElement>,
+    e: MouseEvent<HTMLDivElement>,
     sampleTree: SampleTreeRegistration
   ) => void;
 }
@@ -52,7 +52,7 @@ const SampleTreeMarker = ({
   </Marker>
 );
 
-export default function InterventionLayers(): React.ReactElement {
+export default function InterventionLayers(): ReactElement {
   const {
     interventions,
     hoveredIntervention,
@@ -68,7 +68,7 @@ export default function InterventionLayers(): React.ReactElement {
   const locale = useLocale();
 
   const toggleSampleTree = (
-    e: React.MouseEvent<HTMLDivElement>,
+    e: MouseEvent<HTMLDivElement>,
     tree: SingleTreeRegistration | SampleTreeRegistration
   ) => {
     e.stopPropagation();

--- a/src/features/projectsV2/ProjectsMap/microComponents/SiteLayers.tsx
+++ b/src/features/projectsV2/ProjectsMap/microComponents/SiteLayers.tsx
@@ -1,6 +1,6 @@
+import type { ReactElement } from 'react';
 import type { SitesGeoJSON } from '../../../common/types/ProjectPropsContextInterface';
 
-import React from 'react';
 import { Layer, Source } from 'react-map-gl-v7/maplibre';
 import themeProperties from '../../../../theme/themeProperties';
 import { MAIN_MAP_LAYERS } from '../../../../utils/projectV2';
@@ -13,7 +13,7 @@ interface Props {
 export default function SiteLayers({
   geoJson,
   isSatelliteView,
-}: Props): React.ReactElement {
+}: Props): ReactElement {
   const { colors } = themeProperties.designSystem;
 
   return (

--- a/src/features/projectsV2/TimeTravelDropdown/index.tsx
+++ b/src/features/projectsV2/TimeTravelDropdown/index.tsx
@@ -1,6 +1,6 @@
 import type { SourceName } from '../../../utils/mapsV2/timeTravel';
 
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import CalendarIcon from '../../../../public/assets/images/icons/projectV2/CalendarIcon';
 import DropdownUpArrow from '../../../../public/assets/images/icons/projectV2/DropdownUpArrow';

--- a/src/features/user/Account/CancelModal.tsx
+++ b/src/features/user/Account/CancelModal.tsx
@@ -1,7 +1,7 @@
 import type { APIError } from '@planet-sdk/common';
 import type { Subscription } from '../../common/types/payments';
 
-import React from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { ThemeContext } from '../../../theme/themeContext';
 import styles from './AccountHistory.module.scss';
 import { useTranslations } from 'next-intl';
@@ -41,16 +41,16 @@ export const CancelModal = ({
   record,
   fetchRecurrentDonations,
 }: CancelModalProps) => {
-  const { theme } = React.useContext(ThemeContext);
+  const { theme } = useContext(ThemeContext);
   const { putApiAuthenticated } = useApi();
-  const [option, setOption] = React.useState('cancelImmediately');
-  const [showCalender, setShowCalender] = React.useState(false);
-  const [date, setdate] = React.useState<Date | null>(new Date());
-  const [disabled, setDisabled] = React.useState(false);
+  const [option, setOption] = useState('cancelImmediately');
+  const [showCalender, setShowCalender] = useState(false);
+  const [date, setdate] = useState<Date | null>(new Date());
+  const [disabled, setDisabled] = useState(false);
   const t = useTranslations('Me');
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const { setErrors } = useContext(ErrorHandlingContext);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setDisabled(false);
   }, [cancelModalOpen]);
 

--- a/src/features/user/Account/EditModal.tsx
+++ b/src/features/user/Account/EditModal.tsx
@@ -1,7 +1,7 @@
 import type { APIError } from '@planet-sdk/common';
 import type { Subscription } from '../../common/types/payments';
 
-import React from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import { Controller, useForm } from 'react-hook-form';
 import MaterialTextField from '../../common/InputTypes/MaterialTextField';
@@ -50,9 +50,9 @@ export const EditModal = ({
   record,
   fetchRecurrentDonations,
 }: EditModalProps) => {
-  const { theme } = React.useContext(ThemeContext);
-  const [userLang, setUserLang] = React.useState('en');
-  const [disabled, setDisabled] = React.useState(false);
+  const { theme } = useContext(ThemeContext);
+  const [userLang, setUserLang] = useState('en');
+  const [disabled, setDisabled] = useState(false);
   const { putApiAuthenticated } = useApi();
   const t = useTranslations('Me');
   const locale = useLocale();
@@ -63,14 +63,14 @@ export const EditModal = ({
   } = useForm<FormData>({
     mode: 'all',
   });
-  const { setErrors } = React.useContext(ErrorHandlingContext);
-  React.useEffect(() => {
+  const { setErrors } = useContext(ErrorHandlingContext);
+  useEffect(() => {
     if (localStorage.getItem('language')) {
       const userLang = localStorage.getItem('language');
       if (userLang) setUserLang(userLang);
     }
   }, []);
-  React.useEffect(() => {
+  useEffect(() => {
     setDisabled(false);
   }, [editModalOpen]);
 

--- a/src/features/user/Account/History.tsx
+++ b/src/features/user/Account/History.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import type { Filters, PaymentHistory } from '../../common/types/payments';
 
-import React, { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import TransactionListLoader from '../../../../public/assets/images/icons/TransactionListLoader';
 import TransactionsNotFound from '../../../../public/assets/images/icons/TransactionsNotFound';
@@ -29,10 +29,8 @@ export default function History({
   fetchPaymentHistory,
 }: Props): ReactElement {
   const t = useTranslations('Me');
-  const [selectedRecord, setSelectedRecord] = React.useState<number | null>(
-    null
-  );
-  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const [selectedRecord, setSelectedRecord] = useState<number | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const { isMobile } = useProjectProps();
   const router = useRouter();
 

--- a/src/features/user/Account/PauseModal.tsx
+++ b/src/features/user/Account/PauseModal.tsx
@@ -1,7 +1,7 @@
 import type { APIError } from '@planet-sdk/common';
 import type { Subscription } from '../../common/types/payments';
 
-import React from 'react';
+import { useContext, useState, useEffect } from 'react';
 import { ThemeContext } from '../../../theme/themeContext';
 import styles from './AccountHistory.module.scss';
 import { useTranslations } from 'next-intl';
@@ -40,25 +40,25 @@ export const PauseModal = ({
   record,
   fetchRecurrentDonations,
 }: PauseModalProps) => {
-  const { theme } = React.useContext(ThemeContext);
+  const { theme } = useContext(ThemeContext);
   const { putApiAuthenticated } = useApi();
-  const [option, setOption] = React.useState<string>();
-  const [showCalender, setShowCalender] = React.useState(false);
-  const [date, setdate] = React.useState<Date | null>(
+  const [option, setOption] = useState<string>();
+  const [showCalender, setShowCalender] = useState(false);
+  const [date, setdate] = useState<Date | null>(
     new Date(new Date(record?.currentPeriodEnd).valueOf() + 1000 * 3600 * 24)
   );
-  const [disabled, setDisabled] = React.useState(false);
+  const [disabled, setDisabled] = useState(false);
 
   const t = useTranslations('Me');
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const { setErrors } = useContext(ErrorHandlingContext);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setdate(
       new Date(new Date(record?.currentPeriodEnd).valueOf() + 1000 * 3600 * 24)
     );
   }, [record?.currentPeriodEnd]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setDisabled(false);
   }, [pauseModalOpen]);
 

--- a/src/features/user/Account/ReactivateModal.tsx
+++ b/src/features/user/Account/ReactivateModal.tsx
@@ -1,7 +1,7 @@
 import type { APIError } from '@planet-sdk/common';
 import type { Subscription } from '../../common/types/payments';
 
-import React from 'react';
+import { useState, useContext, useEffect } from 'react';
 import { ThemeContext } from '../../../theme/themeContext';
 import styles from './AccountHistory.module.scss';
 import { useTranslations } from 'next-intl';
@@ -24,14 +24,14 @@ export const ReactivateModal = ({
   record,
   fetchRecurrentDonations,
 }: ReactivateModalProps) => {
-  const [disabled, setDisabled] = React.useState(false);
+  const [disabled, setDisabled] = useState(false);
   const { putApiAuthenticated } = useApi();
-  const { theme } = React.useContext(ThemeContext);
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const { theme } = useContext(ThemeContext);
+  const { setErrors } = useContext(ErrorHandlingContext);
   const t = useTranslations('Me');
   const payload = {};
 
-  React.useEffect(() => {
+  useEffect(() => {
     setDisabled(false);
   }, [reactivateModalOpen]);
 

--- a/src/features/user/Account/Recurrency.tsx
+++ b/src/features/user/Account/Recurrency.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import type { Subscription } from '../../common/types/payments';
 
-import React from 'react';
+import { useEffect, useState } from 'react';
 import TransactionListLoader from '../../../../public/assets/images/icons/TransactionListLoader';
 import TransactionsNotFound from '../../../../public/assets/images/icons/TransactionsNotFound';
 import styles from './AccountHistory.module.scss';
@@ -22,17 +22,15 @@ export default function Recurrency({
   recurrencies,
   fetchRecurrentDonations,
 }: Props): ReactElement {
-  const [selectedRecord, setSelectedRecord] = React.useState<number | null>(0);
-  const [isModalOpen, setIsModalOpen] = React.useState(false);
-  const [editModalOpen, seteditModalOpen] = React.useState(false);
-  const [pauseModalOpen, setpauseModalOpen] = React.useState(false);
-  const [cancelModalOpen, setcancelModalOpen] = React.useState(false);
-  const [reactivateModalOpen, setreactivateModalOpen] = React.useState(false);
-  const [currentRecord, setCurrentRecord] = React.useState<Subscription | null>(
-    null
-  );
+  const [selectedRecord, setSelectedRecord] = useState<number | null>(0);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editModalOpen, seteditModalOpen] = useState(false);
+  const [pauseModalOpen, setpauseModalOpen] = useState(false);
+  const [cancelModalOpen, setcancelModalOpen] = useState(false);
+  const [reactivateModalOpen, setreactivateModalOpen] = useState(false);
+  const [currentRecord, setCurrentRecord] = useState<Subscription | null>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (
       recurrencies &&
       selectedRecord !== null &&

--- a/src/features/user/Account/RecurrentPayments.tsx
+++ b/src/features/user/Account/RecurrentPayments.tsx
@@ -1,6 +1,5 @@
 import type { Subscription } from '../../common/types/payments';
 
-import React from 'react';
 import DashboardView from '../../common/Layout/DashboardView';
 import Recurrency from './Recurrency';
 import { useTranslations } from 'next-intl';

--- a/src/features/user/Account/components/AccountRecord.tsx
+++ b/src/features/user/Account/components/AccountRecord.tsx
@@ -4,7 +4,7 @@ import type {
   RecipientBank,
 } from '../../../common/types/payments';
 
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import styles from '../AccountHistory.module.scss';
 import getFormattedCurrency from '../../../../utils/countryCurrency/getFormattedCurrency';
 import formatDate from '../../../../utils/countryCurrency/getFormattedDate';

--- a/src/features/user/Account/components/DownloadCodes.tsx
+++ b/src/features/user/Account/components/DownloadCodes.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import type { APIError } from '@planet-sdk/common';
 
-import React, { useState } from 'react';
+import { useContext, useState } from 'react';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
 import { unparse } from 'papaparse';
 import styles from '../AccountHistory.module.scss';
@@ -17,7 +17,7 @@ const DownloadCodes = ({ codesUrl }: DownloadCodesProps): ReactElement => {
   const t = useTranslations('Me');
   const [isDownloading, setIsDownloading] = useState(false);
   const { getApi } = useApi();
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const { setErrors } = useContext(ErrorHandlingContext);
 
   function downloadCSV(data: [], filename: string) {
     const csv = unparse(data);

--- a/src/features/user/Account/components/RecurrencyRecord.tsx
+++ b/src/features/user/Account/components/RecurrencyRecord.tsx
@@ -1,4 +1,4 @@
-import type { Dispatch, ReactElement, SetStateAction } from 'react';
+import type { Dispatch, ReactElement, SetStateAction, MouseEvent } from 'react';
 import type {
   MultipleDestinations,
   Subscription,
@@ -266,7 +266,7 @@ export function ManageDonation({
     record?.status === 'paused' || new Date(record?.endsAt || '') > new Date();
 
   const openModal = (
-    e: MouseEvent<HTMLButtonElement, MouseEvent>,
+    e: MouseEvent<HTMLButtonElement>,
     setModalOpen: Dispatch<SetStateAction<boolean>>
   ) => {
     e.preventDefault();

--- a/src/features/user/Account/components/RecurrencyRecord.tsx
+++ b/src/features/user/Account/components/RecurrencyRecord.tsx
@@ -3,7 +3,7 @@ import type {
   MultipleDestinations,
   Subscription,
 } from '../../../common/types/payments';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 
 import styles from '../AccountHistory.module.scss';
 import getFormatedCurrency from '../../../../utils/countryCurrency/getFormattedCurrency';
@@ -229,18 +229,18 @@ interface CommonProps {
   selectedRecord: number | null;
   record: Subscription;
   recurrencies: Subscription[];
-  seteditDonation: React.Dispatch<React.SetStateAction<boolean>>;
-  setpauseDonation: React.Dispatch<React.SetStateAction<boolean>>;
-  setcancelDonation: React.Dispatch<React.SetStateAction<boolean>>;
-  setreactivateDonation: React.Dispatch<React.SetStateAction<boolean>>;
+  seteditDonation: Dispatch<SetStateAction<boolean>>;
+  setpauseDonation: Dispatch<SetStateAction<boolean>>;
+  setcancelDonation: Dispatch<SetStateAction<boolean>>;
+  setreactivateDonation: Dispatch<SetStateAction<boolean>>;
 }
 
 interface ManageDonationProps {
   record: Subscription;
-  seteditDonation: React.Dispatch<React.SetStateAction<boolean>>;
-  setpauseDonation: React.Dispatch<React.SetStateAction<boolean>>;
-  setcancelDonation: React.Dispatch<React.SetStateAction<boolean>>;
-  setreactivateDonation: React.Dispatch<React.SetStateAction<boolean>>;
+  seteditDonation: Dispatch<SetStateAction<boolean>>;
+  setpauseDonation: Dispatch<SetStateAction<boolean>>;
+  setcancelDonation: Dispatch<SetStateAction<boolean>>;
+  setreactivateDonation: Dispatch<SetStateAction<boolean>>;
 }
 
 export function ManageDonation({
@@ -266,7 +266,7 @@ export function ManageDonation({
     record?.status === 'paused' || new Date(record?.endsAt || '') > new Date();
 
   const openModal = (
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    e: MouseEvent<HTMLButtonElement, MouseEvent>,
     setModalOpen: Dispatch<SetStateAction<boolean>>
   ) => {
     e.preventDefault();

--- a/src/features/user/BulkCodes/components/BulkCodesError.tsx
+++ b/src/features/user/BulkCodes/components/BulkCodesError.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import { useTranslations } from 'next-intl';
 import { styled } from '@mui/material';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';

--- a/src/features/user/BulkCodes/components/ProjectSelectAutocomplete.tsx
+++ b/src/features/user/BulkCodes/components/ProjectSelectAutocomplete.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Autocomplete, TextField, styled } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import SearchIcon from '../../../../../public/assets/images/icons/SearchIcon';

--- a/src/features/user/BulkCodes/components/ProjectSelector.tsx
+++ b/src/features/user/BulkCodes/components/ProjectSelector.tsx
@@ -3,7 +3,7 @@ import type { PlanetCashAccount } from '../../../common/Layout/BulkCodeContext';
 import type { PaymentOptions } from '../BulkCodesTypes';
 import type { APIError, CountryProject } from '@planet-sdk/common';
 
-import React from 'react';
+import { useContext } from 'react';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
 import ProjectSelectAutocomplete from './ProjectSelectAutocomplete';
 import UnitCostDisplay from './UnitCostDisplay';
@@ -25,7 +25,7 @@ const ProjectSelector = ({
   active = true,
   planetCashAccount,
 }: ProjectSelectorProps): ReactElement | null => {
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const { setErrors } = useContext(ErrorHandlingContext);
   const { user, token, contextLoaded } = useUserProps();
   const { getApiAuthenticated } = useApi();
 

--- a/src/features/user/BulkCodes/components/RecipientsTable.tsx
+++ b/src/features/user/BulkCodes/components/RecipientsTable.tsx
@@ -2,7 +2,7 @@ import type { ReactElement, ChangeEvent } from 'react';
 import type { SetState } from '../../../common/types/common';
 import type { Recipient, TableHeader } from '../BulkCodesTypes';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Paper from '@mui/material/Paper';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';

--- a/src/features/user/BulkCodes/components/SelectorOption.tsx
+++ b/src/features/user/BulkCodes/components/SelectorOption.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from 'react';
 import type { BulkCodeMethods } from '../../../../utils/constants/bulkCodeConstants';
 
-import React from 'react';
 import { styled } from '@mui/material';
 
 export interface SelectorOptionProps {

--- a/src/features/user/BulkCodes/forms/CreationMethodForm.tsx
+++ b/src/features/user/BulkCodes/forms/CreationMethodForm.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import type { SelectorOptionProps } from '../components/SelectorOption';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@mui/material';
 import SelectorOption from '../components/SelectorOption';
 import BulkCodesError from '../components/BulkCodesError';

--- a/src/features/user/BulkCodes/forms/IssueCodesForm.tsx
+++ b/src/features/user/BulkCodes/forms/IssueCodesForm.tsx
@@ -8,13 +8,7 @@ import type {
 import type { Recipient } from '../../../common/Layout/BulkCodeContext';
 import type { Recipient as LocalRecipient } from '../BulkCodesTypes';
 
-import React, {
-  useContext,
-  useState,
-  useEffect,
-  useCallback,
-  useMemo,
-} from 'react';
+import { useContext, useState, useEffect, useCallback, useMemo } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import { Button, TextField, MenuItem } from '@mui/material';
 import styles from '../../../../../src/features/user/BulkCodes/BulkCodes.module.scss';

--- a/src/features/user/BulkCodes/forms/SelectProjectForm.tsx
+++ b/src/features/user/BulkCodes/forms/SelectProjectForm.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import type { CountryProject } from '@planet-sdk/common';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
 import { Button } from '@mui/material';

--- a/src/features/user/BulkCodes/index.tsx
+++ b/src/features/user/BulkCodes/index.tsx
@@ -3,7 +3,7 @@ import type { TabItem } from '../../common/Layout/TabbedView/TabbedViewTypes';
 import type { APIError, CountryProject } from '@planet-sdk/common';
 
 import { useLocale, useTranslations } from 'next-intl';
-import React, { useEffect, useCallback, useContext, useState } from 'react';
+import { useEffect, useCallback, useContext, useState } from 'react';
 import DashboardView from '../../common/Layout/DashboardView';
 import TabbedView from '../../common/Layout/TabbedView';
 import CreationMethodForm from './forms/CreationMethodForm';

--- a/src/features/user/DonationReceipt/microComponents/DonationInfo.tsx
+++ b/src/features/user/DonationReceipt/microComponents/DonationInfo.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from 'react';
 import type {
   IssuedDonationApi,
   UnissuedDonationApi,

--- a/src/features/user/DonationReceipt/microComponents/DonationInfo.tsx
+++ b/src/features/user/DonationReceipt/microComponents/DonationInfo.tsx
@@ -31,12 +31,9 @@ const DonationInfo = ({
   const [popoverAnchor, setPopoverAnchor] = useState<HTMLButtonElement | null>(
     null
   );
-  const openPopover = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>) => {
-      setPopoverAnchor(event.currentTarget);
-    },
-    []
-  );
+  const openPopover = useCallback((event: MouseEvent<HTMLButtonElement>) => {
+    setPopoverAnchor(event.currentTarget);
+  }, []);
   const closePopover = useCallback(() => {
     setPopoverAnchor(null);
   }, []);

--- a/src/features/user/GiftFunds/GiftFundDetails.tsx
+++ b/src/features/user/GiftFunds/GiftFundDetails.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from 'react';
 import type { GiftFund } from '@planet-sdk/common';
 
-import React from 'react';
 import { useUserProps } from '../../common/Layout/UserPropsContext';
 import { useTranslations } from 'next-intl';
 import { Divider, Grid, styled } from '@mui/material';

--- a/src/features/user/GiftFunds/index.tsx
+++ b/src/features/user/GiftFunds/index.tsx
@@ -1,6 +1,6 @@
 import type { GiftFund } from '@planet-sdk/common/build/types/user';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import DashboardView from '../../common/Layout/DashboardView';
 import GiftFundDetails from './GiftFundDetails';
 import { useTranslations } from 'next-intl';
@@ -26,7 +26,7 @@ const GiftFunds = () => {
 
   const [validGiftFunds, setValidGiftFunds] = useState<GiftFund[] | null>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     //Not displaying details for gift fund where open units = 0
     const nonZeroOpenUnitsGiftFunds = user?.planetCash?.giftFunds.filter(
       (gift) => gift.openUnits !== 0

--- a/src/features/user/ManageProjects/ProjectsContainer.tsx
+++ b/src/features/user/ManageProjects/ProjectsContainer.tsx
@@ -8,7 +8,7 @@ import type {
 } from '@planet-sdk/common';
 
 import Link from 'next/link';
-import React, { useMemo } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import LazyLoad from 'react-lazyload';
 import NotFound from '../../../../public/assets/images/NotFound';
 import { localizedAbbreviatedNumber } from '../../../utils/getFormattedNumber';
@@ -121,9 +121,9 @@ export default function ProjectsContainer() {
   const tDonate = useTranslations('Donate');
   const tManageProjects = useTranslations('ManageProjects');
   const { getApiAuthenticated } = useApi();
-  const [projects, setProjects] = React.useState<ProfileProjectFeature[]>([]);
-  const [loader, setLoader] = React.useState(true);
-  const { redirect, setErrors } = React.useContext(ErrorHandlingContext);
+  const [projects, setProjects] = useState<ProfileProjectFeature[]>([]);
+  const [loader, setLoader] = useState(true);
+  const { redirect, setErrors } = useContext(ErrorHandlingContext);
   const { user, contextLoaded, token } = useUserProps();
   const { localizedPath } = useLocalizedPath();
   async function loadProjects() {
@@ -142,7 +142,7 @@ export default function ProjectsContainer() {
     }
   }
   // This effect is used to get and update UserInfo if the isAuthenticated changes
-  React.useEffect(() => {
+  useEffect(() => {
     if (contextLoaded && token) {
       loadProjects();
     }

--- a/src/features/user/ManageProjects/components/BasicDetails.tsx
+++ b/src/features/user/ManageProjects/components/BasicDetails.tsx
@@ -7,13 +7,7 @@ import type {
 } from '../../../common/types/project';
 import type { MapEvent } from 'react-map-gl';
 
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { Button, FormControlLabel, Tooltip } from '@mui/material';
 import { useLocale, useTranslations } from 'next-intl';
@@ -125,8 +119,8 @@ export default function BasicDetails({
 
   const [acceptDonations, setAcceptDonations] = useState(false);
   const [IsSkipButtonVisible, setIsSkipButtonVisible] =
-    React.useState<boolean>(false);
-  const [isUploadingData, setIsUploadingData] = React.useState<boolean>(false);
+    useState<boolean>(false);
+  const [isUploadingData, setIsUploadingData] = useState<boolean>(false);
   const [style, setStyle] = useState(EMPTY_STYLE);
   const [viewport, setViewPort] = useState<ViewPort>({
     width: 760,

--- a/src/features/user/ManageProjects/components/DetailedAnalysis.tsx
+++ b/src/features/user/ManageProjects/components/DetailedAnalysis.tsx
@@ -8,7 +8,7 @@ import type {
   ExtendedProfileProjectProperties,
 } from '../../../common/types/project';
 
-import React, { useEffect } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
 import styles from './../StepForm.module.scss';
@@ -103,9 +103,9 @@ export default function DetailedAnalysis({
 }: DetailedAnalysisProps): ReactElement {
   const tManageProjects = useTranslations('ManageProjects');
   const tCommon = useTranslations('Common');
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const { setErrors } = useContext(ErrorHandlingContext);
   const { putApiAuthenticated } = useApi();
-  const [siteOwners, setSiteOwners] = React.useState<SiteOwners[]>([
+  const [siteOwners, setSiteOwners] = useState<SiteOwners[]>([
     {
       id: 1,
       title: tManageProjects('siteOwnerPrivate'),
@@ -143,11 +143,9 @@ export default function DetailedAnalysis({
       isSet: false,
     },
   ]);
-  const [isUploadingData, setIsUploadingData] = React.useState<boolean>(false);
+  const [isUploadingData, setIsUploadingData] = useState<boolean>(false);
 
-  const [plantingSeasons, setPlantingSeasons] = React.useState<
-    PlantingSeason[]
-  >([
+  const [plantingSeasons, setPlantingSeasons] = useState<PlantingSeason[]>([
     { id: 1, title: tCommon('january'), isSet: false },
     { id: 2, title: tCommon('february'), isSet: false },
     { id: 3, title: tCommon('march'), isSet: false },
@@ -162,7 +160,7 @@ export default function DetailedAnalysis({
     { id: 12, title: tCommon('december'), isSet: false },
   ]);
 
-  const [interventionOptions, setInterventionOptions] = React.useState<
+  const [interventionOptions, setInterventionOptions] = useState<
     InterventionOption[]
   >([
     ['assisting-seed-rain', false],
@@ -184,14 +182,14 @@ export default function DetailedAnalysis({
     ['stop-tree-harvesting', false],
   ]);
 
-  const [mainInterventions, setMainInterventions] = React.useState<
+  const [mainInterventions, setMainInterventions] = useState<
     InterventionTypes[]
   >([]);
-  const [isInterventionsMissing, setIsInterventionsMissing] = React.useState<
+  const [isInterventionsMissing, setIsInterventionsMissing] = useState<
     boolean | null
   >(null);
 
-  const [minDensity, setMinDensity] = React.useState<number | string | null>(0);
+  const [minDensity, setMinDensity] = useState<number | string | null>(0);
 
   const handleSetPlantingSeasons = (id: number) => {
     const month = plantingSeasons[id - 1];
@@ -292,7 +290,7 @@ export default function DetailedAnalysis({
     }
   }
   // for validating max planting density value > planting density value
-  React.useEffect(() => {
+  useEffect(() => {
     if (
       projectDetails &&
       projectDetails.purpose === 'trees' &&
@@ -375,7 +373,7 @@ export default function DetailedAnalysis({
 
   // Use Effect to hide error message after 10 seconds
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (projectDetails) {
       const { metadata, purpose: projectPurpose } = projectDetails;
       const formData: TreeFormData | ConservationFormData =

--- a/src/features/user/ManageProjects/components/MapComponent.tsx
+++ b/src/features/user/ManageProjects/components/MapComponent.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
+import { useEffect, useRef, useState } from 'react';
 import bbox from '@turf/bbox';
 import ReactMapboxGl, { ZoomControl, Source, Layer } from 'react-mapbox-gl';
 import DrawControl from 'react-mapbox-gl-draw';
@@ -33,7 +33,7 @@ export default function MapComponent({
   const defaultMapCenter = [geoLocation.geoLongitude, geoLocation.geoLatitude];
   const defaultZoom = 1.4;
   const t = useTranslations('ManageProjects');
-  const [viewport, setViewPort] = React.useState({
+  const [viewport, setViewPort] = useState({
     height: '400px',
     width: '100%',
     center: defaultMapCenter,
@@ -45,12 +45,12 @@ export default function MapComponent({
     center: defaultMapCenter,
     zoom: defaultZoom,
   };
-  const [style, setStyle] = React.useState({
+  const [style, setStyle] = useState({
     version: 8,
     sources: {},
     layers: [],
   });
-  const [satellite, setSatellite] = React.useState(false);
+  const [satellite, setSatellite] = useState(false);
 
   const RASTER_SOURCE_OPTIONS = {
     type: 'raster',
@@ -60,7 +60,7 @@ export default function MapComponent({
     tileSize: 128,
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     const promise = getMapStyle('openStreetMap');
     promise.then((style: any) => {
       if (style) {
@@ -70,8 +70,8 @@ export default function MapComponent({
   }, []);
 
   const reader = new FileReader();
-  const mapParentRef = React.useRef(null);
-  const drawControlRef = React.useRef(null);
+  const mapParentRef = useRef(null);
+  const drawControlRef = useRef(null);
 
   const onDrawCreate = () => {
     if (drawControlRef.current) {
@@ -85,7 +85,7 @@ export default function MapComponent({
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (geoJson) {
       const bounds = bbox(geoJson);
       const { longitude, latitude, zoom } = new WebMercatorViewport(

--- a/src/features/user/ManageProjects/components/ProjectCertificates.tsx
+++ b/src/features/user/ManageProjects/components/ProjectCertificates.tsx
@@ -5,7 +5,7 @@ import type {
   ProjectCertificatesProps,
 } from '../../../common/types/project';
 
-import React from 'react';
+import { useEffect, useState, useContext, useCallback } from 'react';
 import styles from './../StepForm.module.scss';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
@@ -37,7 +37,7 @@ function ProjectCertificates({
   userLang,
 }: ProjectCertificatesProps): ReactElement {
   const t = useTranslations('ManageProjects');
-  const { redirect, setErrors } = React.useContext(ErrorHandlingContext);
+  const { redirect, setErrors } = useContext(ErrorHandlingContext);
   const { postApiAuthenticated, getApiAuthenticated, deleteApiAuthenticated } =
     useApi();
   const {
@@ -49,13 +49,13 @@ function ProjectCertificates({
   } = useForm({ mode: 'all' });
 
   const certifierName = watch('certifierName');
-  const [uploadedFiles, setUploadedFiles] = React.useState<Certificate[]>([]);
-  const [showForm, setShowForm] = React.useState<boolean>(true);
-  const [errorMessage, setErrorMessage] = React.useState<string | undefined>(
+  const [uploadedFiles, setUploadedFiles] = useState<Certificate[]>([]);
+  const [showForm, setShowForm] = useState<boolean>(true);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>(
     undefined
   );
-  const [isCertified, setIsCertified] = React.useState<boolean>(true);
-  const [showToggle, setShowToggle] = React.useState<boolean>(true);
+  const [isCertified, setIsCertified] = useState<boolean>(true);
+  const [showToggle, setShowToggle] = useState<boolean>(true);
 
   const onSubmit = async (pdf: string) => {
     const { issueDate, certifierName } = getValues();
@@ -91,7 +91,7 @@ function ProjectCertificates({
     }
   };
 
-  const onDrop = React.useCallback(
+  const onDrop = useCallback(
     (acceptedFiles) => {
       acceptedFiles.forEach((file: File) => {
         const reader = new FileReader();
@@ -107,7 +107,7 @@ function ProjectCertificates({
     [uploadedFiles]
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     // Fetch certificates of the project
 
     const fetchCertificates = async () => {
@@ -161,7 +161,7 @@ function ProjectCertificates({
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (uploadedFiles && uploadedFiles.length == 0) {
       setShowToggle(true);
       setShowForm(true);

--- a/src/features/user/ManageProjects/components/ProjectMedia.tsx
+++ b/src/features/user/ManageProjects/components/ProjectMedia.tsx
@@ -7,7 +7,7 @@ import type {
 } from '../../../common/types/project';
 import type { ReactElement, FocusEvent } from 'react';
 
-import React, { useCallback, useEffect, useContext, useState } from 'react';
+import { useCallback, useEffect, useContext, useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useDropzone } from 'react-dropzone';
 import styles from '../StepForm.module.scss';
@@ -74,7 +74,7 @@ export default function ProjectMedia({
     mode: 'all',
     defaultValues: { youtubeURL: projectDetails?.videoUrl || '' },
   });
-  const [uploadedImages, setUploadedImages] = React.useState<UploadImage[]>([]);
+  const [uploadedImages, setUploadedImages] = useState<UploadImage[]>([]);
 
   const [isUploadingData, setIsUploadingData] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState<string | null>('');

--- a/src/features/user/ManageProjects/components/ProjectSelection.tsx
+++ b/src/features/user/ManageProjects/components/ProjectSelection.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from 'react';
 import type { SetState } from '../../../common/types/common';
 
-import React from 'react';
 import { useTranslations } from 'next-intl';
 import styles from '../StepForm.module.scss';
 import useLocalizedPath from '../../../../hooks/useLocalizedPath';

--- a/src/features/user/ManageProjects/components/ProjectSites.tsx
+++ b/src/features/user/ManageProjects/components/ProjectSites.tsx
@@ -14,7 +14,7 @@ import type {
   Geometry,
 } from 'geojson';
 
-import React from 'react';
+import { useEffect, useState, useContext } from 'react';
 import styles from './../StepForm.module.scss';
 import { Controller, useForm } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
@@ -71,7 +71,7 @@ function EditSite({
   siteGUID,
   siteList,
 }: EditSiteProps) {
-  const { theme } = React.useContext(ThemeContext);
+  const { theme } = useContext(ThemeContext);
   const { putApiAuthenticated } = useApi();
   const t = useTranslations('ManageProjects');
   const {
@@ -79,11 +79,11 @@ function EditSite({
     formState: { errors },
     control,
   } = useForm<ProjectSitesFormData>();
-  const [geoJson, setGeoJson] = React.useState<GeoJson | null>(geoJsonProp);
-  const [geoJsonError, setGeoJsonError] = React.useState<boolean>(false);
-  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
-  const [isUploadingData, setIsUploadingData] = React.useState<boolean>(false);
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const [geoJson, setGeoJson] = useState<GeoJson | null>(geoJsonProp);
+  const [geoJsonError, setGeoJsonError] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isUploadingData, setIsUploadingData] = useState<boolean>(false);
+  const { setErrors } = useContext(ErrorHandlingContext);
 
   const MapProps = {
     geoJson,
@@ -266,16 +266,16 @@ export default function ProjectSites({
     formState: { errors },
     control,
   } = useForm<ProjectSitesFormData>();
-  const [isUploadingData, setIsUploadingData] = React.useState<boolean>(false);
-  const [geoJsonError, setGeoJsonError] = React.useState<boolean>(false);
-  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
-  const [openModal, setOpenModal] = React.useState<boolean>(false);
-  const [showForm, setShowForm] = React.useState<boolean>(true);
-  const [editMode, seteditMode] = React.useState<boolean>(false);
-  const [geoLocation, setgeoLocation] = React.useState<GeoLocation | undefined>(
+  const [isUploadingData, setIsUploadingData] = useState<boolean>(false);
+  const [geoJsonError, setGeoJsonError] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [openModal, setOpenModal] = useState<boolean>(false);
+  const [showForm, setShowForm] = useState<boolean>(true);
+  const [editMode, seteditMode] = useState<boolean>(false);
+  const [geoLocation, setgeoLocation] = useState<GeoLocation | undefined>(
     undefined
   );
-  const [geoJson, setGeoJson] = React.useState<GeoJson | null>(null);
+  const [geoJson, setGeoJson] = useState<GeoJson | null>(null);
   const defaultMapCenter = [36.96, -28.5];
   const defaultZoom = 1.4;
   const viewport = {
@@ -296,14 +296,14 @@ export default function ProjectSites({
   };
 
   const [siteDetails, setSiteDetails] =
-    React.useState<SiteDetails>(defaultSiteDetails);
-  const [siteList, setSiteList] = React.useState<Site[]>([]);
-  const [siteGUID, setSiteGUID] = React.useState<string | null>(null);
-  const { redirect, setErrors } = React.useContext(ErrorHandlingContext);
+    useState<SiteDetails>(defaultSiteDetails);
+  const [siteList, setSiteList] = useState<Site[]>([]);
+  const [siteGUID, setSiteGUID] = useState<string | null>(null);
+  const { redirect, setErrors } = useContext(ErrorHandlingContext);
 
   // Assigning defaultSiteDetails as default
 
-  const changeSiteDetails = (e: React.ChangeEvent<HTMLInputElement>): void => {
+  const changeSiteDetails = (e: ChangeEvent<HTMLInputElement>): void => {
     setSiteDetails({ ...siteDetails, [e.target.name]: e.target.value });
   };
 
@@ -354,7 +354,7 @@ export default function ProjectSites({
       redirect('/profile');
     }
   };
-  React.useEffect(() => {
+  useEffect(() => {
     fetchProjSites();
   }, [projectGUID]);
 

--- a/src/features/user/ManageProjects/components/ProjectSpending.tsx
+++ b/src/features/user/ManageProjects/components/ProjectSpending.tsx
@@ -5,7 +5,7 @@ import type {
   ExpensesScopeProjects,
 } from '../../../common/types/project';
 
-import React from 'react';
+import { useEffect, useState, useContext, useCallback } from 'react';
 import styles from './../StepForm.module.scss';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
@@ -47,7 +47,7 @@ export default function ProjectSpending({
 }: ProjectSpendingProps): ReactElement {
   const tManageProjects = useTranslations('ManageProjects');
   const tCommon = useTranslations('Common');
-  const { redirect, setErrors } = React.useContext(ErrorHandlingContext);
+  const { redirect, setErrors } = useContext(ErrorHandlingContext);
   const {
     formState: { errors, isDirty },
     getValues,
@@ -56,13 +56,11 @@ export default function ProjectSpending({
   } = useForm<ExpenseFormData>({ mode: 'all' });
   const { postApiAuthenticated, deleteApiAuthenticated, getApiAuthenticated } =
     useApi();
-  const [amount, setAmount] = React.useState<number | string>(0);
-  const [isUploadingData, setIsUploadingData] = React.useState<boolean>(false);
-  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
-  const [showForm, setShowForm] = React.useState<boolean>(true);
-  const [uploadedFiles, setUploadedFiles] = React.useState<ProjectExpense[]>(
-    []
-  );
+  const [amount, setAmount] = useState<number | string>(0);
+  const [isUploadingData, setIsUploadingData] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState<boolean>(true);
+  const [uploadedFiles, setUploadedFiles] = useState<ProjectExpense[]>([]);
 
   const onSubmit = async (pdf: string | ArrayBuffer | null | undefined) => {
     setIsUploadingData(true);
@@ -97,7 +95,7 @@ export default function ProjectSpending({
     }
   };
 
-  const onDrop = React.useCallback(
+  const onDrop = useCallback(
     (acceptedFiles: File[]) => {
       acceptedFiles.forEach((file) => {
         const reader = new FileReader();
@@ -163,7 +161,7 @@ export default function ProjectSpending({
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     fetchProjSpending();
   }, [projectGUID]);
 

--- a/src/features/user/ManageProjects/components/SubmitForReview.tsx
+++ b/src/features/user/ManageProjects/components/SubmitForReview.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from 'react';
 import type { SubmitForReviewProps } from '../../../common/types/project';
 
-import React from 'react';
 import BackArrow from '../../../../../public/assets/images/icons/headerIcons/BackArrow';
 import styles from './../StepForm.module.scss';
 import SubmitForReviewImage from '../../../../../public/assets/images/icons/manageProjects/SubmitForReviewImage';

--- a/src/features/user/ManageProjects/index.tsx
+++ b/src/features/user/ManageProjects/index.tsx
@@ -5,7 +5,7 @@ import type {
   ExtendedProfileProjectProperties,
 } from '../../common/types/project';
 
-import React from 'react';
+import { useEffect, useState, useContext } from 'react';
 import BasicDetails from './components/BasicDetails';
 import ProjectMedia from './components/ProjectMedia';
 import ProjectSelection from './components/ProjectSelection';
@@ -47,19 +47,17 @@ export default function ManageProjects({
 }: ManageProjectsProps) {
   const t = useTranslations('ManageProjects');
   const locale = useLocale();
-  const { redirect, setErrors } = React.useContext(ErrorHandlingContext);
+  const { redirect, setErrors } = useContext(ErrorHandlingContext);
   const router = useRouter();
   const { localizedPath } = useLocalizedPath();
   const { putApiAuthenticated, getApiAuthenticated } = useApi();
 
-  const [tabSelected, setTabSelected] = React.useState<number>(0);
-  const [isUploadingData, setIsUploadingData] = React.useState<boolean>(false);
-  const [projectGUID, setProjectGUID] = React.useState<string>(
-    GUID ? GUID : ''
-  );
-  const [tablist, setTabList] = React.useState<TabItem[]>([]);
+  const [tabSelected, setTabSelected] = useState<number>(0);
+  const [isUploadingData, setIsUploadingData] = useState<boolean>(false);
+  const [projectGUID, setProjectGUID] = useState<string>(GUID ? GUID : '');
+  const [tablist, setTabList] = useState<TabItem[]>([]);
   const [projectDetails, setProjectDetails] =
-    React.useState<ExtendedProfileProjectProperties | null>(null);
+    useState<ExtendedProfileProjectProperties | null>(null);
 
   const formRouteHandler = (val: number) => {
     if (router.query.purpose) return;
@@ -143,7 +141,7 @@ export default function ManageProjects({
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     // Fetch details of the project
     const fetchProjectDetails = async () => {
       try {
@@ -161,15 +159,15 @@ export default function ManageProjects({
       fetchProjectDetails();
     }
   }, [GUID, projectGUID]);
-  const [userLang, setUserLang] = React.useState('en');
-  React.useEffect(() => {
+  const [userLang, setUserLang] = useState('en');
+  useEffect(() => {
     if (localStorage.getItem('language')) {
       const userLang = localStorage.getItem('language');
       if (userLang) setUserLang(userLang);
     }
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.query.purpose) {
       setTabSelected(1);
     }
@@ -198,7 +196,7 @@ export default function ManageProjects({
     }
   }, [tabSelected, router.query.type]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.query.type && project) {
       setTabList([
         {

--- a/src/features/user/Profile/CommunityContributions/index.tsx
+++ b/src/features/user/Profile/CommunityContributions/index.tsx
@@ -1,7 +1,7 @@
 import type { ProfileV2Props } from '../../../common/types/profile';
 import type { LeaderboardItem } from '../../../common/types/myForest';
 
-import { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import styles from './communityContributions.module.scss';
 import NoContributions from './NoContributions';
 import ContributionListItem from './ContributionListItem';
@@ -10,7 +10,7 @@ import { useTranslations } from 'next-intl';
 import { useMyForest } from '../../../common/Layout/MyForestContext';
 import CommunityContributionsIcon from '../../../../../public/assets/images/icons/CommunityContributionsIcon';
 import themeProperties from '../../../../theme/themeProperties';
-import React from 'react';
+
 import NewInfoIcon from '../../../../../public/assets/images/icons/projectV2/NewInfoIcon';
 
 type TabOptions = 'most-recent' | 'most-trees';
@@ -51,7 +51,7 @@ const ContributionsList = ({
   return (
     <ul className={styles.leaderboardList}>
       {contributionList.map((item, index) => (
-        <React.Fragment
+        <Fragment
           key={`${tabSelected}-${item.units}-${item.unitType}-${index}`}
         >
           <ContributionListItem
@@ -61,7 +61,7 @@ const ContributionsList = ({
             purpose={item.purpose}
           />
           <div className={styles.horizontalLine}></div>
-        </React.Fragment>
+        </Fragment>
       ))}
     </ul>
   );

--- a/src/features/user/Profile/ContributionsMap/Common/ContributionStats.tsx
+++ b/src/features/user/Profile/ContributionsMap/Common/ContributionStats.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react';
+import type { ReactElement } from 'react';
 
 import {
   ProjectStatIcon,
@@ -9,7 +9,7 @@ import { useTranslations } from 'next-intl';
 import { useMyForest } from '../../../../common/Layout/MyForestContext';
 
 interface StatItemProps {
-  icon: JSX.Element;
+  icon: ReactElement;
   label: string;
 }
 

--- a/src/features/user/Profile/ContributionsMap/Popup/RegisteredTreesPopup.tsx
+++ b/src/features/user/Profile/ContributionsMap/Popup/RegisteredTreesPopup.tsx
@@ -5,7 +5,6 @@ import type {
 } from '../../../../common/types/myForest';
 import type { SetState } from '../../../../common/types/common';
 
-import React from 'react';
 import { useTranslations } from 'next-intl';
 import { Popup } from 'react-map-gl-v7';
 import RegisteredTreePopupIcon from '../../../../../../public/assets/images/icons/myForestMapIcons/RegisteredTreePopupIcon';

--- a/src/features/user/Profile/InfoAndCTA/PublicProfileActions/PublicProfileActionCard.tsx
+++ b/src/features/user/Profile/InfoAndCTA/PublicProfileActions/PublicProfileActionCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styles from '../InfoAndCta.module.scss';
 
 interface Props {

--- a/src/features/user/Profile/InfoAndCTA/PublicProfileActions/PublicProfileActionsHeader.tsx
+++ b/src/features/user/Profile/InfoAndCTA/PublicProfileActions/PublicProfileActionsHeader.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styles from '../InfoAndCta.module.scss';
 import WebappButton from '../../../../common/WebappButton';
 import { useTranslations } from 'next-intl';

--- a/src/features/user/Profile/InfoAndCTA/PublicProfileActions/index.tsx
+++ b/src/features/user/Profile/InfoAndCTA/PublicProfileActions/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styles from '../InfoAndCta.module.scss';
 import PublicProfileActionsHeader from './PublicProfileActionsHeader';
 import PublicProfileActionCard from './PublicProfileActionCard';

--- a/src/features/user/Profile/InfoAndCTA/SDGCardList/index.tsx
+++ b/src/features/user/Profile/InfoAndCTA/SDGCardList/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import CarouselSlider from '../../../../common/CarouselSlider';
 import { useTranslations } from 'next-intl';
 import styles from '../InfoAndCta.module.scss';

--- a/src/features/user/Profile/InfoAndCTA/index.tsx
+++ b/src/features/user/Profile/InfoAndCTA/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import SDGCardList from './SDGCardList';
 import styles from './InfoAndCta.module.scss';
 import PublicProfileActions from './PublicProfileActions';

--- a/src/features/user/Profile/ProfileCard/ProfileActions/SocialMediaShareButton.tsx
+++ b/src/features/user/Profile/ProfileCard/ProfileActions/SocialMediaShareButton.tsx
@@ -1,6 +1,6 @@
 import type { ProfileV2Props } from '../../../../common/types/profile';
 
-import React from 'react';
+import { useState } from 'react';
 import { ShareIcon } from '../../../../../../public/assets/images/icons/ProfilePageV2Icons';
 import WebappButton from '../../../../common/WebappButton';
 import ShareModal from '../ShareModal';
@@ -14,7 +14,7 @@ interface SocialMediaShareButtonProps {
 const SocialMediaShareButton = ({
   userProfile,
 }: SocialMediaShareButtonProps) => {
-  const [isShareModelOpen, setIsShareModelOpen] = React.useState(false);
+  const [isShareModelOpen, setIsShareModelOpen] = useState(false);
   const { tenantConfig } = useTenant();
   const t = useTranslations('Profile');
 

--- a/src/features/user/Profile/ProfileCard/ProfileActions/index.tsx
+++ b/src/features/user/Profile/ProfileCard/ProfileActions/index.tsx
@@ -1,6 +1,6 @@
 import type { ProfileV2Props } from '../../../../common/types/profile';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
   AllDonations,
   RedeemIcon,

--- a/src/features/user/Profile/ProfileCard/RedeemModal/index.tsx
+++ b/src/features/user/Profile/ProfileCard/RedeemModal/index.tsx
@@ -2,9 +2,9 @@ import type { ReactElement } from 'react';
 import type { APIError, SerializedError } from '@planet-sdk/common';
 import type { RedeemedCodeData } from '../../../../common/types/redeem';
 
+import { useState, useContext } from 'react';
 import Modal from '@mui/material/Modal';
 import Fade from '@mui/material/Fade';
-import React from 'react';
 import { useTranslations } from 'next-intl';
 import { ThemeContext } from '../../../../../theme/themeContext';
 import { useUserProps } from '../../../../common/Layout/UserPropsContext';
@@ -32,14 +32,13 @@ export default function RedeemModal({
   const t = useTranslations('Redeem');
   const { postApiAuthenticated } = useApi();
   const { user, contextLoaded, setUser, setRefetchUserData } = useUserProps();
-  const { setErrors, errors: apiErrors } =
-    React.useContext(ErrorHandlingContext);
+  const { setErrors, errors: apiErrors } = useContext(ErrorHandlingContext);
   const { refetchContributions, refetchLeaderboard } = useMyForest();
-  const [inputCode, setInputCode] = React.useState<string | undefined>('');
-  const [redeemedCodeData, setRedeemedCodeData] = React.useState<
+  const [inputCode, setInputCode] = useState<string | undefined>('');
+  const [redeemedCodeData, setRedeemedCodeData] = useState<
     RedeemedCodeData | undefined
   >(undefined);
-  const [isLoading, setIsLoading] = React.useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   async function redeemingCode(data: string): Promise<void> {
     setIsLoading(true);
     const payload = {
@@ -116,7 +115,7 @@ export default function RedeemModal({
     setInputCode('');
     setRedeemedCodeData(undefined);
   };
-  const { theme } = React.useContext(ThemeContext);
+  const { theme } = useContext(ThemeContext);
 
   return (
     <Modal

--- a/src/features/user/Profile/ProfileCard/ShareModal/index.tsx
+++ b/src/features/user/Profile/ProfileCard/ShareModal/index.tsx
@@ -1,6 +1,6 @@
 import type { ProfileV2Props } from '../../../../common/types/profile';
 
-import React from 'react';
+import { useContext } from 'react';
 import styles from './ShareModal.module.scss';
 import { Modal, Fade, TextField } from '@mui/material';
 import { ThemeContext } from '../../../../../theme/themeContext';
@@ -35,7 +35,7 @@ const ShareModal = ({
   handleShareModalClose,
   userProfile,
 }: ShareModalProps) => {
-  const { theme } = React.useContext(ThemeContext);
+  const { theme } = useContext(ThemeContext);
   const { tenantConfig } = useTenant();
   const t = useTranslations('Profile');
   const linkToShare = `${tenantConfig.config.tenantURL}/t/${userProfile?.slug}`;

--- a/src/features/user/Profile/ProfileCard/index.tsx
+++ b/src/features/user/Profile/ProfileCard/index.tsx
@@ -1,6 +1,5 @@
 import type { ProfileV2Props } from '../../../common/types/profile';
 
-import React from 'react';
 import { Avatar } from '@mui/material';
 import getImageUrl from '../../../../utils/getImageURL';
 import styles from './ProfileCard.module.scss';

--- a/src/features/user/Profile/ProfileLayout/index.tsx
+++ b/src/features/user/Profile/ProfileLayout/index.tsx
@@ -1,9 +1,10 @@
 import type { User } from '@planet-sdk/common';
 
+import { useState } from 'react';
 import ContributionsMap from '../ContributionsMap';
 import styles from './ProfileLayout.module.scss';
 import { useRouter } from 'next/router';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 import ProfileCard from '../ProfileCard';
 import { ProfileLoader } from '../../../common/ContentLoaders/ProfileV2';
@@ -17,7 +18,7 @@ import MyContributions from '../MyContributions';
 const ProfileLayout = () => {
   const router = useRouter();
   const { user, contextLoaded } = useUserProps();
-  const [profile, setProfile] = React.useState<null | User>(null);
+  const [profile, setProfile] = useState<null | User>(null);
   const {
     setUserInfo,
     isContributionsLoaded,

--- a/src/features/user/Profile/TpoProjects/index.tsx
+++ b/src/features/user/Profile/TpoProjects/index.tsx
@@ -1,8 +1,8 @@
 import type { APIError, UserPublicProfile } from '@planet-sdk/common';
 import type { MapProject } from '../../../common/types/ProjectPropsContextInterface';
 
+import { useEffect, useState, useContext } from 'react';
 import dynamic from 'next/dynamic';
-import React from 'react';
 import LazyLoad from 'react-lazyload';
 import NotFound from '../../../../../public/assets/images/NotFound';
 import ProjectLoader from '../../../common/ContentLoaders/Projects/ProjectLoader';
@@ -27,8 +27,8 @@ export default function ProjectsContainer({ profile }: Props) {
   const { getApi } = useApi();
   const t = useTranslations('Donate');
   const locale = useLocale();
-  const [projects, setProjects] = React.useState<MapProject[]>();
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const [projects, setProjects] = useState<MapProject[]>();
+  const { setErrors } = useContext(ErrorHandlingContext);
 
   async function loadProjects() {
     try {
@@ -41,7 +41,7 @@ export default function ProjectsContainer({ profile }: Props) {
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     loadProjects();
   }, [locale]);
 

--- a/src/features/user/RegisterTrees/RegisterTrees/DrawMap.tsx
+++ b/src/features/user/RegisterTrees/RegisterTrees/DrawMap.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import type { ViewportProps } from '../../../common/types/map';
 
-import React from 'react';
+import { useEffect, useState, useRef } from 'react';
 import ReactMapboxGl, { ZoomControl } from 'react-mapbox-gl';
 import DrawControl from 'react-mapbox-gl-draw';
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
@@ -26,20 +26,20 @@ export default function MapComponent({
 }: Props): ReactElement {
   const defaultMapCenter: [number, number] = [-28.5, 36.96];
   const defaultZoom: [number] = [1.4];
-  const [viewport, setViewPort] = React.useState<ViewportProps>({
+  const [viewport, setViewPort] = useState<ViewportProps>({
     height: '100%',
     width: '100%',
     center: defaultMapCenter,
     zoom: defaultZoom,
   });
 
-  const [style, setStyle] = React.useState({
+  const [style, setStyle] = useState({
     version: 8,
     sources: {},
     layers: [],
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     const promise = getMapStyle('openStreetMap');
     promise.then((style: any) => {
       if (style) {
@@ -48,8 +48,8 @@ export default function MapComponent({
     });
   }, []);
   const t = useTranslations('Me');
-  const [drawing, setDrawing] = React.useState(false);
-  const drawControlRef = React.useRef<DrawControl | null>(null);
+  const [drawing, setDrawing] = useState(false);
+  const drawControlRef = useRef<DrawControl | null>(null);
 
   const onDrawCreate = () => {
     if (drawControlRef.current?.draw) {
@@ -69,7 +69,7 @@ export default function MapComponent({
       setGeometry(drawControl.draw.getAll());
     }
   };
-  React.useEffect(() => {
+  useEffect(() => {
     if (
       userLocation &&
       userLocation.length === 2 &&

--- a/src/features/user/RegisterTrees/RegisterTrees/SingleContribution.tsx
+++ b/src/features/user/RegisterTrees/RegisterTrees/SingleContribution.tsx
@@ -3,7 +3,7 @@ import type { Image } from '@planet-sdk/common';
 import type { Point, Polygon } from 'geojson';
 
 import dynamic from 'next/dynamic';
-import React from 'react';
+
 import CheckCircle from '../../../../../public/assets/images/icons/CheckCircle';
 import styles from '../RegisterModal.module.scss';
 import UploadImages from './UploadImages';

--- a/src/features/user/RegisterTrees/RegisterTrees/StaticMap.tsx
+++ b/src/features/user/RegisterTrees/RegisterTrees/StaticMap.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
+import { useEffect, useState } from 'react';
 import bbox from '@turf/bbox';
 import ReactMapboxGl, { GeoJSONLayer, Marker } from 'react-mapbox-gl';
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
@@ -22,7 +22,7 @@ interface Props {
 export default function StaticMap({ geoJson }: Props): ReactElement {
   const defaultMapCenter: [number, number] = [-28.5, 36.96];
   const defaultZoom = 1.4;
-  const [viewport, setViewPort] = React.useState({
+  const [viewport, setViewPort] = useState({
     height: '100%',
     width: '100%',
     center: defaultMapCenter,
@@ -34,14 +34,14 @@ export default function StaticMap({ geoJson }: Props): ReactElement {
     center: defaultMapCenter,
     zoom: defaultZoom,
   };
-  const [isPoint, setIsPoint] = React.useState(false);
-  const [style, setStyle] = React.useState({
+  const [isPoint, setIsPoint] = useState(false);
+  const [style, setStyle] = useState({
     version: 8,
     sources: {},
     layers: [],
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     const promise = getMapStyle('openStreetMap');
     promise.then((style) => {
       if (style) {
@@ -50,7 +50,7 @@ export default function StaticMap({ geoJson }: Props): ReactElement {
     });
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (geoJson) {
       if (geoJson.type === 'Point') {
         setIsPoint(true);
@@ -60,7 +60,7 @@ export default function StaticMap({ geoJson }: Props): ReactElement {
     }
   }, [geoJson]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (isPoint) {
       setViewPort({
         ...viewport,

--- a/src/features/user/RegisterTrees/RegisterTrees/UploadImages.tsx
+++ b/src/features/user/RegisterTrees/RegisterTrees/UploadImages.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import type { APIError, Image } from '@planet-sdk/common';
 
-import React from 'react';
+import { useState, useContext, useCallback } from 'react';
 import styles from '../RegisterModal.module.scss';
 import { useDropzone } from 'react-dropzone';
 import getImageUrl from '../../../../utils/getImageURL';
@@ -25,10 +25,10 @@ type UploadImageApiPayload = {
 export default function UploadImages({
   contributionGUID,
 }: Props): ReactElement {
-  const [uploadedImages, setUploadedImages] = React.useState<Image[]>([]);
-  const [isUploadingData, setIsUploadingData] = React.useState(false);
+  const [uploadedImages, setUploadedImages] = useState<Image[]>([]);
+  const [isUploadingData, setIsUploadingData] = useState(false);
   const t = useTranslations('Me');
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const { setErrors } = useContext(ErrorHandlingContext);
   const { deleteApiAuthenticated, postApiAuthenticated } = useApi();
 
   const uploadPhotos = async (image: string) => {
@@ -55,7 +55,7 @@ export default function UploadImages({
     }
   };
 
-  const onDrop = React.useCallback((acceptedFiles: File[]) => {
+  const onDrop = useCallback((acceptedFiles: File[]) => {
     acceptedFiles.forEach((file) => {
       const reader = new FileReader();
       reader.readAsDataURL(file);

--- a/src/features/user/RegisterTrees/RegisterTreesWidget.tsx
+++ b/src/features/user/RegisterTrees/RegisterTreesWidget.tsx
@@ -1,3 +1,4 @@
+import type { ChangeEvent } from 'react';
 import type { ContributionProperties } from './RegisterTrees/SingleContribution';
 import type { APIError, ProfileProjectFeature } from '@planet-sdk/common';
 import type { ViewportProps } from '../../common/types/map';
@@ -5,12 +6,12 @@ import type {
   RegisterTreesFormProps,
   RegisteredTreesGeometry,
 } from '../../common/types/map';
-import { handleError } from '@planet-sdk/common';
 
+import { useEffect, useState, useContext } from 'react';
+import { handleError } from '@planet-sdk/common';
 import { MenuItem, TextField, Button } from '@mui/material';
 import { easeCubic } from 'd3-ease';
 import dynamic from 'next/dynamic';
-import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import MapGL, {
   FlyToInterpolator,
@@ -57,36 +58,36 @@ function RegisterTreesForm({
     sources: {},
     layers: [],
   };
-  const [mapState, setMapState] = React.useState({
+  const [mapState, setMapState] = useState({
     mapStyle: EMPTY_STYLE,
   });
-  const [isMultiple, setIsMultiple] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState<null | string>(null);
+  const [isMultiple, setIsMultiple] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<null | string>(null);
   const screenWidth = window.innerWidth;
   const isMobile = screenWidth <= 767;
   const defaultMapCenter = isMobile ? [22.54, 9.59] : [36.96, -28.5];
   const defaultZoom = isMobile ? 1 : 1.4;
-  const [interventionCoordinates, setInterventionCoordinates] = React.useState<
+  const [interventionCoordinates, setInterventionCoordinates] = useState<
     number[] | undefined
   >(undefined);
-  const [geometry, setGeometry] = React.useState<
-    RegisteredTreesGeometry | undefined
-  >(undefined);
-  const [viewport, setViewPort] = React.useState<ViewportProps>({
+  const [geometry, setGeometry] = useState<RegisteredTreesGeometry | undefined>(
+    undefined
+  );
+  const [viewport, setViewPort] = useState<ViewportProps>({
     height: '100%',
     width: '100%',
     latitude: defaultMapCenter[0],
     longitude: defaultMapCenter[1],
     zoom: defaultZoom,
   });
-  const [userLang, setUserLang] = React.useState('en');
-  const [userLocation, setUserLocation] = React.useState<number[] | null>(null);
-  const [projects, setProjects] = React.useState<ProfileProjectFeature[]>([]);
-  const { setErrors, redirect } = React.useContext(ErrorHandlingContext);
-  const [isStyleReady, setIsStyleReady] = React.useState(false);
+  const [userLang, setUserLang] = useState('en');
+  const [userLocation, setUserLocation] = useState<number[] | null>(null);
+  const [projects, setProjects] = useState<ProfileProjectFeature[]>([]);
+  const { setErrors, redirect } = useContext(ErrorHandlingContext);
+  const [isStyleReady, setIsStyleReady] = useState(false);
   const { postApiAuthenticated, getApiAuthenticated } = useApi();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const promise = getMapStyle('openStreetMap');
     promise.then((style) => {
       if (style) {
@@ -96,7 +97,7 @@ function RegisterTreesForm({
     });
   }, [isStyleReady]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (localStorage.getItem('language')) {
       const userLang = localStorage.getItem('language');
       if (userLang) setUserLang(userLang);
@@ -114,7 +115,7 @@ function RegisterTreesForm({
     getUserLocation();
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (userLocation) {
       const newViewport = {
         ...viewport,
@@ -129,7 +130,7 @@ function RegisterTreesForm({
     }
   }, [userLocation]);
 
-  const [isUploadingData, setIsUploadingData] = React.useState(false);
+  const [isUploadingData, setIsUploadingData] = useState(false);
   const defaultBasicDetails = {
     treeCount: '',
     species: '',
@@ -147,7 +148,7 @@ function RegisterTreesForm({
   });
 
   const onTreeCountChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     if (Number(e.target.value) < 25) {
       setIsMultiple(false);
@@ -210,7 +211,7 @@ function RegisterTreesForm({
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (contextLoaded && user?.type === 'tpo') {
       loadProjects();
     }
@@ -417,10 +418,10 @@ type FormData = {
 };
 
 export default function RegisterTreesWidget() {
-  const [contributionGUID, setContributionGUID] = React.useState('');
+  const [contributionGUID, setContributionGUID] = useState('');
   const [contributionDetails, setContributionDetails] =
-    React.useState<ContributionProperties | null>(null);
-  const [registered, setRegistered] = React.useState(false);
+    useState<ContributionProperties | null>(null);
+  const [registered, setRegistered] = useState(false);
 
   const ContributionProps = {
     contribution: contributionDetails !== null ? contributionDetails : null,

--- a/src/features/user/Settings/ApiKey/ApiKeyForm.tsx
+++ b/src/features/user/Settings/ApiKey/ApiKeyForm.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from 'react';
 import type { APIError } from '@planet-sdk/common';
 
 import { useEffect, useState, useContext } from 'react';
@@ -58,9 +59,7 @@ export default function ApiKey() {
     setIsUploadingData(false);
   };
 
-  const regenerateApiKey = async (
-    e: MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
+  const regenerateApiKey = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     setIsUploadingData(true);
     try {
@@ -108,9 +107,7 @@ export default function ApiKey() {
         </InlineFormDisplayGroup>
         <div>
           <Button
-            onClick={(e: MouseEvent<HTMLButtonElement, MouseEvent>) =>
-              regenerateApiKey(e)
-            }
+            onClick={(e: MouseEvent<HTMLButtonElement>) => regenerateApiKey(e)}
             variant="contained"
             color="primary"
           >

--- a/src/features/user/Settings/ApiKey/ApiKeyForm.tsx
+++ b/src/features/user/Settings/ApiKey/ApiKeyForm.tsx
@@ -1,6 +1,6 @@
 import type { APIError } from '@planet-sdk/common';
 
-import React from 'react';
+import { useEffect, useState, useContext } from 'react';
 import styles from './ApiKey.module.scss';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
@@ -33,11 +33,11 @@ const EyeButton = ({ isVisible, onClick }: EyeButtonParams) => {
 export default function ApiKey() {
   const { token, contextLoaded } = useUserProps();
   const t = useTranslations('Me');
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const { setErrors } = useContext(ErrorHandlingContext);
   const { getApiAuthenticated, putApiAuthenticated } = useApi();
-  const [isUploadingData, setIsUploadingData] = React.useState(false);
-  const [apiKey, setApiKey] = React.useState('');
-  const [isApiKeyVisible, setIsApiKeyVisible] = React.useState(false);
+  const [isUploadingData, setIsUploadingData] = useState(false);
+  const [apiKey, setApiKey] = useState('');
+  const [isApiKeyVisible, setIsApiKeyVisible] = useState(false);
 
   const handleVisibilityChange = () => {
     setIsApiKeyVisible(!isApiKeyVisible);
@@ -59,7 +59,7 @@ export default function ApiKey() {
   };
 
   const regenerateApiKey = async (
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    e: MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
     e.preventDefault();
     setIsUploadingData(true);
@@ -77,7 +77,7 @@ export default function ApiKey() {
     setIsUploadingData(false);
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (token && contextLoaded) {
       getApiKey();
     }
@@ -108,7 +108,7 @@ export default function ApiKey() {
         </InlineFormDisplayGroup>
         <div>
           <Button
-            onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) =>
+            onClick={(e: MouseEvent<HTMLButtonElement, MouseEvent>) =>
               regenerateApiKey(e)
             }
             variant="contained"

--- a/src/features/user/Settings/DeleteProfile/DeleteProfileForm.tsx
+++ b/src/features/user/Settings/DeleteProfile/DeleteProfileForm.tsx
@@ -1,6 +1,7 @@
+import type { ChangeEvent } from 'react';
 import type { APIError, SerializedError } from '@planet-sdk/common';
 
-import React from 'react';
+import { useState, useContext } from 'react';
 import styles from './DeleteProfile.module.scss';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
@@ -17,17 +18,17 @@ export default function DeleteProfileForm() {
   const { user, logoutUser } = useUserProps();
   const tCommon = useTranslations('Common');
 
-  const handleChange = (e: React.ChangeEvent<{}>) => {
+  const handleChange = (e: ChangeEvent<{}>) => {
     e.preventDefault();
   };
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const { setErrors } = useContext(ErrorHandlingContext);
   const router = useRouter();
   const { localizedPath } = useLocalizedPath();
   const { deleteApiAuthenticated } = useApi();
 
-  const [isUploadingData, setIsUploadingData] = React.useState(false);
-  const [isModalOpen, setIsModalOpen] = React.useState(false); //true when subscriptions are present
-  const [canDeleteAccount, setcanDeleteAccount] = React.useState(false);
+  const [isUploadingData, setIsUploadingData] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false); //true when subscriptions are present
+  const [canDeleteAccount, setcanDeleteAccount] = useState(false);
 
   const handleDeleteAccount = async () => {
     setIsUploadingData(true);

--- a/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressActionMenu.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressActionMenu.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from 'react';
 import type { SetState } from '../../../../../common/types/common';
 import type { AddressAction } from '../../../../../common/types/profile';
 import type { Address } from '@planet-sdk/common';

--- a/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressActionMenu.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressActionMenu.tsx
@@ -69,7 +69,7 @@ const AddressActionsMenu = ({
     },
   ];
 
-  const openPopover = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const openPopover = (event: MouseEvent<HTMLButtonElement>) => {
     setPopoverAnchor(event.currentTarget);
   };
 

--- a/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressFormLayout.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressFormLayout.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react';
+
 import styles from '../AddressManagement.module.scss';
 
 interface Props {

--- a/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressFormLayout.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/microComponents/AddressFormLayout.tsx
@@ -1,8 +1,8 @@
-import type { JSX } from 'react';
+import type { ReactElement } from 'react';
 import styles from '../AddressManagement.module.scss';
 
 interface Props {
-  children: JSX.Element;
+  children: ReactElement;
   label: string;
 }
 const AddressFormLayout = ({ children, label }: Props) => {

--- a/src/features/user/Settings/EditProfile/EditProfileForm.tsx
+++ b/src/features/user/Settings/EditProfile/EditProfileForm.tsx
@@ -1,3 +1,4 @@
+import type { SyntheticEvent } from 'react';
 import type { AlertColor } from '@mui/lab';
 import type { APIError } from '@planet-sdk/common';
 import type { User, UserType } from '@planet-sdk/common/build/types/user';
@@ -5,7 +6,7 @@ import type { User, UserType } from '@planet-sdk/common/build/types/user';
 import { TextField } from '@mui/material';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
-import React, { useMemo, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Controller, useForm } from 'react-hook-form';
 import Camera from '../../../../../public/assets/images/icons/userProfileIcons/Camera';
@@ -63,7 +64,7 @@ type UpdateProfileApiPayload = Omit<ProfileFormData, 'isPublic'> & {
 };
 
 export default function EditProfileForm() {
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const { setErrors } = useContext(ErrorHandlingContext);
   const { user, setUser, token, contextLoaded } = useUserProps();
   const t = useTranslations('EditProfile');
   const router = useRouter();
@@ -71,8 +72,8 @@ export default function EditProfileForm() {
   const { putApiAuthenticated } = useApi();
 
   const [snackbarOpen, setSnackbarOpen] = useState(false);
-  const [isUploadingData, setIsUploadingData] = React.useState(false);
-  const [updatingPic, setUpdatingPic] = React.useState(false);
+  const [isUploadingData, setIsUploadingData] = useState(false);
+  const [updatingPic, setUpdatingPic] = useState(false);
   // the form values
   const [severity, setSeverity] = useState<AlertColor>('success');
   const [snackbarMessage, setSnackbarMessage] = useState('OK');
@@ -116,7 +117,7 @@ export default function EditProfileForm() {
     setSnackbarOpen(true);
   };
   const handleSnackbarClose = (
-    _event?: React.SyntheticEvent | Event,
+    _event?: SyntheticEvent | Event,
     reason?: string
   ) => {
     if (reason === 'clickaway') {
@@ -125,7 +126,7 @@ export default function EditProfileForm() {
     setSnackbarOpen(false);
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     reset(defaultProfileDetails);
   }, [defaultProfileDetails]);
 
@@ -147,7 +148,7 @@ export default function EditProfileForm() {
     },
   ];
 
-  React.useEffect(() => {
+  useEffect(() => {
     const selectedProfile = profileTypes.find((p) => p.value === type);
     selectedProfile &&
       setLocalProfileType({
@@ -157,7 +158,7 @@ export default function EditProfileForm() {
       });
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     // This will remove field values which do not exist for the new type
     reset();
   }, [type]);
@@ -182,7 +183,7 @@ export default function EditProfileForm() {
     }
   };
 
-  const onDrop = React.useCallback(
+  const onDrop = useCallback(
     (acceptedFiles) => {
       setUpdatingPic(true);
       acceptedFiles.forEach((file: Blob) => {
@@ -207,7 +208,7 @@ export default function EditProfileForm() {
   );
 
   const deleteProfilePicture = (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    event: MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
     event.preventDefault();
     const profileImagePayload = {

--- a/src/features/user/Settings/EditProfile/EditProfileForm.tsx
+++ b/src/features/user/Settings/EditProfile/EditProfileForm.tsx
@@ -1,4 +1,4 @@
-import type { SyntheticEvent } from 'react';
+import type { SyntheticEvent, MouseEvent } from 'react';
 import type { AlertColor } from '@mui/lab';
 import type { APIError } from '@planet-sdk/common';
 import type { User, UserType } from '@planet-sdk/common/build/types/user';
@@ -207,9 +207,7 @@ export default function EditProfileForm() {
     [token]
   );
 
-  const deleteProfilePicture = (
-    event: MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
+  const deleteProfilePicture = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     const profileImagePayload = {
       imageFile: null,

--- a/src/features/user/Settings/ImpersonateUser/ImpersonationActivated.tsx
+++ b/src/features/user/Settings/ImpersonateUser/ImpersonationActivated.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useTranslations } from 'next-intl';
 import LogoutIcon from '../../../../../public/assets/images/icons/Sidebar/LogoutIcon';
 import styles from './ImpersonateUser.module.scss';

--- a/src/features/user/TreeMapper/Analytics/components/Container/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Container/index.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import styles from './index.module.scss';
 
 /**
@@ -5,11 +7,11 @@ import styles from './index.module.scss';
  */
 interface Props {
   /** The element to be placed on the left side of the container. */
-  leftElement: React.ReactElement;
+  leftElement: ReactElement;
   /** The element to be placed on the right side of the container. */
-  rightElement?: React.ReactElement;
+  rightElement?: ReactElement;
   /** The main content of the container. */
-  children: React.ReactElement;
+  children: ReactElement;
   /**
    * The direction of the flex container. Can be either 'row' (horizontal) or 'column' (vertical).
    * @default 'row'

--- a/src/features/user/TreeMapper/Analytics/components/Map/components/SiteSelectorAutocomplete/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Map/components/SiteSelectorAutocomplete/index.tsx
@@ -3,7 +3,7 @@ import type {
   FeatureCollection,
 } from '../../../../../../../common/types/dataExplorer';
 import type { ReactElement, CSSProperties } from 'react';
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Autocomplete, TextField, styled } from '@mui/material';
 import { useTranslations } from 'next-intl';
 

--- a/src/features/user/TreeMapper/Analytics/components/Map/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/Map/index.tsx
@@ -366,7 +366,7 @@ export const MapContainer = () => {
   // If the input is a HID, the plant location with the matching HID will be selected
   // If the input is a Date, the plant locations with the matching Date will be selected
   const handleSearchChange = (
-    event: React.ChangeEvent<HTMLInputElement> | React.ClipboardEvent
+    event: ChangeEvent<HTMLInputElement> | ClipboardEvent
   ) => {
     let value = '';
 

--- a/src/features/user/TreeMapper/Analytics/components/ProjectFilter/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/ProjectFilter/index.tsx
@@ -1,6 +1,6 @@
 import type { Project } from '../../../../../common/Layout/AnalyticsContext';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useAnalytics } from '../../../../../common/Layout/AnalyticsContext';
 import ProjectSelectAutocomplete from '../ProjectSelectAutocomplete';
 import { MobileDatePicker as MuiDatePicker } from '@mui/x-date-pickers/MobileDatePicker';

--- a/src/features/user/TreeMapper/Analytics/components/ProjectSelectAutocomplete.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/ProjectSelectAutocomplete.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import type { Project } from '../../../../common/Layout/AnalyticsContext';
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Autocomplete, TextField, styled } from '@mui/material';
 import { useTranslations } from 'next-intl';
 

--- a/src/features/user/TreeMapper/Analytics/components/ProjectTypeSelector.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/ProjectTypeSelector.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, CSSProperties } from 'react';
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Autocomplete, TextField, styled } from '@mui/material';
 import { useTranslations } from 'next-intl';
 

--- a/src/features/user/TreeMapper/Analytics/components/TreePlanted/TimeFrameSelector.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/TreePlanted/TimeFrameSelector.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Autocomplete, TextField, styled } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import { getTimeFrames } from '.';

--- a/src/features/user/TreeMapper/Analytics/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/index.tsx
@@ -1,7 +1,7 @@
 import type { Project } from '../../../common/Layout/AnalyticsContext';
 import type { APIError, ProfileProjectFeature } from '@planet-sdk/common';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import DashboardView from '../../../common/Layout/DashboardView';
 import { useTranslations } from 'next-intl';
 import ProjectFilter from './components/ProjectFilter';
@@ -17,7 +17,7 @@ const Analytics = () => {
   const { projectList, setProjectList, setProject } = useAnalytics();
   const [isLoaded, setIsLoaded] = useState(false);
   const { getApiAuthenticated } = useApi();
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const { setErrors } = useContext(ErrorHandlingContext);
 
   const fetchProjects = async () => {
     try {

--- a/src/features/user/TreeMapper/Import/components/Map.tsx
+++ b/src/features/user/TreeMapper/Import/components/Map.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import type { RequiredMapStyle } from '../../../../common/types/map';
 import type { ViewPort } from '../../../../common/types/project';
 
-import React from 'react';
+import { useEffect, useState } from 'react';
 import styles from '../../TreeMapper.module.scss';
 import getMapStyle from '../../../../../utils/maps/getMapStyle';
 import MapGL, { NavigationControl } from 'react-map-gl';
@@ -11,11 +11,11 @@ import LayerDisabled from '../../../../../../public/assets/images/icons/LayerDis
 import SatelliteLayer from '../../../../projects/components/maps/SatelliteLayer';
 
 export default function MyTreesMap(): ReactElement {
-  const [satellite, setSatellite] = React.useState(false);
+  const [satellite, setSatellite] = useState(false);
 
   const defaultMapCenter = [-28.5, 36.96];
   const defaultZoom = 1.4;
-  const [viewport, setViewPort] = React.useState({
+  const [viewport, setViewPort] = useState({
     width: Number('100%'),
     height: Number('100%'),
     latitude: defaultMapCenter[0],
@@ -23,13 +23,13 @@ export default function MyTreesMap(): ReactElement {
     zoom: defaultZoom,
   });
 
-  const [style, setStyle] = React.useState({
+  const [style, setStyle] = useState({
     version: 8,
     sources: {},
     layers: [],
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     const promise = getMapStyle('default');
     promise.then((style: RequiredMapStyle) => {
       if (style) {

--- a/src/features/user/TreeMapper/Import/components/MapComponent.tsx
+++ b/src/features/user/TreeMapper/Import/components/MapComponent.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import type { GeoJSON } from 'geojson';
 import type { RequiredMapStyle } from '../../../../common/types/map';
 
-import React from 'react';
+import { useEffect, useState } from 'react';
 import { featureCollection } from '@turf/helpers';
 import bbox from '@turf/bbox';
 import ReactMapboxGl, { ZoomControl, GeoJSONLayer } from 'react-mapbox-gl';
@@ -29,7 +29,7 @@ export default function MapComponent({ geoJson }: Props): ReactElement {
   const defaultZoom = 1.4;
   const { white, warmGreen } = themeProperties.designSystem.colors;
 
-  const [viewport, setViewPort] = React.useState<viewportProps>({
+  const [viewport, setViewPort] = useState<viewportProps>({
     height: '100%',
     width: '100%',
     center: defaultMapCenter,
@@ -43,12 +43,12 @@ export default function MapComponent({ geoJson }: Props): ReactElement {
     zoom: defaultZoom,
   };
 
-  const [style, setStyle] = React.useState({
+  const [style, setStyle] = useState({
     version: 8,
     sources: {},
     layers: [],
   });
-  React.useEffect(() => {
+  useEffect(() => {
     const promise = getMapStyle('openStreetMap');
     promise.then((style: RequiredMapStyle) => {
       if (style) {
@@ -57,7 +57,7 @@ export default function MapComponent({ geoJson }: Props): ReactElement {
     });
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (geoJson) {
       const geo = featureCollection([
         { type: 'Feature', geometry: geoJson, properties: {} },

--- a/src/features/user/TreeMapper/Import/components/PlantingLocation.tsx
+++ b/src/features/user/TreeMapper/Import/components/PlantingLocation.tsx
@@ -14,7 +14,7 @@ import type { InterventionFormData, SpeciesFormData } from '../../Treemapper';
 import type { SetState } from '../../../../common/types/common';
 import type { APIError, ProfileProjectFeature } from '@planet-sdk/common';
 
-import React from 'react';
+import { useEffect, useState, useContext, useCallback } from 'react';
 import { Controller, useForm, useFieldArray } from 'react-hook-form';
 import styles from '../Import.module.scss';
 import { useTranslations } from 'next-intl';
@@ -162,12 +162,12 @@ export default function PlantingLocation({
 }: Props): ReactElement {
   const { getApiAuthenticated } = useApi();
   const { user, contextLoaded } = useUserProps();
-  const [isUploadingData, setIsUploadingData] = React.useState(false);
-  const [projects, setProjects] = React.useState<ProfileProjectFeature[]>([]);
+  const [isUploadingData, setIsUploadingData] = useState(false);
+  const [projects, setProjects] = useState<ProfileProjectFeature[]>([]);
   const importMethods = ['import', 'editor'];
-  const [geoJsonError, setGeoJsonError] = React.useState(false);
-  const [mySpecies, setMySpecies] = React.useState<Species[] | null>(null);
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const [geoJsonError, setGeoJsonError] = useState(false);
+  const [mySpecies, setMySpecies] = useState<Species[] | null>(null);
+  const { setErrors } = useContext(ErrorHandlingContext);
   const { postApiAuthenticated } = useApi();
   const tTreemapper = useTranslations('Treemapper');
   const tMe = useTranslations('Me');
@@ -219,7 +219,7 @@ export default function PlantingLocation({
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (contextLoaded) {
       loadProjects();
       loadMySpecies();
@@ -249,7 +249,7 @@ export default function PlantingLocation({
     }
   };
 
-  const onDrop = React.useCallback((acceptedFiles) => {
+  const onDrop = useCallback((acceptedFiles) => {
     acceptedFiles.forEach((file: File) => {
       const reader = new FileReader();
       reader.readAsText(file);

--- a/src/features/user/TreeMapper/Import/components/ReviewSubmit.tsx
+++ b/src/features/user/TreeMapper/Import/components/ReviewSubmit.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import type { MultiTreeRegistration } from '../../../../common/types/intervention';
 
-import React from 'react';
+import { useState } from 'react';
 import styles from '../Import.module.scss';
 import { useTranslations } from 'next-intl';
 import formatDate from '../../../../../utils/countryCurrency/getFormattedDate';
@@ -23,8 +23,8 @@ export default function ReviewSubmit({
   const tTreemapper = useTranslations('Treemapper');
   const tMaps = useTranslations('Maps');
 
-  const [isUploadingData, setIsUploadingData] = React.useState(false);
-  const [submitted, setSubmitted] = React.useState(true);
+  const [isUploadingData, setIsUploadingData] = useState(false);
+  const [submitted, setSubmitted] = useState(true);
 
   const handleSubmit = () => {
     setIsUploadingData(true);

--- a/src/features/user/TreeMapper/Import/components/SampleTreeCard.tsx
+++ b/src/features/user/TreeMapper/Import/components/SampleTreeCard.tsx
@@ -3,7 +3,6 @@ import type { MultiTreeRegistration } from '../../../../common/types/interventio
 import type { SampleTree } from '../../../../common/types/intervention';
 import type { Control, FieldArrayWithId, FieldErrors } from 'react-hook-form';
 
-import React from 'react';
 import { useTranslations } from 'next-intl';
 import styles from '../Import.module.scss';
 import DeleteIcon from '../../../../../../public/assets/images/icons/manageProjects/Delete';

--- a/src/features/user/TreeMapper/Import/components/SampleTrees.tsx
+++ b/src/features/user/TreeMapper/Import/components/SampleTrees.tsx
@@ -8,7 +8,7 @@ import type {
   SampleTree,
 } from '../../../../common/types/intervention';
 
-import React, { useState } from 'react';
+import { useState, useContext, useCallback } from 'react';
 import styles from '../Import.module.scss';
 import { useDropzone } from 'react-dropzone';
 import { useTranslations } from 'next-intl';
@@ -50,11 +50,11 @@ export default function SampleTrees({
 }: Props): ReactElement {
   const tTreemapper = useTranslations('Treemapper');
   const tBulkCodes = useTranslations('BulkCodes');
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const { setErrors } = useContext(ErrorHandlingContext);
   const { postApiAuthenticated } = useApi();
-  const [isUploadingData, setIsUploadingData] = React.useState(false);
-  const [uploadStatus, setUploadStatus] = React.useState<string[]>([]);
-  const [sampleTrees, setSampleTrees] = React.useState<SampleTree[]>([]);
+  const [isUploadingData, setIsUploadingData] = useState(false);
+  const [uploadStatus, setUploadStatus] = useState<string[]>([]);
+  const [sampleTrees, setSampleTrees] = useState<SampleTree[]>([]);
   const [parseError, setParseError] = useState<FileImportError | null>(null);
   const [hasIgnoredColumns, setHasIgnoredColumns] = useState(false);
 
@@ -101,7 +101,7 @@ export default function SampleTrees({
     };
   };
 
-  const onDrop = React.useCallback((acceptedFiles) => {
+  const onDrop = useCallback((acceptedFiles) => {
     acceptedFiles.forEach((file: File) => {
       setParseError(null);
       setHasIgnoredColumns(false);

--- a/src/features/user/TreeMapper/Import/index.tsx
+++ b/src/features/user/TreeMapper/Import/index.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import type { APIError } from '@planet-sdk/common';
 import type { Intervention } from '../../../common/types/intervention';
 
-import React from 'react';
+import { useEffect, useState, useContext } from 'react';
 import PlantingLocation from './components/PlantingLocation';
 import styles from './Import.module.scss';
 import { useTranslations } from 'next-intl';
@@ -46,7 +46,7 @@ export default function ImportData(): ReactElement {
   const router = useRouter();
   const tTreemapper = useTranslations('Treemapper');
   const tCommon = useTranslations('Common');
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const { setErrors } = useContext(ErrorHandlingContext);
   const { getApiAuthenticated } = useApi();
   function getSteps() {
     return [
@@ -55,13 +55,11 @@ export default function ImportData(): ReactElement {
       tTreemapper('submitted'),
     ];
   }
-  const [activeStep, setActiveStep] = React.useState(0);
+  const [activeStep, setActiveStep] = useState(0);
   const steps = getSteps();
-  const [intervention, setIntervention] = React.useState<Intervention | null>(
-    null
-  );
-  const [userLang, setUserLang] = React.useState('en');
-  const [geoJson, setGeoJson] = React.useState(null);
+  const [intervention, setIntervention] = useState<Intervention | null>(null);
+  const [userLang, setUserLang] = useState('en');
+  const [geoJson, setGeoJson] = useState(null);
 
   const fetchIntervention = async (id: string) => {
     try {
@@ -77,13 +75,13 @@ export default function ImportData(): ReactElement {
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router && router.query.loc && !Array.isArray(router.query.loc)) {
       fetchIntervention(router.query.loc);
     }
   }, [router]);
 
-  const [activeMethod, setActiveMethod] = React.useState('import');
+  const [activeMethod, setActiveMethod] = useState('import');
 
   const handleNext = () => {
     setActiveStep(activeStep + 1);
@@ -93,7 +91,7 @@ export default function ImportData(): ReactElement {
     setActiveStep(activeStep - 1);
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (localStorage.getItem('language')) {
       const userLang = localStorage.getItem('language');
       if (userLang) setUserLang(userLang);

--- a/src/features/user/TreeMapper/MySpecies/MySpeciesForm.tsx
+++ b/src/features/user/TreeMapper/MySpecies/MySpeciesForm.tsx
@@ -4,7 +4,7 @@ import type {
   SpeciesSuggestionType,
 } from '../../../common/types/intervention';
 
-import React from 'react';
+import { useEffect, useState, useContext } from 'react';
 import StyledForm from '../../../common/Layout/StyledForm';
 import TrashIcon from '../../../../../public/assets/images/icons/manageProjects/Trash';
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
@@ -32,9 +32,9 @@ export default function MySpeciesForm() {
   const tTreemapper = useTranslations('Treemapper');
   const tCommon = useTranslations('Common');
   const { token, contextLoaded } = useUserProps();
-  const { setErrors } = React.useContext(ErrorHandlingContext);
-  const [species, setSpecies] = React.useState<Species[]>([]);
-  const [isUploadingData, setIsUploadingData] = React.useState(false);
+  const { setErrors } = useContext(ErrorHandlingContext);
+  const [species, setSpecies] = useState<Species[]>([]);
+  const [isUploadingData, setIsUploadingData] = useState(false);
   const { getApiAuthenticated, deleteApiAuthenticated, postApiAuthenticated } =
     useApi();
 
@@ -95,7 +95,7 @@ export default function MySpeciesForm() {
     setIsUploadingData(false);
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (contextLoaded && token) {
       fetchMySpecies();
     }

--- a/src/features/user/TreeMapper/MySpecies/SpeciesAutoComplete.tsx
+++ b/src/features/user/TreeMapper/MySpecies/SpeciesAutoComplete.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable no-use-before-define */
+import type { ReactNode } from 'react';
 import type { Control, FieldValues, FieldPath } from 'react-hook-form';
 import type { APIError } from '@planet-sdk/common';
 import type { SpeciesSuggestionType } from '../../../common/types/intervention';
 
-import React from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { Controller } from 'react-hook-form';
 import { Autocomplete, TextField } from '@mui/material';
-
 import { useTranslations } from 'next-intl';
 import { handleError } from '@planet-sdk/common';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
@@ -16,12 +16,12 @@ interface Props<
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues>
 > {
-  label: React.ReactNode;
+  label: ReactNode;
   name: TName;
   width?: string | undefined;
   control: Control<TFieldValues>;
   error?: boolean | undefined;
-  helperText?: React.ReactNode;
+  helperText?: ReactNode;
   // mySpecies?: any;
 }
 
@@ -42,16 +42,16 @@ export default function SpeciesSelect<
   error,
   helperText,
 }: Props<TFieldValues, TName>) {
-  const [speciesSuggestion, setspeciesSuggestion] = React.useState<
+  const [speciesSuggestion, setspeciesSuggestion] = useState<
     SpeciesSuggestionType[]
   >([]);
-  const [query, setQuery] = React.useState('');
+  const [query, setQuery] = useState('');
   const { postApi } = useApi();
   const t = useTranslations('Treemapper');
-  const { setErrors } = React.useContext(ErrorHandlingContext);
+  const { setErrors } = useContext(ErrorHandlingContext);
 
   // Code below can be removed if no longer needed, along with the `mySpecies` prop
-  /* React.useEffect(() => {
+  /* useEffect(() => {
     if (mySpecies && mySpecies.length > 0) {
       const species = mySpecies.map((item: any) => ({
         id: item.id,
@@ -89,7 +89,7 @@ export default function SpeciesSelect<
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     suggestSpecies(query);
   }, [query]);
 

--- a/src/features/user/TreeMapper/MySpecies/index.tsx
+++ b/src/features/user/TreeMapper/MySpecies/index.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import DashboardView from '../../../common/Layout/DashboardView';
 import CenteredContainer from '../../../common/Layout/CenteredContainer';
 import MySpeciesForm from './MySpeciesForm';

--- a/src/features/user/TreeMapper/components/InterventionPage.tsx
+++ b/src/features/user/TreeMapper/components/InterventionPage.tsx
@@ -6,7 +6,7 @@ import type {
 } from '../../../common/types/intervention';
 import type { SetState } from '../../../common/types/common';
 
-import React from 'react';
+import { useEffect, useState } from 'react';
 import formatDate from '../../../../utils/countryCurrency/getFormattedDate';
 import styles from '../TreeMapper.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
@@ -54,7 +54,7 @@ export function InterventionInfo({
   const tTreemapper = useTranslations('Treemapper');
   const tMaps = useTranslations('Maps');
   const locale = useLocale();
-  const [sampleTreeImages, setSampleTreeImages] = React.useState<
+  const [sampleTreeImages, setSampleTreeImages] = useState<
     SampleTreeImageProps[]
   >([]);
 
@@ -119,7 +119,7 @@ export function InterventionInfo({
       </div>
     ));
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (selectedIntervention?.type === 'multi-tree-registration') {
       if (
         selectedIntervention &&

--- a/src/features/user/TreeMapper/components/Map.tsx
+++ b/src/features/user/TreeMapper/components/Map.tsx
@@ -11,7 +11,7 @@ import type { SetState } from '../../../common/types/common';
 import type { Feature, Point, Polygon } from 'geojson';
 import type { AllGeoJSON } from '@turf/turf';
 
-import React from 'react';
+import { useEffect, useState } from 'react';
 import styles from '../TreeMapper.module.scss';
 import getMapStyle from '../../../../utils/maps/getMapStyle';
 import area from '@turf/area';
@@ -64,17 +64,17 @@ export default function MyTreesMap({
   const { primaryColor, white } = themeProperties.designSystem.colors;
   const defaultMapCenter = [-28.5, 36.96];
   const defaultZoom = 1.4;
-  const [viewport, setViewPort] = React.useState({
+  const [viewport, setViewPort] = useState({
     width: Number('100%'),
     height: Number('100%'),
     latitude: defaultMapCenter[0],
     longitude: defaultMapCenter[1],
     zoom: defaultZoom,
   });
-  const [satellite, setSatellite] = React.useState(false);
-  const [geoJson, setGeoJson] = React.useState<GeoJson | null>(null);
-  const [plIds, setPlIds] = React.useState<string[] | null>(null);
-  const [style, setStyle] = React.useState({
+  const [satellite, setSatellite] = useState(false);
+  const [geoJson, setGeoJson] = useState<GeoJson | null>(null);
+  const [plIds, setPlIds] = useState<string[] | null>(null);
+  const [style, setStyle] = useState({
     version: 8,
     sources: {},
     layers: [],
@@ -160,7 +160,7 @@ export default function MyTreesMap({
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     const promise = getMapStyle('default');
     promise.then((style: RequiredMapStyle) => {
       if (style) {
@@ -169,7 +169,7 @@ export default function MyTreesMap({
     });
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (interventions) {
       const features = [];
       const ids = [];
@@ -201,7 +201,7 @@ export default function MyTreesMap({
     }
   }, [interventions]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (selectedIntervention) {
       zoomToLocation(selectedIntervention.geometry);
     }

--- a/src/features/user/TreeMapper/components/TreeMapperList.tsx
+++ b/src/features/user/TreeMapper/components/TreeMapperList.tsx
@@ -6,7 +6,6 @@ import type {
   SampleTreeRegistration,
 } from '../../../common/types/intervention';
 
-import React from 'react';
 import TransactionListLoader from '../../../../../public/assets/images/icons/TransactionListLoader';
 import TransactionsNotFound from '../../../../../public/assets/images/icons/TransactionsNotFound';
 import styles from '../TreeMapper.module.scss';

--- a/src/features/user/TreeMapper/components/TreemapperIntervention.tsx
+++ b/src/features/user/TreeMapper/components/TreemapperIntervention.tsx
@@ -5,7 +5,7 @@ import type {
 } from '../../../common/types/intervention';
 import type { SetState } from '../../../common/types/common';
 
-import React from 'react';
+import { useEffect, useState } from 'react';
 import formatDate from '../../../../utils/countryCurrency/getFormattedDate';
 import styles from '../TreeMapper.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
@@ -33,7 +33,7 @@ function TreemapperIntervention({
   const locale = useLocale();
   const router = useRouter();
   let treeCount = 0;
-  const [plantationArea, setPlantationArea] = React.useState(0);
+  const [plantationArea, setPlantationArea] = useState(0);
 
   if (
     intervention.type === 'multi-tree-registration' &&
@@ -57,7 +57,7 @@ function TreemapperIntervention({
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (intervention.type === 'multi-tree-registration') {
       const calculatedArea = area(intervention.geometry);
       setPlantationArea(calculatedArea / 10000);

--- a/src/features/user/TreeMapper/index.tsx
+++ b/src/features/user/TreeMapper/index.tsx
@@ -7,7 +7,7 @@ import type {
 import type { Links } from '../../common/types/payments';
 import type { ReactElement } from 'react';
 
-import React from 'react';
+import { useEffect, useState, useContext } from 'react';
 import styles from './TreeMapper.module.scss';
 import dynamic from 'next/dynamic';
 import TreeMapperList from './components/TreeMapperList';
@@ -29,14 +29,14 @@ function TreeMapper(): ReactElement {
   const { token, contextLoaded } = useUserProps();
   const t = useTranslations('Treemapper');
   const { getApiAuthenticated } = useApi();
-  const [progress, setProgress] = React.useState(0);
-  const [isDataLoading, setIsDataLoading] = React.useState(false);
-  const [interventions, setInterventions] = React.useState<Intervention[]>([]);
-  const [selectedIntervention, setSelectedIntervention] = React.useState<
+  const [progress, setProgress] = useState(0);
+  const [isDataLoading, setIsDataLoading] = useState(false);
+  const [interventions, setInterventions] = useState<Intervention[]>([]);
+  const [selectedIntervention, setSelectedIntervention] = useState<
     Intervention | SampleTreeRegistration | null
   >(null);
-  const { redirect, setErrors } = React.useContext(ErrorHandlingContext);
-  const [links, setLinks] = React.useState<Links>();
+  const { redirect, setErrors } = useContext(ErrorHandlingContext);
+  const [links, setLinks] = useState<Links>();
 
   async function fetchTreemapperData(next = false) {
     setIsDataLoading(true);
@@ -125,11 +125,11 @@ function TreeMapper(): ReactElement {
     setTimeout(() => setProgress(0), 1000);
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (contextLoaded && token) fetchTreemapperData();
   }, [contextLoaded, token]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.query.l) {
       if (interventions) {
         for (const key in interventions) {

--- a/src/features/user/Widget/DonationLink/DonationLinkForm.tsx
+++ b/src/features/user/Widget/DonationLink/DonationLinkForm.tsx
@@ -9,7 +9,7 @@ import AutoCompleteCountry from '../../../common/InputTypes/AutoCompleteCountry'
 import { useUserProps } from '../../../common/Layout/UserPropsContext';
 import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDisplayGroup';
 import supportedLanguages from '../../../../utils/language/supportedLanguages.json';
-import React from 'react';
+
 import ProjectSelectAutocomplete from '../../BulkCodes/components/ProjectSelectAutocomplete';
 import { useTenant } from '../../../common/Layout/TenantContext';
 import styles from '../../../../../src/features/user/Widget/DonationLink/DonationLinkForm.module.scss';

--- a/src/features/user/Widget/DonationLink/index.tsx
+++ b/src/features/user/Widget/DonationLink/index.tsx
@@ -3,7 +3,7 @@ import type { ProjectOption } from '../../../common/types/project';
 import type { MapProject } from '../../../common/types/projectv2';
 import type { APIError } from '@planet-sdk/common';
 
-import React, { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import DashboardView from '../../../common/Layout/DashboardView';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';

--- a/src/features/user/Widget/EmbedModal.tsx
+++ b/src/features/user/Widget/EmbedModal.tsx
@@ -1,6 +1,7 @@
+import type { SyntheticEvent } from 'react';
 import type { APIError, User } from '@planet-sdk/common';
 
-import React from 'react';
+import { useState, useContext } from 'react';
 import { Modal, Snackbar } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import styles from './EmbedModal.module.scss';
@@ -25,9 +26,9 @@ export default function EmbedModal({
   setEmbedModalOpen,
 }: Props) {
   const t = useTranslations('EditProfile');
-  const { setErrors } = React.useContext(ErrorHandlingContext);
-  const [isUploadingData, setIsUploadingData] = React.useState(false);
-  const [snackbarOpen, setSnackbarOpen] = React.useState(false);
+  const { setErrors } = useContext(ErrorHandlingContext);
+  const [isUploadingData, setIsUploadingData] = useState(false);
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
   const router = useRouter();
   const { putApiAuthenticated } = useApi();
   // This effect is used to get and update UserInfo if the isAuthenticated changes
@@ -37,10 +38,7 @@ export default function EmbedModal({
   const handleSnackbarOpen = () => {
     setSnackbarOpen(true);
   };
-  const handleSnackbarClose = (
-    event?: React.SyntheticEvent,
-    reason?: string
-  ) => {
+  const handleSnackbarClose = (event?: SyntheticEvent, reason?: string) => {
     if (reason === 'clickaway') {
       return;
     }
@@ -68,7 +66,7 @@ export default function EmbedModal({
     }
   };
 
-  const { theme } = React.useContext(ThemeContext);
+  const { theme } = useContext(ThemeContext);
 
   return (
     <>

--- a/src/temp/icons/SatelliteAnalysisIcon.tsx
+++ b/src/temp/icons/SatelliteAnalysisIcon.tsx
@@ -1,7 +1,5 @@
 import type { IconProps } from '../../features/common/types/common';
 
-import React from 'react';
-
 const SatelliteAnalysisIcon = ({ color, width }: IconProps) => {
   return (
     <svg

--- a/src/tenants/common/Home/index.tsx
+++ b/src/tenants/common/Home/index.tsx
@@ -3,12 +3,12 @@ import type {
   TenantScore,
 } from '../../../features/common/types/leaderboard';
 
+import { useEffect, useRef } from 'react';
 import styles from './Home.module.scss';
 import LandingSection from '../../../features/common/Layout/LandingSection';
 import LeaderBoard from '../LeaderBoard';
 import TreeCounter from '../../../features/common/TreeCounter/TreeCounter';
 import Footer from '../../../features/common/Layout/Footer';
-import React from 'react';
 import { useTenant } from '../../../features/common/Layout/TenantContext';
 import { useTranslations } from 'next-intl';
 
@@ -21,8 +21,8 @@ export default function Home({ leaderboard, tenantScore }: Props) {
   const { tenantConfig } = useTenant();
   const t = useTranslations('Tenants');
 
-  const descriptionRef = React.useRef<HTMLParagraphElement>(null);
-  React.useEffect(() => {
+  const descriptionRef = useRef<HTMLParagraphElement>(null);
+  useEffect(() => {
     if (descriptionRef.current !== null) {
       descriptionRef.current.innerHTML = t(
         `${tenantConfig.config.slug}.description`

--- a/src/tenants/common/LeaderBoard/index.tsx
+++ b/src/tenants/common/LeaderBoard/index.tsx
@@ -1,6 +1,6 @@
 import type { LeaderBoardList } from '../../../features/common/types/leaderboard';
 
-import React from 'react';
+import { useState } from 'react';
 import styles from './LeaderBoard.module.scss';
 import { getFormattedNumber } from '../../../utils/getFormattedNumber';
 import { useLocale, useTranslations } from 'next-intl';
@@ -10,7 +10,7 @@ interface Props {
 }
 
 export default function LeaderBoardSection(leaderboard: Props) {
-  const [selectedTab, setSelectedTab] = React.useState('recent');
+  const [selectedTab, setSelectedTab] = useState('recent');
   const leaderboardData = leaderboard.leaderboard;
   const tLeaderboard = useTranslations('Leaderboard');
   const tCommon = useTranslations('Common');

--- a/src/tenants/planet/LeaderBoard/components/Score.tsx
+++ b/src/tenants/planet/LeaderBoard/components/Score.tsx
@@ -1,6 +1,6 @@
 import type { APIError } from '@planet-sdk/common';
 
-import React from 'react';
+import { useState, useContext } from 'react';
 import styles from './LeaderBoard.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
 import { getFormattedNumber } from '../../../../utils/getFormattedNumber';
@@ -35,15 +35,15 @@ type UserApiPayload = {
 };
 
 export default function LeaderBoardSection(leaderboard: Props) {
-  const [selectedTab, setSelectedTab] = React.useState('recent');
+  const [selectedTab, setSelectedTab] = useState('recent');
   const leaderboardData = leaderboard.leaderboard;
   const tLeaderboard = useTranslations('Leaderboard');
   const tCommon = useTranslations('Common');
   const locale = useLocale();
   const { postApi } = useApi();
   const { localizedPath } = useLocalizedPath();
-  const { setErrors } = React.useContext(ErrorHandlingContext);
-  const [users, setUsers] = React.useState<LeaderboardUser[]>([]);
+  const { setErrors } = useContext(ErrorHandlingContext);
+  const [users, setUsers] = useState<LeaderboardUser[]>([]);
   const fetchUsers = async (query: string) => {
     try {
       const res = await postApi<LeaderboardUser[], UserApiPayload>(

--- a/src/tenants/planet/LeaderBoard/components/Stats.tsx
+++ b/src/tenants/planet/LeaderBoard/components/Stats.tsx
@@ -4,8 +4,8 @@ import type {
   TreesDonated,
 } from '../../../../features/common/types/leaderboard';
 
+import { useState, useContext } from 'react';
 import { Modal } from '@mui/material';
-import React from 'react';
 import InfoIcon from '../../../../../public/assets/images/icons/InfoIcon';
 import styles from './Stats.module.scss';
 import StatsInfoModal from './StatsInfoModal';
@@ -22,15 +22,15 @@ export default function Stats({
   tenantScore,
   treesDonated,
 }: Props): ReactElement {
-  const [infoExpanded, setInfoExpanded] = React.useState<String | null>(null);
+  const [infoExpanded, setInfoExpanded] = useState<String | null>(null);
   const tPlanet = useTranslations('Planet');
   const locale = useLocale();
-  const [openModal, setModalOpen] = React.useState(false);
+  const [openModal, setModalOpen] = useState(false);
   const handleModalClose = () => {
     setModalOpen(false);
   };
 
-  const { theme } = React.useContext(ThemeContext);
+  const { theme } = useContext(ThemeContext);
   return (
     <div className={styles.wrapper}>
       <div className={styles.container}>

--- a/src/tenants/planet/LeaderBoard/components/StatsInfoModal.tsx
+++ b/src/tenants/planet/LeaderBoard/components/StatsInfoModal.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
+import { forwardRef } from 'react';
 import styles from './Stats.module.scss';
 import { useTranslations } from 'next-intl';
 import OpenLink from '../../../../../public/assets/images/icons/OpenLink';
@@ -81,6 +81,4 @@ function ExploreInfoModal({
   );
 }
 
-export default React.forwardRef((props: Props) => (
-  <ExploreInfoModal {...props} />
-));
+export default forwardRef((props: Props) => <ExploreInfoModal {...props} />);

--- a/src/tenants/planet/LeaderBoard/components/Stories.tsx
+++ b/src/tenants/planet/LeaderBoard/components/Stories.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import styles from './Stories.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
 import { lang_path } from '../../../../utils/constants/wpLanguages';

--- a/src/tenants/planet/LeaderBoard/components/Video.tsx
+++ b/src/tenants/planet/LeaderBoard/components/Video.tsx
@@ -1,7 +1,6 @@
 // Not used currently. Left as a reference.
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import styles from './Video.module.scss';
 import { useTranslations } from 'next-intl';
 import ReactPlayer from 'react-player/lazy';

--- a/src/tenants/planet/LeaderBoard/index.tsx
+++ b/src/tenants/planet/LeaderBoard/index.tsx
@@ -5,7 +5,6 @@ import type {
   TreesDonated,
 } from '../../../features/common/types/leaderboard';
 
-import React from 'react';
 import Footer from '../../../features/common/Layout/Footer';
 import Score from './components/Score';
 import Stats from './components/Stats';

--- a/src/tenants/salesforce/Home/components/LeaderBoardSection.tsx
+++ b/src/tenants/salesforce/Home/components/LeaderBoardSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState } from 'react';
 import styles from './../styles/LeaderBoardSection.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
 import { getFormattedNumber } from '../../../../utils/getFormattedNumber';
@@ -8,7 +8,7 @@ interface Props {
 }
 
 export default function LeaderBoardSection(leaderboard: Props) {
-  const [selectedTab, setSelectedTab] = React.useState('recent');
+  const [selectedTab, setSelectedTab] = useState('recent');
   const leaderboardData = leaderboard.leaderboard;
   const tLeaderboard = useTranslations('Leaderboard');
   const tCommon = useTranslations('Common');

--- a/src/tenants/salesforce/Home/components/Timeline.tsx
+++ b/src/tenants/salesforce/Home/components/Timeline.tsx
@@ -1,6 +1,6 @@
 import styles from './../styles/Timeline.module.scss';
 import gridStyles from './../styles/Grid.module.scss';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 
 const moments = [

--- a/src/tenants/salesforce/Home/index.tsx
+++ b/src/tenants/salesforce/Home/index.tsx
@@ -12,7 +12,7 @@ import SeaOfTrees from './components/SeaOfTrees';
 import ContentSection from './components/ContentSection';
 import ClimateAction from './components/ClimateAction';
 import Social from './components/Social';
-import React from 'react';
+
 import { useTenant } from '../../../features/common/Layout/TenantContext';
 
 interface Props {

--- a/src/tenants/salesforce/Mangroves/components/AboveFooter.tsx
+++ b/src/tenants/salesforce/Mangroves/components/AboveFooter.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styles from './../styles/AboveFooter.module.scss';
 
 export default function LeaderBoardSection() {

--- a/src/tenants/salesforce/Mangroves/components/ProjectGrid.tsx
+++ b/src/tenants/salesforce/Mangroves/components/ProjectGrid.tsx
@@ -1,7 +1,7 @@
 import type { MapProject } from '../../../../features/common/types/ProjectPropsContextInterface';
 import type { APIError } from '@planet-sdk/common/build/types/errors';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { ErrorHandlingContext } from '../../../../features/common/Layout/ErrorHandlingContext';
 import getStoredCurrency from '../../../../utils/countryCurrency/getStoredCurrency';
 import gridStyles from './../styles/Grid.module.scss';
@@ -28,7 +28,7 @@ const MANGROVE_PROJECTS = [
 ];
 
 export default function ProjectGrid() {
-  const { setErrors, redirect } = React.useContext(ErrorHandlingContext);
+  const { setErrors, redirect } = useContext(ErrorHandlingContext);
   const { tenantConfig } = useTenant();
   const locale = useLocale();
   const { getApi } = useApi();

--- a/src/tenants/salesforce/Mangroves/index.tsx
+++ b/src/tenants/salesforce/Mangroves/index.tsx
@@ -4,7 +4,7 @@ import Landing from './components/Landing';
 import ContentSection from './components/ContentSection';
 import ProjectGrid from './components/ProjectGrid';
 import AboveFooter from './components/AboveFooter';
-import React from 'react';
+
 import BlueCarbon from './components/BlueCarbon';
 import { useTenant } from '../../../features/common/Layout/TenantContext';
 

--- a/src/tenants/salesforce/OceanforceCampaign/components/LeaderBoardSection.tsx
+++ b/src/tenants/salesforce/OceanforceCampaign/components/LeaderBoardSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState } from 'react';
 import styles from './../styles/LeaderBoardSection.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
 import { getFormattedNumber } from '../../../../utils/getFormattedNumber';
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export default function LeaderBoardSection({ leaderboard, isLoaded }: Props) {
-  const [selectedTab, setSelectedTab] = React.useState('recent');
+  const [selectedTab, setSelectedTab] = useState('recent');
   const isLeaderboardAvailable =
     isLoaded &&
     leaderboard &&

--- a/src/tenants/salesforce/OceanforceCampaign/components/ParticipationSection.tsx
+++ b/src/tenants/salesforce/OceanforceCampaign/components/ParticipationSection.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import gridStyles from './../styles/Grid.module.scss';
 import styles from './../styles/ParticipationSection.module.scss';
 

--- a/src/tenants/salesforce/TreeCounter/index.tsx
+++ b/src/tenants/salesforce/TreeCounter/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import treeCounterStyles from './TreeCounter.module.scss';
 
 interface Props {

--- a/src/tenants/salesforce/VTOCampaign2023/components/LeaderBoardSection.tsx
+++ b/src/tenants/salesforce/VTOCampaign2023/components/LeaderBoardSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState } from 'react';
 import styles from './../styles/LeaderBoardSection.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
 import { getFormattedNumber } from '../../../../utils/getFormattedNumber';
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export default function LeaderBoardSection({ leaderboard, isLoaded }: Props) {
-  const [selectedTab, setSelectedTab] = React.useState('recent');
+  const [selectedTab, setSelectedTab] = useState('recent');
   const isLeaderboardAvailable =
     isLoaded &&
     leaderboard &&

--- a/src/tenants/salesforce/VTOCampaign2023/components/ProjectGrid.tsx
+++ b/src/tenants/salesforce/VTOCampaign2023/components/ProjectGrid.tsx
@@ -1,7 +1,7 @@
 import type { MapProject } from '../../../../features/common/types/ProjectPropsContextInterface';
 import type { APIError } from '@planet-sdk/common/build/types/errors';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { ErrorHandlingContext } from '../../../../features/common/Layout/ErrorHandlingContext';
 import { useApi } from '../../../../hooks/useApi';
 import getStoredCurrency from '../../../../utils/countryCurrency/getStoredCurrency';
@@ -16,7 +16,7 @@ export default function ProjectGrid() {
   const { getApi } = useApi();
   const locale = useLocale();
   const { tenantConfig } = useTenant();
-  const { setErrors, redirect } = React.useContext(ErrorHandlingContext);
+  const { setErrors, redirect } = useContext(ErrorHandlingContext);
   const [projects, setProjects] = useState<MapProject[] | null>(null);
 
   useEffect(() => {

--- a/src/tenants/salesforce/VTOCampaign2023/index.tsx
+++ b/src/tenants/salesforce/VTOCampaign2023/index.tsx
@@ -5,7 +5,7 @@ import ContentSection from './components/ContentSection';
 import ProjectGrid from './components/ProjectGrid';
 import LeaderBoard from './components/LeaderBoardSection';
 import AdditionalInfo from './components/AdditionalInfo';
-import React from 'react';
+
 import { useTenant } from '../../../features/common/Layout/TenantContext';
 
 interface Props {

--- a/src/tenants/salesforce/VTOCampaign2024/components/LeaderBoardSection.tsx
+++ b/src/tenants/salesforce/VTOCampaign2024/components/LeaderBoardSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState } from 'react';
 import styles from './../styles/LeaderBoardSection.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
 import { getFormattedNumber } from '../../../../utils/getFormattedNumber';
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export default function LeaderBoardSection({ leaderboard, isLoaded }: Props) {
-  const [selectedTab, setSelectedTab] = React.useState('recent');
+  const [selectedTab, setSelectedTab] = useState('recent');
   const isLeaderboardAvailable =
     isLoaded &&
     leaderboard &&

--- a/src/tenants/salesforce/VTOCampaign2024/components/ProjectGrid.tsx
+++ b/src/tenants/salesforce/VTOCampaign2024/components/ProjectGrid.tsx
@@ -1,7 +1,7 @@
 import type { MapProject } from '../../../../features/common/types/ProjectPropsContextInterface';
 import type { APIError } from '@planet-sdk/common/build/types/errors';
 
-import React, { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { ErrorHandlingContext } from '../../../../features/common/Layout/ErrorHandlingContext';
 import getStoredCurrency from '../../../../utils/countryCurrency/getStoredCurrency';
 import gridStyles from './../styles/Grid.module.scss';
@@ -16,7 +16,7 @@ export default function ProjectGrid() {
   const { getApi } = useApi();
   const locale = useLocale();
   const { tenantConfig } = useTenant();
-  const { setErrors, redirect } = React.useContext(ErrorHandlingContext);
+  const { setErrors, redirect } = useContext(ErrorHandlingContext);
   const [projects, setProjects] = useState<MapProject[] | null>(null);
 
   useEffect(() => {

--- a/src/tenants/salesforce/VTOCampaign2024/index.tsx
+++ b/src/tenants/salesforce/VTOCampaign2024/index.tsx
@@ -5,7 +5,7 @@ import ContentSection from './components/ContentSection';
 import ProjectGrid from './components/ProjectGrid';
 import LeaderBoard from './components/LeaderBoardSection';
 import AdditionalInfo from './components/AdditionalInfo';
-import React from 'react';
+
 import { useTenant } from '../../../features/common/Layout/TenantContext';
 interface Props {
   leaderboard: {

--- a/src/tenants/salesforce/VTOCampaign2025/components/LeaderBoardSection.tsx
+++ b/src/tenants/salesforce/VTOCampaign2025/components/LeaderBoardSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState } from 'react';
 import styles from './../styles/LeaderBoardSection.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
 import { getFormattedNumber } from '../../../../utils/getFormattedNumber';
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export default function LeaderBoardSection({ leaderboard, isLoaded }: Props) {
-  const [selectedTab, setSelectedTab] = React.useState('recent');
+  const [selectedTab, setSelectedTab] = useState('recent');
   const isLeaderboardAvailable =
     isLoaded &&
     leaderboard &&

--- a/src/tenants/salesforce/VTOCampaign2025/components/ProjectGrid.tsx
+++ b/src/tenants/salesforce/VTOCampaign2025/components/ProjectGrid.tsx
@@ -1,7 +1,7 @@
 import type { MapProject } from '../../../../features/common/types/ProjectPropsContextInterface';
 import type { APIError } from '@planet-sdk/common/build/types/errors';
 
-import React, { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { ErrorHandlingContext } from '../../../../features/common/Layout/ErrorHandlingContext';
 import getStoredCurrency from '../../../../utils/countryCurrency/getStoredCurrency';
 import gridStyles from './../styles/Grid.module.scss';
@@ -13,7 +13,7 @@ import { useApi } from '../../../../hooks/useApi';
 import { useLocale } from 'next-intl';
 
 export default function ProjectGrid() {
-  const { setErrors, redirect } = React.useContext(ErrorHandlingContext);
+  const { setErrors, redirect } = useContext(ErrorHandlingContext);
   const { tenantConfig } = useTenant();
   const locale = useLocale();
   const { getApi } = useApi();

--- a/src/tenants/salesforce/VTOCampaign2025/index.tsx
+++ b/src/tenants/salesforce/VTOCampaign2025/index.tsx
@@ -5,7 +5,7 @@ import ContentSection from './components/ContentSection';
 import ProjectGrid from './components/ProjectGrid';
 import LeaderBoard from './components/LeaderBoardSection';
 import AdditionalInfo from './components/AdditionalInfo';
-import React from 'react';
+
 import { useTenant } from '../../../features/common/Layout/TenantContext';
 interface Props {
   leaderboard: {

--- a/src/utils/getMetaTags/GetHomeMeta.tsx
+++ b/src/utils/getMetaTags/GetHomeMeta.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import { useTenant } from '../../features/common/Layout/TenantContext';
 import Head from 'next/head';
 

--- a/src/utils/getMetaTags/GetLeaderboardMeta.tsx
+++ b/src/utils/getMetaTags/GetLeaderboardMeta.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import { useTenant } from '../../features/common/Layout/TenantContext';
 import Head from 'next/head';
 

--- a/src/utils/getMetaTags/GetPublicUserProfileMeta.tsx
+++ b/src/utils/getMetaTags/GetPublicUserProfileMeta.tsx
@@ -2,7 +2,7 @@ import type { UserPublicProfile } from '@planet-sdk/common';
 import type { ReactElement } from 'react';
 
 import Head from 'next/head';
-import React from 'react';
+
 import { useTenant } from '../../features/common/Layout/TenantContext';
 
 interface Props {

--- a/src/utils/getMetaTags/ProjectDetailsMeta.tsx
+++ b/src/utils/getMetaTags/ProjectDetailsMeta.tsx
@@ -4,7 +4,6 @@ import type {
   TreeProjectExtended,
 } from '@planet-sdk/common';
 
-import React from 'react';
 import { useTenant } from '../../features/common/Layout/TenantContext';
 import getImageUrl from '../getImageURL';
 import Head from 'next/head';

--- a/src/utils/getMetaTags/ProjectsListMeta.tsx
+++ b/src/utils/getMetaTags/ProjectsListMeta.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 
-import React from 'react';
 import { useTenant } from '../../features/common/Layout/TenantContext';
 import Head from 'next/head';
 


### PR DESCRIPTION
- Replace generic React imports with specific hooks and imports across multiple components for improved performance and clarity.
- Replace JSX.Element with ReactElement throughout