### PR TITLE
fix(a11y): expose expanded state on disclosure toggles (A11Y-021)

### DIFF
--- a/docs/accessibility/ACCESSIBILITY_FINDINGS.md
+++ b/docs/accessibility/ACCESSIBILITY_FINDINGS.md
@@ -992,6 +992,9 @@ useEffect(() => {
 | **Component / Feature** | AboutProject, MapFeatureExplorer, UserLayout submenu |
 | **Effort** | Small |
 | **Priority Score** | 50 / 100 |
+| **Status** | 🟡 Remediated in code (2026-07-26) — pending verification |
+
+**Remediation:** All three toggles now expose `aria-expanded` bound directly to their React state, plus `aria-controls` pointing at the region they toggle. Panel ids come from `useId()` (AboutProject, MapFeatureExplorer) or the stable `link.key` (NavLink); `aria-controls` is omitted while a region is unmounted so the IDREF is never dangling. The MapFeatureExplorer `<h3>` inside the button became a styled `<span>` (`.exploreTitle`), removing the heading from inside the control. In NavLink both the title button and the arrow button toggle the same submenu, so both carry the state; the arrow button gained an `aria-label` (`Me.toggleSubMenu`), and the submenu items are now wrapped in a container div that owns the `aria-controls` target. No visual or behavioural change. Line numbers below reflect the pre-fix code.
 
 **File(s) & Line(s):**
 - `src/features/projectsV2/ProjectDetails/components/AboutProject.tsx:40` (Read more/less)

--- a/public/static/locales/en/me.json
+++ b/public/static/locales/en/me.json
@@ -33,6 +33,7 @@
     "accountHistory": "Account History",
     "logout": "Logout",
     "close": "Close",
+    "toggleSubMenu": "Toggle {menuTitle} submenu",
     "addTarget": "Add Target",
     "noOfTrees": "How many trees?",
     "datePlanted": "Date Planted",

--- a/src/features/common/Layout/UserLayout/NavLink.tsx
+++ b/src/features/common/Layout/UserLayout/NavLink.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import type { SetState } from '../../types/common';
 
 import { useState, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import DownArrow from '../../../../../public/assets/images/icons/DownArrow';
 import IconContainer from './IconContainer';
 import styles from './UserLayout.module.scss';
@@ -74,11 +75,18 @@ function NavLink({
   user,
   closeMenu,
 }: NavLinkProps) {
+  const t = useTranslations('Me');
   const router = useRouter();
   const { localizedPath } = useLocalizedPath();
   const [isSubMenuOpen, setIsSubMenuOpen] = useState(false);
   // Determine if this is the current menu item (based on route)
   const isCurrentMainMenu = currentMenuKey === link.key;
+  // Whether this menu item acts as a disclosure control for a submenu
+  const hasSubMenu = Boolean(
+    link.subMenu && link.subMenu.length > 0 && !link.hideSubMenu
+  );
+  // Associates both toggles with the submenu they expand/collapse
+  const subMenuId = `user-nav-submenu-${link.key}`;
 
   useEffect(() => {
     if (link.subMenu && link.subMenu.length > 0 && currentSubMenuKey) {
@@ -105,8 +113,7 @@ function NavLink({
     }
 
     // Check if this menu item should navigate directly (no submenu interaction)
-    const shouldNavigateDirectly =
-      !link.subMenu || link.subMenu.length <= 0 || link.hideSubMenu;
+    const shouldNavigateDirectly = !hasSubMenu;
 
     if (shouldNavigateDirectly && link.path) {
       router.push(localizedPath(link.path));
@@ -140,15 +147,20 @@ function NavLink({
           type="button"
           className={styles.navLinkTitle}
           onClick={handleMainMenuClick}
+          aria-expanded={hasSubMenu ? isSubMenuOpen : undefined}
+          aria-controls={hasSubMenu && isSubMenuOpen ? subMenuId : undefined}
         >
           {link.title}
           {link.flag && <span className={styles.itemFlag}>{link.flag}</span>}
         </button>
-        {link.subMenu && link.subMenu.length > 0 && !link.hideSubMenu && (
+        {hasSubMenu && (
           <button
             type="button"
             className={styles.subMenuArrow}
             onClick={handleMainMenuClick}
+            aria-label={t('toggleSubMenu', { menuTitle: link.title })}
+            aria-expanded={isSubMenuOpen}
+            aria-controls={isSubMenuOpen ? subMenuId : undefined}
             style={{
               transform: isSubMenuOpen ? 'rotate(-180deg)' : 'rotate(-90deg)',
             }}
@@ -157,30 +169,30 @@ function NavLink({
           </button>
         )}
       </div>
-      {isSubMenuOpen &&
-        link.subMenu &&
-        link.subMenu.length > 0 &&
-        !link.hideSubMenu &&
-        link.subMenu.map((subLink) => {
-          if (!subLink.hideItem) {
-            return (
-              <button
-                type="button"
-                className={clsx(styles.navLinkSubMenu, {
-                  [styles.navLinkActiveSubMenu]:
-                    currentSubMenuKey === subLink.key,
-                })}
-                key={subLink.title}
-                onClick={() => handleSubMenuClick(subLink)}
-              >
-                {subLink.title}
-                {subLink.flag && (
-                  <span className={styles.itemFlag}>{subLink.flag}</span>
-                )}
-              </button>
-            );
-          }
-        })}
+      {isSubMenuOpen && hasSubMenu && link.subMenu && (
+        <div id={subMenuId}>
+          {link.subMenu.map((subLink) => {
+            if (!subLink.hideItem) {
+              return (
+                <button
+                  type="button"
+                  className={clsx(styles.navLinkSubMenu, {
+                    [styles.navLinkActiveSubMenu]:
+                      currentSubMenuKey === subLink.key,
+                  })}
+                  key={subLink.title}
+                  onClick={() => handleSubMenuClick(subLink)}
+                >
+                  {subLink.title}
+                  {subLink.flag && (
+                    <span className={styles.itemFlag}>{subLink.flag}</span>
+                  )}
+                </button>
+              );
+            }
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/projectsV2/ProjectDetails/components/AboutProject.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/AboutProject.tsx
@@ -1,5 +1,5 @@
 import styles from '../styles/AboutProject.module.scss';
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import DownArrow from '../../../../../public/assets/images/icons/projectV2/DownArrow';
 import UpArrow from '../../../../../public/assets/images/icons/projectV2/UpArrow';
@@ -14,6 +14,8 @@ const AboutProject = ({ description, wordCount = 60 }: Props) => {
   const tDonate = useTranslations('Donate');
   const tProjectDetails = useTranslations('ProjectDetails');
   const [isExpanded, setIsExpanded] = useState(false);
+  // Associates the Read more/less toggle with the collapsible part of the description
+  const expandableTextId = useId();
   const descriptionWords = description?.split(' ');
   const hasOverflow = descriptionWords?.length > wordCount;
   const startingText = hasOverflow
@@ -27,6 +29,7 @@ const AboutProject = ({ description, wordCount = 60 }: Props) => {
         {startingText} {hasOverflow && !isExpanded && <span>...</span>}
         {hasOverflow && (
           <span
+            id={expandableTextId}
             className={clsx({
               [styles.showText]: isExpanded,
               [styles.hideText]: !isExpanded,
@@ -37,7 +40,12 @@ const AboutProject = ({ description, wordCount = 60 }: Props) => {
         )}
       </div>
       {hasOverflow && (
-        <button onClick={() => setIsExpanded(!isExpanded)}>
+        <button
+          type="button"
+          aria-expanded={isExpanded}
+          aria-controls={expandableTextId}
+          onClick={() => setIsExpanded(!isExpanded)}
+        >
           <div>
             {isExpanded
               ? tProjectDetails('readLess')

--- a/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/MapFeatureExplorer.module.scss
+++ b/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/MapFeatureExplorer.module.scss
@@ -24,7 +24,7 @@
   flex-direction: column;
   align-items: flex-start;
 
-  h3 {
+  .exploreTitle {
     font-size: $fontSmall;
     @include xsPhoneView {
       font-size: $fontXXSmall;

--- a/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/MapSettings.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/MapSettings.tsx
@@ -7,6 +7,8 @@ import { mapSettingsConfig } from '../../../../utils/mapsV2/mapSettings.config';
 import styles from './MapFeatureExplorer.module.scss';
 
 type MapSettingsProps = {
+  /** Referenced by the explore toggle's `aria-controls` */
+  id?: string;
   mapOptions: MapOptions;
   updateMapOption: (option: keyof MapOptions, value: boolean) => void;
   isMobile?: boolean;
@@ -14,6 +16,7 @@ type MapSettingsProps = {
 };
 
 const MapSettings = ({
+  id,
   mapOptions,
   updateMapOption,
   isMobile,
@@ -55,14 +58,14 @@ const MapSettings = ({
 
   if (isMobile && setIsOpen) {
     return (
-      <MobileMapSettingsLayout setIsOpen={setIsOpen}>
+      <MobileMapSettingsLayout id={id} setIsOpen={setIsOpen}>
         {content}
       </MobileMapSettingsLayout>
     );
   }
 
   return (
-    <div className={styles.exploreMainContainer}>
+    <div id={id} className={styles.exploreMainContainer}>
       <div className={styles.exploreItemsContainer}>{content}</div>
     </div>
   );

--- a/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/MobileMapSettingsLayout.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/MobileMapSettingsLayout.tsx
@@ -2,21 +2,25 @@ import type { SetState } from '../../../common/types/common';
 import type { ReactNode } from 'react';
 
 import { useTranslations } from 'next-intl';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useId, useRef } from 'react';
 import { ExploreIcon } from '../../../../../public/assets/images/icons/projectV2/ExploreIcon';
 import CrossIcon from '../../../../../public/assets/images/icons/projectV2/CrossIcon';
 import styles from './MobileMapSettingsLayout.module.scss';
 import { clsx } from 'clsx';
 
 interface Props {
+  /** Referenced by the explore toggle's `aria-controls` */
+  id?: string;
   setIsOpen: SetState<boolean>;
   children: ReactNode;
 }
 
-const MobileMapSettingsLayout = ({ setIsOpen, children }: Props) => {
+const MobileMapSettingsLayout = ({ id, setIsOpen, children }: Props) => {
   const tMaps = useTranslations('Maps');
   const [isAtBottom, setIsAtBottom] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  // Names the dialog using its visible header text
+  const labelId = useId();
 
   const handleScroll = () => {
     if (!scrollRef.current) return;
@@ -43,11 +47,16 @@ const MobileMapSettingsLayout = ({ setIsOpen, children }: Props) => {
   }, []);
 
   return (
-    <div className={styles.container}>
+    <div
+      id={id}
+      className={styles.container}
+      role="dialog"
+      aria-labelledby={labelId}
+    >
       <div className={styles.header}>
         <div className={styles.exploreLabel}>
           <ExploreIcon />
-          <p>{tMaps('explore')}</p>
+          <p id={labelId}>{tMaps('explore')}</p>
         </div>
         <button
           className={styles.closeButton}

--- a/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/index.tsx
@@ -56,6 +56,7 @@ const MapFeatureExplorer = ({
           }}
         >
           <MapSettings
+            id={panelId}
             mapOptions={mapOptions}
             updateMapOption={updateMapOption}
             isMobile={isMobile}

--- a/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/MapFeatureExplorer/index.tsx
@@ -1,6 +1,6 @@
 import type { MapOptions } from '../../../common/types/map';
 
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Modal } from '@mui/material';
 import { ExploreIcon } from '../../../../../public/assets/images/icons/projectV2/ExploreIcon';
@@ -22,21 +22,26 @@ const MapFeatureExplorer = ({
 }: MapFeatureExplorerProps) => {
   const tExplore = useTranslations('Maps.exploreLayers');
   const [isOpen, setIsOpen] = useState(false);
+  // Associates the toggle with the layer settings panel it opens
+  const panelId = useId();
   return (
     <div className={styles.mapFeatureExplorer}>
       <CustomButton
         startIcon={<ExploreIcon />}
         onClick={() => setIsOpen(!isOpen)}
         className={clsx(styles.exploreButton, { active: isOpen })}
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? panelId : undefined}
       >
         <div className={styles.exploreButtonContent}>
-          <h3>{tExplore('title')}</h3>
+          <span className={styles.exploreTitle}>{tExplore('title')}</span>
           {!isMobile && <p>{tExplore('subtitle')}</p>}
         </div>
       </CustomButton>
 
       {isOpen && !isMobile && (
         <MapSettings
+          id={panelId}
           mapOptions={mapOptions}
           updateMapOption={updateMapOption}
         />
@@ -44,7 +49,6 @@ const MapFeatureExplorer = ({
       {isMobile && (
         <Modal
           open={isOpen}
-          aria-labelledby="map-settings-menu"
           onClose={(_event, reason) => {
             if (reason === 'backdropClick') {
               setIsOpen(false);


### PR DESCRIPTION
## Summary

Addresses **A11Y-021: Disclosure toggles missing `aria-expanded`** by exposing the expanded/collapsed state of disclosure controls to assistive technologies.

Previously, the UI tracked the open/closed state in React, but that state was not reflected through ARIA attributes. As a result, screen reader users could activate the controls but had no indication whether the associated content was currently expanded or collapsed.

## Changes

- Added `aria-expanded` to all disclosure controls so screen readers announce their current state.
- Added `aria-controls` to associate each toggle with the content region it expands/collapses.

### AboutProject
- Added `type="button"` to prevent unintended form submission.
- Added `aria-expanded` and `aria-controls` for the collapsible description.

### MapFeatureExplorer
- Added `aria-expanded` and `aria-controls` to the desktop explore toggle.
- Threaded an optional panel ID through `MapSettings` so both desktop and mobile panels can be referenced correctly.
- Moved the `<h3>` outside the button and replaced it with a styled `<span>` to avoid placing a heading inside an interactive control while preserving the existing visual appearance.

### NavLink
- Added `aria-expanded` to both submenu toggle buttons since either control can expand/collapse the submenu.
- Added an accessible label to the arrow button (`Me.toggleSubMenu`).
- Wrapped submenu items in a container that serves as the `aria-controls` target.
- Simplified the repeated submenu condition into a single `hasSubMenu` flag.

## Why

These changes expose the current expanded/collapsed state to assistive technologies, allowing screen reader users to understand whether each disclosure widget is open or closed.

This addresses:
- **WCAG 4.1.2 – Name, Role, Value (Level A)**
- **WCAG 1.3.1 – Info and Relationships (Level A)**

## Testing

- Confirmed `aria-controls` references only mounted elements.
- Verified there are no visual or behavioural changes.