### PR TITLE
fix(auth): route email_not_verified denials to verify-email

### DIFF
--- a/pages/sites/[slug]/[locale]/login.tsx
+++ b/pages/sites/[slug]/[locale]/login.tsx
@@ -58,10 +58,13 @@ export default function Login(): ReactElement {
       } else if (
         user === null &&
         (isAuthenticated ||
+          // TODO: Remove '401' case after July 31, 2026. Confirm whether safe to remove before then.
           auth0Error?.message === '401' ||
           auth0Error?.message === 'email_not_verified')
       ) {
-        // wait for context to redirect to complete signup / verify email
+        // Wait for
+        // Navbar to handle redirect to /verify-email OR
+        // UserPropsContext to handle redirect to /complete-signup (via 303)
       } else {
         loginWithRedirect({
           redirectUri: `${window.location.origin}/login`,

--- a/pages/sites/[slug]/[locale]/login.tsx
+++ b/pages/sites/[slug]/[locale]/login.tsx
@@ -57,9 +57,11 @@ export default function Login(): ReactElement {
         loadFunction();
       } else if (
         user === null &&
-        (isAuthenticated || auth0Error?.message === '401')
+        (isAuthenticated ||
+          auth0Error?.message === '401' ||
+          auth0Error?.message === 'email_not_verified')
       ) {
-        // wait for context to redirect to complete signup
+        // wait for context to redirect to complete signup / verify email
       } else {
         loginWithRedirect({
           redirectUri: `${window.location.origin}/login`,

--- a/src/features/common/Layout/Navbar/index.tsx
+++ b/src/features/common/Layout/Navbar/index.tsx
@@ -39,7 +39,7 @@ export default function Navbar() {
   if (auth0Error) {
     const { message } = auth0Error;
 
-    if (message === '401') {
+    if (message === '401' || message === 'email_not_verified') {
       if (typeof window !== 'undefined') {
         setUser(null);
         logoutUser(`${window.location.origin}/verify-email`);

--- a/src/features/common/Layout/Navbar/index.tsx
+++ b/src/features/common/Layout/Navbar/index.tsx
@@ -39,6 +39,7 @@ export default function Navbar() {
   if (auth0Error) {
     const { message } = auth0Error;
 
+    // TODO: Remove '401' case after July 31, 2026. Confirm whether safe to remove before then.
     if (message === '401' || message === 'email_not_verified') {
       if (typeof window !== 'undefined') {
         setUser(null);


### PR DESCRIPTION
The Auth0 PostLogin Action now denies unverified logins with 'email_not_verified' instead of '401'. Match the new message so the verify-email routing (Navbar) and the login wait-state still trigger, instead of falling through to a generic alert and logout loop.
