### PR TITLE
fix(a11y): use native table for donation receipt donations list

### DIFF
--- a/src/features/user/DonationReceipt/DonationReceipt.module.scss
+++ b/src/features/user/DonationReceipt/DonationReceipt.module.scss
@@ -62,15 +62,16 @@
 .receiptDataSection {
   width: 100%;
   border-radius: 16px;
-  padding: 20px;
+  padding: 16px;
   background-color: $dsWhite;
 }
 
 .donationsTable {
   width: 100%;
   table-layout: fixed;
-  border-collapse: collapse;
-  padding: 6px 16px 16px;
+  border-collapse: separate;
+  border-spacing: 0;
+  padding: 8px 8px 24px 8px;
 
   @include xsPhoneView {
     padding: 6px 6px 16px;
@@ -118,8 +119,7 @@
   background: $dsBaseGrey;
   width: 100%;
   border-radius: 9px;
-  padding: 10px 15px;
-  margin-top: 20px;
+  padding: 8px;
 
   .errorMessageContainer {
     display: flex;
@@ -194,6 +194,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 4px;
   background: $dsBaseGrey;
   border-radius: 9px;
   padding: 8px;

--- a/src/features/user/DonationReceipt/DonationReceipt.module.scss
+++ b/src/features/user/DonationReceipt/DonationReceipt.module.scss
@@ -62,67 +62,53 @@
 .receiptDataSection {
   width: 100%;
   border-radius: 16px;
-  padding: 16px;
+  padding: 20px;
   background-color: $dsWhite;
 }
 
 .donationsTable {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
   width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
   padding: 6px 16px 16px;
 
   @include xsPhoneView {
     padding: 6px 6px 16px;
   }
 
-  .header {
-    display: flex;
-    justify-content: space-between;
+  .header th {
     font-weight: 700;
-  }
-}
-
-.paymentDate {
-  text-align: right;
-}
-
-.amountDonated {
-  text-align: center;
-}
-
-.record {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding-top: 8px;
-  padding-bottom: 8px;
-
-  .amount {
-    flex: 1;
-    text-align: center;
+    padding-bottom: 12px;
   }
 
   .reference {
-    flex: 1;
     text-align: left;
   }
 
-  .date {
-    flex: 1;
+  .amount,
+  .amountDonated {
+    text-align: center;
+  }
+
+  .date,
+  .paymentDate {
     text-align: right;
   }
-}
 
-.record:not(:last-child) {
-  border-bottom: 1px solid $dsMediumGreyTransparent70;
-}
+  .record td {
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
 
-.totalAmount {
-  width: 100%;
-  text-align: center;
-  font-weight: 700;
+  .record:not(:last-child) td {
+    border-bottom: 1px solid $dsMediumGreyTransparent70;
+  }
+
+  .totalAmount {
+    text-align: center;
+    font-weight: 700;
+    padding-top: 12px;
+  }
 }
 
 .donorDetails {
@@ -133,6 +119,7 @@
   width: 100%;
   border-radius: 9px;
   padding: 10px 15px;
+  margin-top: 20px;
 
   .errorMessageContainer {
     display: flex;

--- a/src/features/user/DonationReceipt/DonationReceipt.module.scss
+++ b/src/features/user/DonationReceipt/DonationReceipt.module.scss
@@ -71,7 +71,7 @@
   table-layout: fixed;
   border-collapse: separate;
   border-spacing: 0;
-  padding: 8px 8px 24px 8px;
+  padding: 8px 8px 24px;
 
   @include xsPhoneView {
     padding: 6px 6px 16px;

--- a/src/features/user/DonationReceipt/microComponents/DonationsTable.tsx
+++ b/src/features/user/DonationReceipt/microComponents/DonationsTable.tsx
@@ -13,7 +13,10 @@ type Props = {
 const DonationsTable = ({ donations, amount, currency }: Props) => {
   const tReceipt = useTranslations('DonationReceipt');
   return (
-    <table className={styles.donationsTable}>
+    <table
+      className={styles.donationsTable}
+      aria-label={tReceipt('donationDetails.title')}
+    >
       <thead>
         <tr className={styles.header}>
           <th scope="col" className={styles.reference}>

--- a/src/features/user/DonationReceipt/microComponents/DonationsTable.tsx
+++ b/src/features/user/DonationReceipt/microComponents/DonationsTable.tsx
@@ -13,47 +13,51 @@ type Props = {
 const DonationsTable = ({ donations, amount, currency }: Props) => {
   const tReceipt = useTranslations('DonationReceipt');
   return (
-    <div className={styles.donationsTable}>
-      <div className={styles.header} role="row">
-        <span role="columnheader">
-          {tReceipt('donationDetails.referenceNumber')}
-        </span>
-        <span className={styles.amountDonated} role="columnheader">
-          {tReceipt('donationDetails.amountDonated')}
-        </span>
-        <span className={styles.paymentDate} role="columnheader">
-          {tReceipt('donationDetails.paymentDate')}
-        </span>
-      </div>
-      <ul role="table">
+    <table className={styles.donationsTable}>
+      <thead>
+        <tr className={styles.header}>
+          <th scope="col" className={styles.reference}>
+            {tReceipt('donationDetails.referenceNumber')}
+          </th>
+          <th scope="col" className={styles.amountDonated}>
+            {tReceipt('donationDetails.amountDonated')}
+          </th>
+          <th scope="col" className={styles.paymentDate}>
+            {tReceipt('donationDetails.paymentDate')}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
         {donations?.map(({ reference, currency, amount, paymentDate }) => {
           return (
-            <li className={styles.record} key={reference} role="row">
-              <span className={styles.reference} role="cell">
-                {reference}
-              </span>
-              <span className={styles.amount} role="cell">
+            <tr className={styles.record} key={reference}>
+              <td className={styles.reference}>{reference}</td>
+              <td className={styles.amount}>
                 {tReceipt('donationDetails.donationAmount', {
                   currency,
                   amount: amount.toFixed(2),
                 })}
-              </span>
-              <time className={styles.date} dateTime={paymentDate} role="cell">
-                {formatDate(paymentDate)}
-              </time>
-            </li>
+              </td>
+              <td className={styles.date}>
+                <time dateTime={paymentDate}>{formatDate(paymentDate)}</time>
+              </td>
+            </tr>
           );
         })}
-      </ul>
-      {Boolean(amount) && (
-        <div className={styles.totalAmount}>
-          {tReceipt('donationDetails.donationAmount', {
-            currency,
-            amount,
-          })}
-        </div>
+      </tbody>
+      {amount !== null && currency !== null && (
+        <tfoot>
+          <tr>
+            <td colSpan={3} className={styles.totalAmount}>
+              {tReceipt('donationDetails.donationAmount', {
+                currency,
+                amount,
+              })}
+            </td>
+          </tr>
+        </tfoot>
       )}
-    </div>
+    </table>
   );
 };
 


### PR DESCRIPTION
## Summary

Addresses **A11Y-018: Custom ARIA table has header outside the table role** by replacing the role-based donations table with a native HTML table.

The previous implementation rendered the header row and total outside the element with `role="table"`, preventing screen readers from correctly associating column headers with data cells. This change adopts semantic table markup and gives the table an accessible name.

## Changes

- Replaced the role-based table structure with a native `<table>`.
- Added semantic table elements:
  - `<thead>`
  - `<tbody>`
  - `<tfoot>`
  - `<th scope="col">`
  - `<td>`
- Added an `aria-label` to the table so screen readers announce it.
- Converted the `DonationsTable` SCSS from flexbox to a table layout, using `border-collapse: separate` with `border-spacing: 0` so the table's horizontal padding still applies (with `collapse`, table padding is ignored, which left the columns flush and misaligned with the donor details section).
- Adjusted section padding so the donations table and donor details align consistently.
- Narrowed the total row type guard to ensure `amount` and `currency` are non-null, resolving a pre-existing TypeScript error.

## Accessibility

This change resolves **A11Y-018** by ensuring:

- Column headers are correctly associated with data cells.
- The table has an accessible name.
- Screen readers can navigate the table using native table semantics.
- The implementation complies with **WCAG 1.3.1 – Info and Relationships (Level A)**.

## Testing

- Verified the donations table renders correctly with the updated semantic markup
- Verified column alignment matches the donor details section.
- Verified the table is announced with its name and column headers by screen readers