### PR TITLE
Fix/a11y 008 html lang locale sync

### DIFF
--- a/docs/accessibility/FOLLOW_UPS.md
+++ b/docs/accessibility/FOLLOW_UPS.md
@@ -61,3 +61,83 @@ Responsibilities:
 ### References
 
 - Finding: `ACCESSIBILITY_FINDINGS.md` → A11Y-002.
+
+---
+
+## FU-002 — Resolve accumulated TypeScript errors and enforce type-checking in CI
+
+**Status:** Proposed (not started)
+**Origin:** Surfaced during A11Y-008 (syncing `<html lang>` with the active locale). Running `npx tsc --noEmit` to validate that change revealed a large backlog of pre-existing type errors, none related to A11Y-008.
+**Priority:** Medium — not a user-facing defect, but a growing correctness and regression risk.
+
+### Background
+
+`tsconfig.json` declares `"strict": true`, but `next.config.js` sets:
+
+```js
+typescript: {
+  ignoreBuildErrors: true,
+}
+```
+
+So type errors never fail `next build`, and there is no `type-check` npm script or CI gate. As a result the project currently has **146 `tsc --noEmit` errors across ~63 files** that compile and ship anyway. Because nothing enforces the check, the count only grows over time.
+
+To reproduce:
+
+```bash
+npx tsc --noEmit -p tsconfig.json
+```
+
+### Error breakdown
+
+By TypeScript error code (top categories):
+
+| Count | Code | Meaning |
+|------:|------|---------|
+| 51 | TS2322 | Type not assignable to target type |
+| 30 | TS2345 | Argument type not assignable to parameter |
+| 10 | TS2339 | Property does not exist on type |
+| 9  | TS7006 | Parameter implicitly has an `any` type |
+| 8  | TS2353 | Unknown property in object literal |
+| 5  | TS2820 / TS2561 | Typo / wrong property name (did-you-mean) |
+| 5  | TS18046 | Value is of type `unknown` |
+| 4  | TS7053 | Element implicitly `any` from index expression |
+| —  | others | TS7034/7031/7016/7005, TS2769, TS2740/2739, TS2589, TS2564, TS2551, TS2304, TS2307 |
+
+Highest-concentration files (candidates to tackle first):
+
+- `src/features/user/DonationReceipt/microComponents/__tests__/YearHeader.test.tsx` — 17
+- `src/features/user/ManageProjects/components/DetailedAnalysis.tsx` — 11
+- `src/features/user/Account/components/RecurrencyRecord.tsx` — 8
+- `src/tenants/salesforce/Home/components/Timeline.tsx` — 7
+- `src/tenants/planet/LeaderBoard/components/Score.tsx` — 7
+- `src/utils/constants/countries.ts` — 6
+- `src/features/user/Account/components/AccountRecord.tsx` — 6
+
+(Full current list obtainable from the reproduce command above.)
+
+### Why deferred (not fixed in the A11Y-008 PR)
+
+- **Scope discipline** — A11Y-008 is a bounded, single-file accessibility fix. Touching ~63 unrelated files would make it unreviewable.
+- **Risk isolation** — many fixes are behavioural (narrowing `undefined`/`null`, changing types), which needs its own testing and review.
+- **Sequencing** — this is best landed incrementally as its own effort, ideally with a CI gate added last so the count can only go down.
+
+### Proposed approach
+
+1. Add a `type-check` script (`tsc --noEmit`) and wire it into CI as a **non-blocking** report first, to establish the baseline.
+2. Burn down errors in batches (by file cluster or by error code — the `any`/typo classes are low-risk quick wins).
+3. Once the count reaches zero, flip CI to **blocking** and remove `ignoreBuildErrors: true` from `next.config.js` so regressions can't reappear.
+
+### Suggested acceptance criteria
+
+- [ ] `type-check` npm script added and documented.
+- [ ] CI runs `tsc --noEmit` (report-only initially).
+- [ ] All 146 errors resolved (tracked as sub-tasks by file cluster).
+- [ ] `ignoreBuildErrors` removed from `next.config.js`.
+- [ ] CI type-check made blocking to prevent regressions.
+
+### References
+
+- Reproduce: `npx tsc --noEmit -p tsconfig.json`
+- Config: `tsconfig.json` (`strict: true`), `next.config.js` (`typescript.ignoreBuildErrors: true`)
+- Surfaced by: `ACCESSIBILITY_FINDINGS.md` → A11Y-008.

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -145,12 +145,11 @@ const PlanetWeb = ({
     setBrowserCompatible(browserNotCompatible());
   }, []);
 
-  // Sync the document language with the active locale. `_document` renders a
-  // default `<Html lang="en">` at SSR and cannot read the custom `[locale]`
-  // route param per request, so keep `<html lang>` in step on the client.
+  // `_document` sets `<html lang>` at SSR and on every full load, including language switches. This effect is purely defensive: it would re-sync lang if the locale ever changed without a document render, which doesn't happen today. Its `router.isReady` guard avoids overwriting the SSR value in Next's static case where query can be empty pre-hydration.
   useEffect(() => {
+    if (!router.isReady) return;
     document.documentElement.lang = locale;
-  }, [locale]);
+  }, [locale, router.isReady]);
 
   const isMobile = useMemo(() => {
     if (typeof window === 'undefined') return false;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -121,6 +121,7 @@ const PlanetWeb = ({
   const router = useRouter();
   const { tenantConfig } = pageProps;
   const [browserCompatible, setBrowserCompatible] = useState(false);
+  const locale = (router.query?.locale as string) ?? 'en';
 
   const tagManagerArgs = {
     gtmId: process.env.NEXT_PUBLIC_GA_TRACKING_ID,
@@ -144,6 +145,13 @@ const PlanetWeb = ({
     setBrowserCompatible(browserNotCompatible());
   }, []);
 
+  // Sync the document language with the active locale. `_document` renders a
+  // default `<Html lang="en">` at SSR and cannot read the custom `[locale]`
+  // route param per request, so keep `<html lang>` in step on the client.
+  useEffect(() => {
+    document.documentElement.lang = locale;
+  }, [locale]);
+
   const isMobile = useMemo(() => {
     if (typeof window === 'undefined') return false;
     return window.innerWidth < 481;
@@ -164,10 +172,7 @@ const PlanetWeb = ({
     return <BrowserNotSupported />;
   } else {
     return tenantConfig ? (
-      <NextIntlClientProvider
-        locale={(router.query?.locale as string) ?? 'en'}
-        messages={pageProps.messages}
-      >
+      <NextIntlClientProvider locale={locale} messages={pageProps.messages}>
         <CacheProvider value={emotionCache}>
           <Auth0Provider
             domain={process.env.AUTH0_CUSTOM_DOMAIN!}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -7,7 +7,7 @@ import Document, { Head, Html, Main, NextScript } from 'next/document';
 import createEmotionServer from '@emotion/server/create-instance';
 import createEmotionCache from '../src/createEmotionCache';
 
-class MyDocument extends Document {
+class MyDocument extends Document<{ locale: string }> {
   static async getInitialProps(
     ctx: DocumentContext
   ): Promise<DocumentInitialProps> {
@@ -17,7 +17,7 @@ class MyDocument extends Document {
 
   render() {
     return (
-      <Html lang="en">
+      <Html lang={this.props.locale}>
         <Head>
           <link
             rel="dns-prefetch"
@@ -65,6 +65,9 @@ MyDocument.getInitialProps = async (ctx) => {
 
   const initialProps = await Document.getInitialProps(ctx);
 
+  // Set `<html lang>` from the active locale so each page declares its language. The locale is the `[locale]` route segment, read here via `ctx.query`. This runs on every full document render.
+  const locale = (ctx.query?.locale as string) ?? 'en';
+
   // This is important. It prevents Emotion to render invalid HTML.
   // See https://github.com/mui/material-ui/issues/26561#issuecomment-855286153
   const emotionStyles = extractCriticalToChunks(initialProps.html);
@@ -79,6 +82,7 @@ MyDocument.getInitialProps = async (ctx) => {
 
   return {
     ...initialProps,
+    locale,
     // Styles fragment is rendered after the app and page rendering finish.
     styles: (
       <>


### PR DESCRIPTION
## Summary

Addresses **A11Y-008: Root `<html lang>` hardcoded to English in a multi-locale app** by declaring the document language from the active locale, at SSR and on client-side locale changes.

Previously, `_document.tsx` rendered a hardcoded `<Html lang="en">`, so non-English pages declared English as the page language and assistive tech could apply the wrong pronunciation and language rules for localized content.

## Changes

* `_document.tsx` now reads the `[locale]` route param via `ctx.query` in `getInitialProps` and renders `<Html lang={locale}>` (falling back to `en`), so the served HTML declares the correct language on first paint.
* `_app.tsx` keeps a `useEffect` that syncs `document.documentElement.lang` as a safety net for any locale change that happens without a document render.
* Reused the same locale value provided to `NextIntlClientProvider` to avoid a second source of locale state.

## Accessibility Impact

This change addresses:

* **WCAG 3.1.1 – Language of Page (Level A)**

Benefits include:

* Screen readers can use the correct pronunciation and language rules.
* Correct page language in the served HTML for browser tooling and non-JS crawlers.
* Improved support for multilingual content.

## Testing

### Manual

* Navigate to pages in different locales (e.g. `en`, `de`, `fr`, `es`) and verify `<html lang>` matches the active locale.
* Verify the language stays correct after switching languages and after route transitions.

### Runtime verification

* Confirmed `ctx.query.locale` resolves correctly in `_document` after the middleware rewrite (e.g. `/de/home` → `de`, `/en` → `en`), so the SSR `lang` is set from the real locale rather than always `en`.
