### PR TITLE
Clear PlanetCashContext on user change

### DIFF
--- a/src/features/common/Layout/PlanetCashContext.tsx
+++ b/src/features/common/Layout/PlanetCashContext.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react';
 import type { PlanetCashAccount } from '../types/planetcash';
 
-import { createContext, useState, useContext } from 'react';
+import { createContext, useState, useContext, useEffect } from 'react';
+import { useUserProps } from './UserPropsContext';
 
 interface PlanetCashContextInterface {
   accounts: PlanetCashAccount[] | null;
@@ -14,8 +15,14 @@ export const PlanetCashContext =
   createContext<PlanetCashContextInterface | null>(null);
 
 export const PlanetCashProvider = ({ children }: { children: ReactNode }) => {
+  const { user } = useUserProps();
   const [accounts, setAccounts] = useState<PlanetCashAccount[] | null>(null);
   const [isPlanetCashActive, setIsPlanetCashActive] = useState<boolean>(false);
+
+  useEffect(() => {
+    setAccounts(null);
+    setIsPlanetCashActive(false);
+  }, [user?.id]);
 
   return (
     <PlanetCashContext.Provider


### PR DESCRIPTION
Ensure the availability of correct Planet Cash accounts when a user changes, particularly during impersonation or exiting impersonation. This update resets the context state accordingly.