### PR TITLE
refactor: replace hardcoded colors with design system colors

### DIFF
--- a/src/features/projectsV2/ProjectsMap/FirePopup/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/FirePopup/index.tsx
@@ -13,6 +13,7 @@ import FireIcon from '../../../../../public/assets/images/icons/FireIcon';
 import FirePopupIcon from '../../../../../public/assets/images/icons/FirePopupIcon';
 import styles from './FirePopup.module.scss';
 import { getDeviceType } from '../../../../utils/projectV2';
+import themeProperties from '../../../../theme/themeProperties';
 
 interface Props {
   isOpen: boolean;
@@ -23,6 +24,7 @@ type ConfidencesType =
   | 'mediumAlertConfidenceText'
   | 'lowAlertConfidenceText';
 
+const { colors } = themeProperties.designSystem;
 function popperModifiers(options: {
   arrowRef: SetStateAction<HTMLElement | null>;
   clippingBoundary: HTMLElement | null;
@@ -158,7 +160,7 @@ export default function FirePopup({ isOpen, feature }: Props) {
                 : tProjectDetails('daysAgo', {
                     age: alertAge.amount,
                   })}
-              <InfoIconPopup width={9} height={9} color={'#828282'}>
+              <InfoIconPopup width={9} height={9} color={colors.softText2}>
                 <div className={styles.infoIconPopupContainer}>
                   {tProjectDetails('firePopupText')}
                 </div>
@@ -183,7 +185,7 @@ export default function FirePopup({ isOpen, feature }: Props) {
                   important: (chunks) => <span>{chunks}</span>,
                 })}
               </p>
-              <RightArrowIcon width={5} color={'#4F4F4F'} />
+              <RightArrowIcon width={5} color={colors.softText} />
             </a>
           </div>
         </aside>

--- a/src/features/projectsV2/ProjectsMap/SiteMapLayerControls/SiteLayerOptions.tsx
+++ b/src/features/projectsV2/ProjectsMap/SiteMapLayerControls/SiteLayerOptions.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react';
 import styles from './SiteMapLayerControls.module.scss';
 import BiomassChangeIcon from '../../../../../public/assets/images/icons/projectV2/BiomassChangeIcon';
 import TreeCoverIcon from '../../../../../public/assets/images/icons/projectV2/TreeCoverIcon';
+import themeProperties from '../../../../theme/themeProperties';
 
 export type LayerKey = 'biomass' | 'tree-cover';
 
@@ -29,6 +30,9 @@ export type LayerOption = {
   legend: LegendData;
 };
 
+const { forestGreen, white, hintText, warmRed, primaryColor } =
+  themeProperties.designSystem.colors;
+
 export const availableLayerOptions: LayerOption[] = [
   {
     id: 'biomass',
@@ -40,8 +44,7 @@ export const availableLayerOptions: LayerOption[] = [
       max: 20,
       average: 18,
       unit: 'tons',
-      gradient:
-        'linear-gradient(270deg, #219653 0%, #FFF 49.48%, #BDBDBD 75.52%, #E86F56 100%)',
+      gradient: `linear-gradient(270deg, ${forestGreen} 0%, ${white} 49.48%, ${hintText} 75.52%, ${warmRed} 100%)`,
     },
   },
   {
@@ -50,7 +53,7 @@ export const availableLayerOptions: LayerOption[] = [
     icon: <TreeCoverIcon />,
     legend: {
       type: 'percent',
-      gradient: 'linear-gradient(270deg, #007A49 0%, #FFF 100%)',
+      gradient: `linear-gradient(270deg, ${primaryColor} 0%, ${white} 100%)`,
     },
   },
 ];

--- a/src/features/projectsV2/ProjectsMap/TimeTravel/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/TimeTravel/index.tsx
@@ -23,6 +23,7 @@ import { useProjectsMap } from '../../ProjectsMapContext';
 import { ErrorHandlingContext } from '../../../common/Layout/ErrorHandlingContext';
 import TimeTravelDropdown from '../../TimeTravelDropdown';
 import styles from './TimeTravel.module.scss';
+import themeProperties from '../../../../theme/themeProperties';
 
 const EMPTY_STYLE = {
   version: 8 as const,
@@ -339,7 +340,7 @@ export default function TimeTravel({
         source: polygonSourceId,
         layout: {},
         paint: {
-          'line-color': '#fff',
+          'line-color': themeProperties.designSystem.colors.white,
           'line-width': 4,
         },
       });

--- a/src/features/projectsV2/ProjectsMap/stories/SingleMapTab.stories.tsx
+++ b/src/features/projectsV2/ProjectsMap/stories/SingleMapTab.stories.tsx
@@ -1,7 +1,10 @@
-import SatelliteIcon from '../../../../../public/assets/images/icons/SatelliteIcon';
 import type { Meta, StoryObj } from '@storybook/react';
-import SingleTab from '../ProjectMapTabs/SingleTab';
 
+import SatelliteIcon from '../../../../../public/assets/images/icons/SatelliteIcon';
+import SingleTab from '../ProjectMapTabs/SingleTab';
+import themeProperties from '../../../../theme/themeProperties';
+
+const { colors } = themeProperties.designSystem;
 const meta: Meta<typeof SingleTab> = {
   title: 'Projects/Details/SingleTab',
   component: SingleTab,
@@ -12,7 +15,7 @@ type Story = StoryObj<typeof SingleTab>;
 
 export const Selected: Story = {
   args: {
-    icon: <SatelliteIcon color={'#fff'} />,
+    icon: <SatelliteIcon color={colors.white} />,
     title: 'Time Travel',
     isSelected: true,
     onClickHandler: () => {},
@@ -21,7 +24,7 @@ export const Selected: Story = {
 
 export const Unselected: Story = {
   args: {
-    icon: <SatelliteIcon color={'#000'} />,
+    icon: <SatelliteIcon color={colors.coreText} />,
     title: 'Time Travel',
     isSelected: false,
     onClickHandler: () => {},

--- a/src/features/projectsV2/ProjectsMap/stories/SiteMapLayerControls.stories.tsx
+++ b/src/features/projectsV2/ProjectsMap/stories/SiteMapLayerControls.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import SiteMapLayerControls from '../SiteMapLayerControls';
+import themeProperties from '../../../../theme/themeProperties';
 
 const meta: Meta<typeof SiteMapLayerControls> = {
   title: 'Projects/Details/SiteMapLayerControls',
@@ -11,7 +12,7 @@ const meta: Meta<typeof SiteMapLayerControls> = {
     (Story) => (
       <div
         style={{
-          backgroundColor: 'green',
+          backgroundColor: themeProperties.designSystem.colors.leafGreen,
           height: '550px',
           position: 'relative',
         }}


### PR DESCRIPTION
- Removed hardcoded color values from the projectV2.
- Replaced them with corresponding design system color tokens for consistency.