### PR TITLE
Revert "feat: noindex entire app across all environments"

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -136,14 +136,6 @@ const nextConfig = {
     // !! WARN !!
     ignoreBuildErrors: true,
   },
-  async headers() {
-    return [
-      {
-        source: '/:path*',
-        headers: [{ key: 'X-Robots-Tag', value: 'noindex, nofollow' }],
-      },
-    ];
-  },
   async redirects() {
     return [
       {

--- a/src/features/common/Layout/Header/index.tsx
+++ b/src/features/common/Layout/Header/index.tsx
@@ -11,7 +11,6 @@ export default function Header() {
   return (
     <>
       <Head>
-        <meta name="robots" content="noindex, nofollow" />
         {tenantConfig.config.manifest && (
           <link rel="manifest" href={tenantConfig.config.manifest} />
         )}


### PR DESCRIPTION
Restores the previous configuration by removing the noindex directives from the application headers and meta tags. This change re-enables indexing for the app across all environments. 