### PR TITLE
Remove unused map dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
         "geocoder-arcgis": "^2.0.5",
         "geojson-validation": "^1.0.2",
         "jwt-decode": "^3.1.2",
-        "layer-manager": "^3.0.11",
         "luma.gl": "^7.3.2",
         "mapbox-gl": "^1.13.0",
         "mapbox-gl-compare": "^0.4.0",
@@ -83,7 +82,6 @@
         "superjson": "^1.12.3",
         "swiper": "^12.1.2",
         "uuid": "^14.0.0",
-        "vizzuality-components": "^3.0.3",
         "xlsx": "^0.18.5",
         "zod": "^3.25.76",
         "zustand": "^5.0.8"
@@ -10652,15 +10650,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/add-dom-event-listener": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/add-dom-event-listener/-/add-dom-event-listener-1.1.0.tgz",
-      "integrity": "sha512-WCxx1ixHT0GQU9hb0KI/mhgRQhnU+U3GvwY6ZvVjYq8rsihIGoaIOUbY0yMPBxLH5MDtr0kz3fisWGNcbWW7Jw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "4.x"
-      }
-    },
     "node_modules/adjust-sourcemap-loader": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
@@ -10987,18 +10976,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-move": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/array-move/-/array-move-2.2.2.tgz",
-      "integrity": "sha512-lKc6C+nsOSA1o7eHSP/HshlGDYUI7QKyaus5kPDm2zEEPQID9xlspnraLR8l+rDlqg9mGo8ziE7F8TEnF6D3Tw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -11317,43 +11294,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "deprecated": "Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "1.5.10"
-      }
-    },
-    "node_modules/axios/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "=3.1.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/axios/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
@@ -11819,6 +11759,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-js": "^2.4.0",
@@ -11830,6 +11771,7 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT"
     },
@@ -13161,20 +13103,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/component-classes": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/component-classes/-/component-classes-1.2.6.tgz",
-      "integrity": "sha512-hPFGULxdwugu1QWW3SvVOCUHLzO34+a2J6Wqy0c5ASQkfi9/8nZcBB0ZohaEbXOQlCflMAEMmEWk7u7BVs4koA==",
-      "license": "MIT",
-      "dependencies": {
-        "component-indexof": "0.0.3"
-      }
-    },
-    "node_modules/component-indexof": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz",
-      "integrity": "sha512-puDQKvx/64HZXb4hBwIcvQLaLgux8o1CbWl39s41hrIIZDl1lJiD5jc22gj3RBeGK0ovxALDYpIbyjqDUUl0rw=="
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -13514,16 +13442,6 @@
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
-    },
-    "node_modules/css-animation": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/css-animation/-/css-animation-1.6.1.tgz",
-      "integrity": "sha512-/48+/BaEaHRY6kNQ2OIPzKf9A6g8WjZYjhiNDNuIVbsm5tXCGIAsHDjB4Xu1C4vXJtUWZo26O68OQkDpNBaPog==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "6.x",
-        "component-classes": "^1.2.5"
-      }
     },
     "node_modules/css-loader": {
       "version": "6.11.0",
@@ -14589,12 +14507,6 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/dom-align": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.4.tgz",
-      "integrity": "sha512-R8LUSEay/68zE5c8/3BDxiTEvgb4xZTF0RKmAHfiEVN3klfIpXfi2/QCoiWPccVQ0J/ZGdz9OjzL4uJEP/MRAw==",
       "license": "MIT"
     },
     "node_modules/dom-converter": {
@@ -18259,6 +18171,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
@@ -18494,29 +18407,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/is-bun-module": {
@@ -19417,36 +19307,6 @@
       },
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/layer-manager": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/layer-manager/-/layer-manager-3.0.11.tgz",
-      "integrity": "sha512-e6PVUjG27+d1F4b8vqxHaJMVf8dc3v0ToXQE4cdu97KLw6zI1Z1SFlQR3qVnBU+2iOpUDST+INDcNj/aTO++Aw==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^0.19.0",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.7.2",
-        "supercluster": "^4.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.3.2"
-      }
-    },
-    "node_modules/layer-manager/node_modules/kdbush": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-2.0.1.tgz",
-      "integrity": "sha512-9KqSdmWCkBIisFIGclT0FRagKhI7IVbMyUjsxCFG0Ly1Dg6whlxJ7b9lrq8ifk3X/fGeJzok1R75LQfZTfA5zQ==",
-      "license": "ISC"
-    },
-    "node_modules/layer-manager/node_modules/supercluster": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-4.1.1.tgz",
-      "integrity": "sha512-sF0FfUOPFp96DKzwWFLeQOEqqKu2PpcesxAFeFsknA/q7g7igVVn/p3NI2XHEghNSyDAqunKNKqAbqNO8+7NDQ==",
-      "license": "ISC",
-      "dependencies": {
-        "kdbush": "^2.0.1"
       }
     },
     "node_modules/less": {
@@ -20609,15 +20469,6 @@
       "dependencies": {
         "fast-equals": "^3.0.1",
         "micro-memoize": "^4.1.2"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/mri": {
@@ -21847,6 +21698,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -22856,15 +22708,6 @@
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "license": "MIT",
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -22939,93 +22782,6 @@
       "bin": {
         "rc": "cli.js"
       }
-    },
-    "node_modules/rc-align": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-2.4.5.tgz",
-      "integrity": "sha512-nv9wYUYdfyfK+qskThf4BQUSIadeI/dCsfaMZfNEoxm9HwOIioQ+LyqmMK6jWHAZQgOzMLaqawhuBXlF63vgjw==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.26.0",
-        "dom-align": "^1.7.0",
-        "prop-types": "^15.5.8",
-        "rc-util": "^4.0.4"
-      }
-    },
-    "node_modules/rc-animate": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.11.1.tgz",
-      "integrity": "sha512-1NyuCGFJG/0Y+9RKh5y/i/AalUCA51opyyS/jO2seELpgymZm2u9QV3xwODwEuzkmeQ1BDPxMLmYLcTJedPlkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.6",
-        "css-animation": "^1.3.2",
-        "prop-types": "15.x",
-        "raf": "^3.4.0",
-        "rc-util": "^4.15.3",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "node_modules/rc-slider": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-8.7.1.tgz",
-      "integrity": "sha512-WMT5mRFUEcrLWwTxsyS8jYmlaMsTVCZIGENLikHsNv+tE8ThU2lCoPfi/xFNUfJFNFSBFP3MwPez9ZsJmNp13g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.5",
-        "prop-types": "^15.5.4",
-        "rc-tooltip": "^3.7.0",
-        "rc-util": "^4.0.4",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "warning": "^4.0.3"
-      }
-    },
-    "node_modules/rc-tooltip": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-3.7.0.tgz",
-      "integrity": "sha512-xEoUMatXp8OEL61UFH0+NrC39nkKzpOBhLrJCnnRpDRduU8L3DOhF6CNlIMkvg68hxlGGdquFtFw2t+1xNLX5A==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "6.x",
-        "prop-types": "^15.5.8",
-        "rc-trigger": "^2.2.2"
-      }
-    },
-    "node_modules/rc-trigger": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.6.5.tgz",
-      "integrity": "sha512-m6Cts9hLeZWsTvWnuMm7oElhf+03GOjOLfTuU0QmdB9ZrW7jR2IpI5rpNM7i9MvAAlMAmTx5Zr7g3uu/aMvZAw==",
-      "dependencies": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.6",
-        "prop-types": "15.x",
-        "rc-align": "^2.4.0",
-        "rc-animate": "2.x",
-        "rc-util": "^4.4.0",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "node_modules/rc-util": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.21.1.tgz",
-      "integrity": "sha512-Z+vlkSQVc1l8O2UjR3WQ+XdWlhj5q9BMQNLk2iOBch75CqPfrJyGtcWMcnhRlNuDu0Ndtt4kLVO8JI8BrABobg==",
-      "license": "MIT",
-      "dependencies": {
-        "add-dom-event-listener": "^1.1.0",
-        "prop-types": "^15.5.10",
-        "react-is": "^16.12.0",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0"
-      }
-    },
-    "node_modules/rc-util/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/rc/node_modules/ini": {
       "version": "1.3.8",
@@ -23180,12 +22936,6 @@
         "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
-    },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "license": "MIT"
     },
     "node_modules/react-loading-skeleton": {
       "version": "3.5.0",
@@ -23345,22 +23095,6 @@
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/react-sortable-hoc": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
-      "integrity": "sha512-v1CDCvdfoR3zLGNp6qsBa4J1BWMEVH25+UKxF/RvQRh+mrB+emqtVHMgZ+WreUiKJoEaiwYoScaueIKhMVBHUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.2.0",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.5.7"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.5.7",
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-        "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/react-transition-group": {
@@ -23539,6 +23273,7 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/regex-parser": {
@@ -24436,12 +24171,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.33.5",
@@ -27139,98 +26868,6 @@
         "gl-matrix": "^3.0.0"
       }
     },
-    "node_modules/vizzuality-components": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/vizzuality-components/-/vizzuality-components-3.0.3.tgz",
-      "integrity": "sha512-0Ee1p9nnX8MpH4GXpbkMba7RUZ7bs1C+B7yvipUf2a1WiyhmjHzEipBjphdRmirA6+ShFxIyR5017F0zwYm2WA==",
-      "license": "MIT",
-      "dependencies": {
-        "array-move": "^2.1.0",
-        "axios": "^0.19.0",
-        "classnames": "^2.2.6",
-        "layer-manager": "^1.10.0",
-        "lodash": "^4.17.10",
-        "moment": "^2.22.2",
-        "prop-types": "^15.6.2",
-        "rc-slider": "^8.6.3",
-        "rc-tooltip": "3.7.0",
-        "react-sortable-hoc": "^1.9.1",
-        "wri-json-api-serializer": "^1.0.1"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0",
-        "react-dom": "^16.0.0"
-      }
-    },
-    "node_modules/vizzuality-components/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/vizzuality-components/node_modules/follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "=3.1.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/vizzuality-components/node_modules/kdbush": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-2.0.1.tgz",
-      "integrity": "sha512-9KqSdmWCkBIisFIGclT0FRagKhI7IVbMyUjsxCFG0Ly1Dg6whlxJ7b9lrq8ifk3X/fGeJzok1R75LQfZTfA5zQ==",
-      "license": "ISC"
-    },
-    "node_modules/vizzuality-components/node_modules/layer-manager": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/layer-manager/-/layer-manager-1.16.0.tgz",
-      "integrity": "sha512-W3aduKBzOzZau1G31WEqcN60/tMb0XNJz35nMgPMoa0Vf1PCXUsi0WFo2hU0LMajnZ1tOIyV5wxYpuKdqVktaw==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^0.18.0",
-        "lodash": "^4.17.11",
-        "prop-types": "^15.6.2",
-        "supercluster": "^4.1.1",
-        "wri-json-api-serializer": "^1.0.1"
-      },
-      "peerDependencies": {
-        "react": "^16.3.2"
-      }
-    },
-    "node_modules/vizzuality-components/node_modules/layer-manager/node_modules/axios": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
-      "deprecated": "Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
-      }
-    },
-    "node_modules/vizzuality-components/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/vizzuality-components/node_modules/supercluster": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-4.1.1.tgz",
-      "integrity": "sha512-sF0FfUOPFp96DKzwWFLeQOEqqKu2PpcesxAFeFsknA/q7g7igVVn/p3NI2XHEghNSyDAqunKNKqAbqNO8+7NDQ==",
-      "license": "ISC",
-      "dependencies": {
-        "kdbush": "^2.0.1"
-      }
-    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -27263,15 +26900,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {
@@ -27637,12 +27265,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/wri-json-api-serializer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wri-json-api-serializer/-/wri-json-api-serializer-1.0.1.tgz",
-      "integrity": "sha512-yhu69MyIeKtKKztIzxwWQ87OLWsZ+oz8/vtMs2etPu2GZr2ZrT2S6YDiI4CjAtS9gs3iwQqygnbw6WdGXWmpPw==",
-      "license": "MIT"
     },
     "node_modules/ws": {
       "version": "8.21.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "geocoder-arcgis": "^2.0.5",
     "geojson-validation": "^1.0.2",
     "jwt-decode": "^3.1.2",
-    "layer-manager": "^3.0.11",
     "luma.gl": "^7.3.2",
     "mapbox-gl": "^1.13.0",
     "mapbox-gl-compare": "^0.4.0",
@@ -120,7 +119,6 @@
     "superjson": "^1.12.3",
     "swiper": "^12.1.2",
     "uuid": "^14.0.0",
-    "vizzuality-components": "^3.0.3",
     "xlsx": "^0.18.5",
     "zod": "^3.25.76",
     "zustand": "^5.0.8"

--- a/src/theme/global.scss
+++ b/src/theme/global.scss
@@ -1,5 +1,4 @@
 @import './theme';
-@import '~vizzuality-components/dist/bundle';
 
 .mapboxgl-ctrl-bottom-left .mapboxgl-ctrl {
   padding-left: 20px;
@@ -440,15 +439,6 @@ button {
   margin-left: 6px;
   max-width: 320px;
   margin-bottom: -18px;
-}
-
-.vizzuality__legend-item-container {
-  background-color: $backgroundColor;
-}
-
-// cspell:ignore vizzuality__c-timestep
-.vizzuality__c-timestep .vizzuality__player-btn > svg {
-  fill: $primaryFontColor;
 }
 
 // .MuiSvgIcon-root {


### PR DESCRIPTION
Clean up the project by removing unused map-related dependencies from `package.json` and `global.scss`. This helps streamline the codebase and reduce unnecessary bloat. 

## Changes in this pull request:

- Removed `layer-manager` from `package.json`.
- Removed `vizzuality-components` from `package.json`.
- Removed unused imports and styles related to `vizzuality` in `global.scss`.


