### PR TITLE
fix(a11y): add autocomplete attributes to signup and profile fields

### DIFF
--- a/src/features/user/CompleteSignup/components/FullNameInput.tsx
+++ b/src/features/user/CompleteSignup/components/FullNameInput.tsx
@@ -47,6 +47,7 @@ const FullNameInput = ({ control, errors }: FullNameInputProps) => {
         render={({ field: { onChange, value, onBlur } }) => (
           <MuiTextField
             label={tSignup('fieldLabels.firstName')}
+            autoComplete="given-name"
             error={errors.firstname !== undefined}
             helperText={
               errors.firstname !== undefined && errors.firstname.message
@@ -69,6 +70,7 @@ const FullNameInput = ({ control, errors }: FullNameInputProps) => {
         render={({ field: { onChange, value, onBlur } }) => (
           <MuiTextField
             label={tSignup('fieldLabels.lastName')}
+            autoComplete="family-name"
             error={errors.lastname !== undefined}
             helperText={
               errors.lastname !== undefined && errors.lastname.message

--- a/src/features/user/CompleteSignup/components/SignupAddressField.tsx
+++ b/src/features/user/CompleteSignup/components/SignupAddressField.tsx
@@ -112,6 +112,7 @@ const SignupAddressField = ({
         render={({ field: { onChange, value, onBlur } }) => (
           <MuiTextField
             label={tSignup('fieldLabels.address')}
+            autoComplete="street-address"
             error={errors.address !== undefined}
             helperText={errors.address !== undefined && errors.address.message}
             onChange={(event) => {
@@ -164,6 +165,7 @@ const SignupAddressField = ({
           render={({ field: { onChange, value, onBlur } }) => (
             <MuiTextField
               label={tSignup('fieldLabels.city')}
+              autoComplete="address-level2"
               error={errors.city !== undefined}
               helperText={errors.city !== undefined && errors.city.message}
               onChange={onChange}
@@ -194,6 +196,7 @@ const SignupAddressField = ({
           render={({ field: { onChange, value, onBlur } }) => (
             <MuiTextField
               label={tSignup('fieldLabels.zipCode')}
+              autoComplete="postal-code"
               error={errors.zipCode !== undefined}
               helperText={
                 errors.zipCode !== undefined && errors.zipCode.message

--- a/src/features/user/CompleteSignup/index.tsx
+++ b/src/features/user/CompleteSignup/index.tsx
@@ -174,6 +174,7 @@ export default function CompleteSignup(): ReactElement | null {
       <MuiTextField
         defaultValue={auth0User?.email}
         label={t('fieldLabels.email')}
+        autoComplete="email"
         disabled
       />
       <AutoCompleteCountry

--- a/src/features/user/Settings/EditProfile/EditProfileForm.tsx
+++ b/src/features/user/Settings/EditProfile/EditProfileForm.tsx
@@ -349,6 +349,7 @@ export default function EditProfileForm() {
             render={({ field: { onChange, value, onBlur } }) => (
               <TextField
                 label={`${t('fieldLabels.firstName')}*`}
+                autoComplete="given-name"
                 onChange={onChange}
                 onBlur={onBlur}
                 value={value}
@@ -376,6 +377,7 @@ export default function EditProfileForm() {
             render={({ field: { onChange, value, onBlur } }) => (
               <TextField
                 label={`${t('fieldLabels.lastName')}*`}
+                autoComplete="family-name"
                 onChange={onChange}
                 onBlur={onBlur}
                 value={value}
@@ -391,6 +393,7 @@ export default function EditProfileForm() {
           <TextField
             label={t('fieldLabels.email')}
             name="email"
+            autoComplete="email"
             defaultValue={user?.email}
             disabled
           ></TextField>

--- a/src/features/user/Settings/EditProfile/EditProfileForm.tsx
+++ b/src/features/user/Settings/EditProfile/EditProfileForm.tsx
@@ -410,6 +410,7 @@ export default function EditProfileForm() {
             render={({ field: { onChange, value, onBlur } }) => (
               <TextField
                 label={t('fieldLabels.website')}
+                autoComplete="url"
                 onChange={onChange}
                 onBlur={onBlur}
                 value={value}


### PR DESCRIPTION
## Summary

Addresses **A11Y-016: Missing `autocomplete` on identity and address fields** by adding appropriate `autoComplete` attributes to profile and signup form inputs.

Previously, several name, email, and address fields did not expose their input purpose to browsers, preventing users from benefiting from autofill and increasing the amount of manual typing required. This change adds the appropriate autocomplete tokens while preserving the existing UI and behavior.

## Changes

- Added `autoComplete` attributes to identity fields:
  - `given-name`
  - `family-name`
  - `email`
- Added `autoComplete` attributes to address fields:
  - `street-address`
  - `address-level2`
  - `postal-code`
- Updated the following components:
  - `EditProfileForm`
  - `FullNameInput`
  - `CompleteSignup`
  - `SignupAddressField`

## Accessibility

This change resolves **A11Y-016** by enabling browser autofill and exposing the purpose of form fields to assistive technologies.

**WCAG**
- **1.3.5 – Identify Input Purpose (Level AA)**

## Testing

- Verified the appropriate `autoComplete` attributes are applied to all affected inputs.
- Confirmed browser autofill recognizes supported fields.
- Verified there are no visual or functional regressions.