### PR TITLE
Hotfix/a11y 004 image alt text

### DIFF
--- a/src/features/common/Layout/Navbar/microComponents/SecondaryLogo.tsx
+++ b/src/features/common/Layout/Navbar/microComponents/SecondaryLogo.tsx
@@ -20,6 +20,7 @@ const SecondaryLogo = ({ isMobile }: { isMobile: boolean }) => {
           <a href={tenantConfig.config?.header?.tenantLogoLink}>
             <img
               src={tenantConfig.config?.header?.tenantLogoURL}
+              alt={tenantConfig.name}
               className={clsx(styles.tenantLogo, {
                 [styles.wideLogo]: hasWideLogo,
               })}

--- a/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
@@ -136,7 +136,7 @@ const ImageSection = (props: ImageSectionProps) => {
       {/* Loading state */}
       {isImageLoading && (
         <img
-          alt="loading"
+          alt=""
           src="/assets/images/project-contribution-default-landscape.png"
           className={styles.projectImageFile}
         />
@@ -145,7 +145,7 @@ const ImageSection = (props: ImageSectionProps) => {
       {/* Main image */}
       {image && typeof image !== 'undefined' && (
         <img
-          alt={'projectImage'}
+          alt={projectName}
           src={imageSource}
           loading="lazy"
           decoding="async"
@@ -160,7 +160,7 @@ const ImageSection = (props: ImageSectionProps) => {
       {/* Error/fallback state */}
       {(hasError || !image) && (
         <img
-          alt="fallback"
+          alt=""
           src="/assets/images/project-contribution-default-landscape.png"
           className={styles.projectImageFile}
         />

--- a/src/features/user/ManageProjects/components/ProjectMedia.tsx
+++ b/src/features/user/ManageProjects/components/ProjectMedia.tsx
@@ -299,7 +299,10 @@ export default function ProjectMedia({
               {uploadedImages.map((image, index) => {
                 return (
                   <div className={styles.uploadedImageContainer} key={index}>
-                    <img src={getImageUrl('project', 'medium', image.image)} />
+                    <img
+                      src={getImageUrl('project', 'medium', image.image)}
+                      alt={image.description || projectDetails?.name || ''}
+                    />
                     <div className={styles.uploadedImageOverlay}></div>
 
                     <input

--- a/src/features/user/Profile/ContributionsMap/Popup/PopupImageSection.tsx
+++ b/src/features/user/Profile/ContributionsMap/Popup/PopupImageSection.tsx
@@ -23,7 +23,7 @@ const PopupImageSection = ({
   return (
     <div className={styles.imageContainer}>
       <img
-        alt="projectImage"
+        alt={name}
         src={getImageUrl('project', 'medium', image)}
         width={'fit-content'}
         className={styles.popupProjectImage}

--- a/src/features/user/Settings/EditProfile/EditProfileForm.tsx
+++ b/src/features/user/Settings/EditProfile/EditProfileForm.tsx
@@ -264,6 +264,7 @@ export default function EditProfileForm() {
               <div className={styles.profilePic}>
                 <img
                   src={getImageUrl('profile', 'thumb', user.image)}
+                  alt={user.displayName}
                   className={styles.profilePicImg}
                 />
               </div>

--- a/src/features/user/Widget/DonationLink/DonationLinkForm.tsx
+++ b/src/features/user/Widget/DonationLink/DonationLinkForm.tsx
@@ -277,6 +277,7 @@ const DonationLinkForm = ({
                 className={styles.qrContainer}
                 id="base64image"
                 src={qrCode}
+                alt={tDonationLink('qrCodeTitle')}
               />
               <div>
                 <Button


### PR DESCRIPTION
## Summary

Addresses A11Y-004 by replacing missing and non-descriptive image alt text with meaningful alternatives and marking decorative images as presentational.

## Changes

- Project images use the project name as alt text
- Loading and fallback placeholders use `alt=""`
- Profile avatars use the user's display name
- Tenant logos use the tenant name and provide an accessible link name
- Uploaded media uses its caption or project name
- Donation QR codes use a localized description
- Contribution map popup images use the project name

## Accessibility

WCAG 2.1 — 1.1.1 Non-text Content (Level A)