### PR TITLE
feat(seo): noindex entire app across all environments

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -136,6 +136,14 @@ const nextConfig = {
     // !! WARN !!
     ignoreBuildErrors: true,
   },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [{ key: 'X-Robots-Tag', value: 'noindex, nofollow' }],
+      },
+    ];
+  },
   async redirects() {
     return [
       {

--- a/src/features/common/Layout/Header/index.tsx
+++ b/src/features/common/Layout/Header/index.tsx
@@ -11,6 +11,7 @@ export default function Header() {
   return (
     <>
       <Head>
+        <meta name="robots" content="noindex, nofollow" />
         {tenantConfig.config.manifest && (
           <link rel="manifest" href={tenantConfig.config.manifest} />
         )}


### PR DESCRIPTION
## What

Disables search engine indexing for the whole app, in every environment, via two layers:

- `X-Robots-Tag: noindex, nofollow` HTTP header on all routes (`next.config.js` `headers()`)
- `<meta name="robots" content="noindex, nofollow">` in the shared Header component

`public/robots.txt` is intentionally left permissive so crawlers can still fetch pages and read the noindex directive.

## Why

The app serves the same page structure across 16+ tenant domains, producing duplicate and partially-duplicate content that hurts SEO. For now we disable indexing everywhere while the team decides whether to instead pursue a canonical or hreflang strategy.

## Why two layers

The HTTP header is the primary mechanism: it covers every response type (HTML, API, static, `_next` assets) regardless of the middleware matcher, which excludes some of those paths. The meta tag is a backup for HTML crawlers and renders on every page through the global Layout. Both set the same `noindex, nofollow` value, so there is no conflict.

## Out of scope

Canonical (`<link rel="canonical">`) and hreflang tags are deferred to a separate team decision.

## Verification

- [x]  `curl -I` on a page route returns `X-Robots-Tag: noindex, nofollow`
- [x]  View Source shows `<meta name="robots" content="noindex, nofollow">`
- [x]  `npm run build` succeeds with the new `headers()` config
