### PR TITLE
fix: add null checks in addMissingMonths to prevent undefined errors

### DIFF
--- a/src/features/user/TreeMapper/Analytics/components/TreePlanted/index.tsx
+++ b/src/features/user/TreeMapper/Analytics/components/TreePlanted/index.tsx
@@ -286,6 +286,8 @@ export const TreePlanted = () => {
   }
 
   function addMissingMonths(data: IMonthlyFrame[]) {
+    if (!data || data.length === 0) return [];
+
     const months = [
       'Jan',
       'Feb',
@@ -304,6 +306,11 @@ export const TreePlanted = () => {
     // Extract the first and last month and year from the data
     const firstData = data[0];
     const lastData = data[data.length - 1];
+
+    if (!firstData || !lastData || !firstData.month || !lastData.month) {
+      console.warn('Invalid monthly data structure received');
+      return [];
+    }
     const firstMonthIndex = months.indexOf(firstData.month);
     const lastMonthIndex = months.indexOf(lastData.month);
     const firstYear = firstData.year;


### PR DESCRIPTION
[Resolves](https://github.com/Plant-for-the-Planet-org/planet-webapp/pull/2725#issuecomment-3432854690)

### Issue
`TypeError: Cannot read properties of undefined (reading 'month')` in `addMissingMonths` function when processing empty or malformed data.

### Changes
- Added null/undefined checks before accessing `firstData.month` and `lastData.month`
- Return empty array for invalid data 
- Added warning logs for debugging

### Result
Component now handles invalid data gracefully by rendering an empty chart instead of crashing.