### PR TITLE
Here is my analysis of the staged changes.

### DIFF
--- a/src/features/user/CompleteSignup/components/FullNameInput.tsx
+++ b/src/features/user/CompleteSignup/components/FullNameInput.tsx
@@ -47,6 +47,7 @@ const FullNameInput = ({ control, errors }: FullNameInputProps) => {
         render={({ field: { onChange, value, onBlur } }) => (
           <MuiTextField
             label={tSignup('fieldLabels.firstName')}
+            autoComplete="given-name"
             error={errors.firstname !== undefined}
             helperText={
               errors.firstname !== undefined && errors.firstname.message
@@ -69,6 +70,7 @@ const FullNameInput = ({ control, errors }: FullNameInputProps) => {
         render={({ field: { onChange, value, onBlur } }) => (
           <MuiTextField
             label={tSignup('fieldLabels.lastName')}
+            autoComplete="family-name"
             error={errors.lastname !== undefined}
             helperText={
               errors.lastname !== undefined && errors.lastname.message

--- a/src/features/user/CompleteSignup/components/SignupAddressField.tsx
+++ b/src/features/user/CompleteSignup/components/SignupAddressField.tsx
@@ -112,6 +112,7 @@ const SignupAddressField = ({
         render={({ field: { onChange, value, onBlur } }) => (
           <MuiTextField
             label={tSignup('fieldLabels.address')}
+            autoComplete="street-address"
             error={errors.address !== undefined}
             helperText={errors.address !== undefined && errors.address.message}
             onChange={(event) => {
@@ -164,6 +165,7 @@ const SignupAddressField = ({
           render={({ field: { onChange, value, onBlur } }) => (
             <MuiTextField
               label={tSignup('fieldLabels.city')}
+              autoComplete="address-level2"
               error={errors.city !== undefined}
               helperText={errors.city !== undefined && errors.city.message}
               onChange={onChange}
@@ -194,6 +196,7 @@ const SignupAddressField = ({
           render={({ field: { onChange, value, onBlur } }) => (
             <MuiTextField
               label={tSignup('fieldLabels.zipCode')}
+              autoComplete="postal-code"
               error={errors.zipCode !== undefined}
               helperText={
                 errors.zipCode !== undefined && errors.zipCode.message

--- a/src/features/user/CompleteSignup/index.tsx
+++ b/src/features/user/CompleteSignup/index.tsx
@@ -174,6 +174,7 @@ export default function CompleteSignup(): ReactElement | null {
       <MuiTextField
         defaultValue={auth0User?.email}
         label={t('fieldLabels.email')}
+        autoComplete="email"
         disabled
       />
       <AutoCompleteCountry

--- a/src/features/user/Settings/EditProfile/EditProfileForm.tsx
+++ b/src/features/user/Settings/EditProfile/EditProfileForm.tsx
@@ -349,6 +349,7 @@ export default function EditProfileForm() {
             render={({ field: { onChange, value, onBlur } }) => (
               <TextField
                 label={`${t('fieldLabels.firstName')}*`}
+                autoComplete="given-name"
                 onChange={onChange}
                 onBlur={onBlur}
                 value={value}
@@ -376,6 +377,7 @@ export default function EditProfileForm() {
             render={({ field: { onChange, value, onBlur } }) => (
               <TextField
                 label={`${t('fieldLabels.lastName')}*`}
+                autoComplete="family-name"
                 onChange={onChange}
                 onBlur={onBlur}
                 value={value}
@@ -391,6 +393,7 @@ export default function EditProfileForm() {
           <TextField
             label={t('fieldLabels.email')}
             name="email"
+            autoComplete="email"
             defaultValue={user?.email}
             disabled
           ></TextField>


### PR DESCRIPTION
## What

Adds standard HTML `autocomplete` attributes to the user name, email, and address fields in the signup and profile-edit forms.

| File | Field | Token |
| --- | --- | --- |
| CompleteSignup/components/FullNameInput | First name | `given-name` |
| CompleteSignup/components/FullNameInput | Last name | `family-name` |
| CompleteSignup/components/SignupAddressField | Address | `street-address` |
| CompleteSignup/components/SignupAddressField | City | `address-level2` |
| CompleteSignup/components/SignupAddressField | Zip code | `postal-code` |
| CompleteSignup/index | Email | `email` |
| Settings/EditProfile/EditProfileForm | First name | `given-name` |
| Settings/EditProfile/EditProfileForm | Last name | `family-name` |
| Settings/EditProfile/EditProfileForm | Email | `email` |

## Why

Resolves accessibility finding **A11Y-016**. Meets WCAG 2.1 SC 1.3.5 (Identify Input Purpose): fields now declare their purpose, so browsers can auto-fill and assistive tech can present them correctly to users.

## How to test

1. Open the signup flow and the Edit Profile page.
2. Confirm the browser offers to auto-fill name, email, and address fields.
3. Inspect each input and verify the `autocomplete` attribute is present.

## Notes

Attribute-only change, no logic or styling affected.
