### PR TITLE
Update ProjectSiteDropdown to handle single site display

### DIFF
--- a/src/features/projectsV2/ProjectsMap/MapControls.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapControls.tsx
@@ -74,7 +74,7 @@ const MapControls = ({
 
   const hasProjectSites =
     singleProject?.sites?.length !== undefined &&
-    singleProject?.sites?.length > 1;
+    singleProject?.sites?.length > 0;
   const canShowSatelliteToggle =
     !(
       isMobile &&

--- a/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/SiteDropdown.module.scss
+++ b/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/SiteDropdown.module.scss
@@ -3,7 +3,8 @@
 $layoutPaddingTop: 24px;
 $layoutPaddingSide: 20px;
 
-.dropdownButton {
+.dropdownButton,
+.dropdownDetails {
   display: flex;
   border-radius: 12px;
   background: $dsWhite;
@@ -11,13 +12,19 @@ $layoutPaddingSide: 20px;
   padding: 12px 0px 9px 12px;
   min-width: 350px;
   justify-content: space-between;
-  cursor: pointer;
   gap: 18px;
   position: absolute;
   z-index: 40;
   top: calc($layoutPaddingTop + 10px);
   right: calc($layoutPaddingSide + 10px);
 }
+.dropdownButton {
+  cursor: pointer;
+}
+.dropdownDetails {
+  cursor: default;
+}
+
 .siteIconAndTextContainer {
   display: flex;
   gap: 6px;

--- a/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/index.tsx
@@ -71,6 +71,10 @@ const ProjectSiteDropdown = ({
       };
     });
   }, [projectSites]);
+  const hasMultipleSites = useMemo(
+    () => siteList.length > 1,
+    [siteList.length]
+  );
 
   const getId = useCallback(
     (selectedSiteId: number) => {
@@ -90,6 +94,7 @@ const ProjectSiteDropdown = ({
   }, [activeDropdown]);
 
   const toggleSiteMenu = () => {
+    if (!hasMultipleSites) return;
     if (activeDropdown !== 'site') {
       setActiveDropdown('site');
       setIsMenuOpen(true);
@@ -97,9 +102,15 @@ const ProjectSiteDropdown = ({
       setIsMenuOpen((prev) => !prev);
     }
   };
+
   return (
     <>
-      <div className={styles.dropdownButton} onClick={toggleSiteMenu}>
+      <div
+        className={`${
+          hasMultipleSites ? styles.dropdownButton : styles.dropdownDetails
+        }`}
+        onClick={hasMultipleSites ? toggleSiteMenu : undefined}
+      >
         <div className={styles.siteIconAndTextContainer}>
           <SiteIcon
             width={27}
@@ -136,15 +147,17 @@ const ProjectSiteDropdown = ({
             </>
           )}
         </div>
-        <div className={styles.menuArrow}>
-          {isMenuOpen ? (
-            <DropdownUpArrow width={10} />
-          ) : (
-            <DropdownDownArrow width={10} />
-          )}
-        </div>
+        {hasMultipleSites && (
+          <div className={styles.menuArrow}>
+            {isMenuOpen ? (
+              <DropdownUpArrow width={10} />
+            ) : (
+              <DropdownDownArrow width={10} />
+            )}
+          </div>
+        )}
       </div>
-      {isMenuOpen && (
+      {isMenuOpen && hasMultipleSites && (
         <ProjectSiteList
           siteList={siteList}
           setSelectedSite={setSelectedSite}


### PR DESCRIPTION
Enhance the ProjectSiteDropdown component to show details for a single site while removing interactivity when only one site is present. Adjustments ensure proper rendering and user experience based on the number of sites available.