### PR TITLE
fix: standardize casing for modal state setters in Recurrency components

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -49,6 +49,7 @@
     "planetcash",
     "ploc",
     "projectv",
+    "recurrencies",
     "recurrency",
     "regenerant",
     "Regenerants",

--- a/src/features/user/Account/Recurrency.tsx
+++ b/src/features/user/Account/Recurrency.tsx
@@ -24,10 +24,10 @@ export default function Recurrency({
 }: Props): ReactElement {
   const [selectedRecord, setSelectedRecord] = useState<number | null>(0);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [editModalOpen, seteditModalOpen] = useState(false);
-  const [pauseModalOpen, setpauseModalOpen] = useState(false);
-  const [cancelModalOpen, setcancelModalOpen] = useState(false);
-  const [reactivateModalOpen, setreactivateModalOpen] = useState(false);
+  const [editModalOpen, setEditModalOpen] = useState(false);
+  const [pauseModalOpen, setPauseModalOpen] = useState(false);
+  const [cancelModalOpen, setCancelModalOpen] = useState(false);
+  const [reactivateModalOpen, setReactivateModalOpen] = useState(false);
   const [currentRecord, setCurrentRecord] = useState<Subscription | null>(null);
 
   useEffect(() => {
@@ -51,16 +51,16 @@ export default function Recurrency({
   };
 
   const handlePauseModalClose = () => {
-    setpauseModalOpen(false);
+    setPauseModalOpen(false);
   };
   const handleCancelModalClose = () => {
-    setcancelModalOpen(false);
+    setCancelModalOpen(false);
   };
   const handleReactivateModalClose = () => {
-    setreactivateModalOpen(false);
+    setReactivateModalOpen(false);
   };
   const handleEditModalClose = () => {
-    seteditModalOpen(false);
+    setEditModalOpen(false);
   };
 
   return (
@@ -91,10 +91,10 @@ export default function Recurrency({
                     selectedRecord={selectedRecord}
                     record={record}
                     recurrencies={recurrencies}
-                    seteditDonation={seteditModalOpen}
-                    setpauseDonation={setpauseModalOpen}
-                    setcancelDonation={setcancelModalOpen}
-                    setreactivateDonation={setreactivateModalOpen}
+                    setEditDonation={setEditModalOpen}
+                    setPauseDonation={setPauseModalOpen}
+                    setCancelDonation={setCancelModalOpen}
+                    setReactivateDonation={setReactivateModalOpen}
                   />
                 );
               })
@@ -108,10 +108,10 @@ export default function Recurrency({
             selectedRecord={selectedRecord}
             record={recurrencies[selectedRecord]}
             recurrencies={recurrencies}
-            seteditDonation={seteditModalOpen}
-            setpauseDonation={setpauseModalOpen}
-            setcancelDonation={setcancelModalOpen}
-            setreactivateDonation={setreactivateModalOpen}
+            setEditDonation={setEditModalOpen}
+            setPauseDonation={setPauseModalOpen}
+            setCancelDonation={setCancelModalOpen}
+            setReactivateDonation={setReactivateModalOpen}
           />
         )}
       </div>

--- a/src/features/user/Account/components/RecurrencyRecord.tsx
+++ b/src/features/user/Account/components/RecurrencyRecord.tsx
@@ -229,26 +229,26 @@ interface CommonProps {
   selectedRecord: number | null;
   record: Subscription;
   recurrencies: Subscription[];
-  seteditDonation: Dispatch<SetStateAction<boolean>>;
-  setpauseDonation: Dispatch<SetStateAction<boolean>>;
-  setcancelDonation: Dispatch<SetStateAction<boolean>>;
-  setreactivateDonation: Dispatch<SetStateAction<boolean>>;
+  setEditDonation: Dispatch<SetStateAction<boolean>>;
+  setPauseDonation: Dispatch<SetStateAction<boolean>>;
+  setCancelDonation: Dispatch<SetStateAction<boolean>>;
+  setReactivateDonation: Dispatch<SetStateAction<boolean>>;
 }
 
 interface ManageDonationProps {
   record: Subscription;
-  seteditDonation: Dispatch<SetStateAction<boolean>>;
-  setpauseDonation: Dispatch<SetStateAction<boolean>>;
-  setcancelDonation: Dispatch<SetStateAction<boolean>>;
-  setreactivateDonation: Dispatch<SetStateAction<boolean>>;
+  setEditDonation: Dispatch<SetStateAction<boolean>>;
+  setPauseDonation: Dispatch<SetStateAction<boolean>>;
+  setCancelDonation: Dispatch<SetStateAction<boolean>>;
+  setReactivateDonation: Dispatch<SetStateAction<boolean>>;
 }
 
 export function ManageDonation({
   record,
-  seteditDonation,
-  setpauseDonation,
-  setcancelDonation,
-  setreactivateDonation,
+  setEditDonation,
+  setPauseDonation,
+  setCancelDonation,
+  setReactivateDonation,
 }: ManageDonationProps): ReactElement {
   const t = useTranslations('Me');
 
@@ -278,7 +278,7 @@ export function ManageDonation({
         <button
           className={styles.options}
           style={{ color: themeProperties.designSystem.colors.primaryColor }}
-          onClick={(e) => openModal(e, seteditDonation)}
+          onClick={(e) => openModal(e, setEditDonation)}
         >
           {t('editDonation')}
         </button>
@@ -289,7 +289,7 @@ export function ManageDonation({
         <button
           className={styles.options}
           style={{ color: themeProperties.designSystem.colors.warmBlue }}
-          onClick={(e) => openModal(e, setreactivateDonation)}
+          onClick={(e) => openModal(e, setReactivateDonation)}
         >
           {record?.status === 'paused'
             ? t('resumeDonation')
@@ -302,7 +302,7 @@ export function ManageDonation({
         <button
           className={styles.options}
           style={{ color: themeProperties.designSystem.colors.sunriseOrange }}
-          onClick={(e) => openModal(e, setpauseDonation)}
+          onClick={(e) => openModal(e, setPauseDonation)}
         >
           {t('pauseDonation')}
         </button>
@@ -313,7 +313,7 @@ export function ManageDonation({
         <button
           className={styles.options}
           style={{ color: themeProperties.designSystem.colors.fireRed }}
-          onClick={(e) => openModal(e, setcancelDonation)}
+          onClick={(e) => openModal(e, setCancelDonation)}
         >
           {t('cancelDonation')}
         </button>
@@ -342,10 +342,10 @@ export default function RecurrencyRecord({
   handleRecordToggle,
   selectedRecord,
   record,
-  seteditDonation,
-  setpauseDonation,
-  setcancelDonation,
-  setreactivateDonation,
+  setEditDonation,
+  setPauseDonation,
+  setCancelDonation,
+  setReactivateDonation,
 }: Props): ReactElement {
   const outerDivClasses = isModal
     ? styles.recordModal
@@ -383,10 +383,10 @@ export default function RecurrencyRecord({
             {record.status !== 'incomplete' && (
               <ManageDonation
                 record={record}
-                seteditDonation={seteditDonation}
-                setpauseDonation={setpauseDonation}
-                setcancelDonation={setcancelDonation}
-                setreactivateDonation={setreactivateDonation}
+                setEditDonation={setEditDonation}
+                setPauseDonation={setPauseDonation}
+                setCancelDonation={setCancelDonation}
+                setReactivateDonation={setReactivateDonation}
               />
             )}
           </div>


### PR DESCRIPTION
This PR standardizes the casing and naming convention of modal state setter functions across the Recurrency components.

