### PR TITLE
Update @formatjs/intl-localematcher to version 0.8.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.1",
-        "@formatjs/intl-localematcher": "^0.7.3",
+        "@formatjs/intl-localematcher": "^0.8.5",
         "@mapbox/mapbox-gl-draw": "^1.5.1",
         "@mapbox/togeojson": "^0.16.1",
         "@maplibre/maplibre-gl-compare": "^0.5.0",
@@ -3066,23 +3066,19 @@
       }
     },
     "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.7.3.tgz",
-      "integrity": "sha512-NaeABectKdTCOnlH9VFGmMS3K0JuR7Soc2t5R2MCkBrM3H/hlKVYh0XSrcjjPkbjIdrF7L/Bzx9JtGuVaSfYlA==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.5.tgz",
+      "integrity": "sha512-TEW/NR367c3PcQ2AXfkNig9jC740+qbkM0LgKl7UCE7Xtv7C5Uk1mvlu86MjQZBmscUai8HSWjcEETpwaVvJ6A==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/fast-memoize": "3.0.1",
-        "tslib": "^2.8.0"
+        "@formatjs/fast-memoize": "3.1.3"
       }
     },
     "node_modules/@formatjs/intl-localematcher/node_modules/@formatjs/fast-memoize": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.0.1.tgz",
-      "integrity": "sha512-kzk635kEmsxrrEWQXY7uKRocFCVXR4es5OQqcqCGg2NPtQztG/OBkE9THHu6UOTxpfyIkZhh6DjPBZGRp7y3og==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.3.tgz",
+      "integrity": "sha512-Ocd1vPuD68rW6BJDuAOtnnc1GPeVepY5kZXML1psGVFQ+1Q8CfkftT3Tnam+Mxx97Pz08jIEDCotl/GV+Naccg==",
+      "license": "MIT"
     },
     "node_modules/@hookform/devtools": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@formatjs/intl-localematcher": "^0.7.3",
+    "@formatjs/intl-localematcher": "^0.8.5",
     "@mapbox/mapbox-gl-draw": "^1.5.1",
     "@mapbox/togeojson": "^0.16.1",
     "@maplibre/maplibre-gl-compare": "^0.5.0",


### PR DESCRIPTION


- Updated @formatjs/intl-localematcher to version 0.8.5
- Updated dependency @formatjs/fast-memoize to version 3.1.3

This replaces #2869 