### PR TITLE
Improve unit count formatting in ProjectInfoSection

### DIFF
--- a/src/features/projectsV2/ProjectSnippet/microComponents/ProjectInfoSection.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/ProjectInfoSection.tsx
@@ -49,7 +49,11 @@ const ProjectInfoSection = (props: ProjectInfoProps) => {
     if (unitCount === undefined) {
       return;
     }
-    const formattedUnitCount = localizedAbbreviatedNumber(locale, unitCount, 1);
+    const formattedUnitCount =
+      unitCount < 1000000
+        ? localizedAbbreviatedNumber(locale, Math.floor(unitCount), 0)
+        : localizedAbbreviatedNumber(locale, unitCount, 1);
+
     if (unitType === 'tree' && purpose === 'trees') {
       return tAllProjects('treeDonated', {
         count: unitCount,


### PR DESCRIPTION
Enhance the formatting of unit counts in the ProjectInfoSection to remove decimal display for values below one million.

**Before:**
<img width="374" height="284" alt="Screenshot 2025-11-05 at 5 20 06 PM" src="https://github.com/user-attachments/assets/fd9c09e1-1b98-4247-921e-34da5292e537" />
<img width="369" height="283" alt="Screenshot 2025-11-05 at 5 20 14 PM" src="https://github.com/user-attachments/assets/858d948f-e9b4-43a7-8bea-32740540b837" />


**After:**
<img width="378" height="277" alt="Screenshot 2025-11-05 at 5 15 03 PM" src="https://github.com/user-attachments/assets/a11711b7-cdef-448f-96f1-d471ee6af790" />
<img width="376" height="287" alt="Screenshot 2025-11-05 at 5 14 40 PM" src="https://github.com/user-attachments/assets/239ccb4d-40d6-4537-aaca-009f2e6242ad" />
