### PR TITLE
fix: reset textfield value after successful form submission

### DIFF
--- a/src/features/user/ManageProjects/components/ProjectSites.tsx
+++ b/src/features/user/ManageProjects/components/ProjectSites.tsx
@@ -265,6 +265,7 @@ export default function ProjectSites({
     handleSubmit,
     formState: { errors },
     control,
+    reset,
   } = useForm<ProjectSitesFormData>();
   const { redirect, setErrors } = useContext(ErrorHandlingContext);
   const [isUploadingData, setIsUploadingData] = useState<boolean>(false);
@@ -359,6 +360,10 @@ export default function ProjectSites({
         };
         temp.push(_submitData);
         setSiteList(temp);
+        reset({
+          name: '',
+          status: '',
+        });
         setGeoJson(null);
         setIsUploadingData(false);
         setShowForm(false);


### PR DESCRIPTION
- Added form reset to clear name and status fields after a site is successfully uploaded.
- Ensures the form is ready for a new entry without retaining old values.
- Prevents confusion for users when adding multiple sites sequentially.