### PR TITLE
Refactor site area calculation in SiteDropdown

### DIFF
--- a/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/index.tsx
@@ -64,11 +64,15 @@ const ProjectSiteDropdown = ({
   const { query } = router;
   const siteList = useMemo(() => {
     if (!projectSites) return [];
-    return projectSites.map((site, index: number) => ({
-      siteName: site.properties.name,
-      siteArea: area(site) > 0 ? area(site) / 10000 : 0,
-      id: index,
-    }));
+    return projectSites.map((site, index: number) => {
+      const calculatedSiteAreaInM2 = area(site);
+      return {
+        siteName: site.properties.name,
+        siteArea:
+          calculatedSiteAreaInM2 > 0 ? calculatedSiteAreaInM2 / 10000 : 0,
+        id: index,
+      };
+    });
   }, [projectSites]);
 
   const getId = useCallback(


### PR DESCRIPTION
Eliminate duplicate calculations of site area in the SiteDropdown component for improved performance and readability.

Addresses [pending feedback](https://github.com/Plant-for-the-Planet-org/planet-webapp/pull/2682#discussion_r2315008729) in #2682 