### PR TITLE
Fix visibility issue for sectionOneLandscape on xsPhoneView

### DIFF
--- a/src/features/user/Profile/MyContributions/MyContributions.module.scss
+++ b/src/features/user/Profile/MyContributions/MyContributions.module.scss
@@ -373,10 +373,6 @@
   }
 
   .sectionOneLandscape {
-    @include xsPhoneView {
-      display: none;
-    }
-
     display: flex;
     gap: 16px;
 
@@ -393,6 +389,10 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
+    }
+
+    @include xsPhoneView {
+      display: none;
     }
   }
 


### PR DESCRIPTION
Adjust the CSS order to ensure the xsPhoneView rules for `.sectionOneLandscape` are correctly applied and the section is hidden on mobile devices

Before: both `sectionOneLandscape` and `sectionOneMobile` were visible on mobile devices
<img width="519" height="612" alt="Screenshot 2025-10-02 at 4 08 00 PM" src="https://github.com/user-attachments/assets/3724a6aa-72a3-4fff-8c81-b6ddff348596" />

After: only `sectionOneMobile` is visible on mobile devices
<img width="516" height="404" alt="Screenshot 2025-10-02 at 4 08 41 PM" src="https://github.com/user-attachments/assets/309f0ec2-1e17-4fed-8890-f336bf5cc3b4" />

Issue cause:

Updating sass library - introduced in #2486 
