### PR TITLE
fix(a11y): correct heading semantics and hierarchy

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -6,7 +6,9 @@ import type {
 import type { AbstractIntlMessages } from 'next-intl';
 
 import Custom404Image from '../public/assets/images/Custom404Image';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
+import { useTranslations } from 'next-intl';
 import Footer from '../src/features/common/Layout/Footer';
 import getMessagesForPage from '../src/utils/language/getMessagesForPage';
 
@@ -25,15 +27,21 @@ export default function Custom404({ pageProps }: Props) {
     flexDirection: 'column',
   } as const;
   const router = useRouter();
+  const t = useTranslations('Common');
+  const error =
+    typeof router.query.error === 'string' ? router.query.error : undefined;
 
   return (
     <>
-      <div style={styles}>
-        <h2>{router.query.error}</h2>
+      <Head>
+        <title>{t('pageNotFound')}</title>
+      </Head>
+      <main style={styles}>
+        <h1>{error || t('pageNotFound')}</h1>
         <div style={{ width: '300px', height: '175px' }}>
           <Custom404Image />
         </div>
-      </div>
+      </main>
       <Footer />
     </>
   );

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -108,6 +108,7 @@
     "deleteCondition": "Before proceeding, make sure you've cancelled all subscriptions.",
     "showSubscriptions": "Show my Subscriptions",
     "notFound": "Resource not found",
+    "pageNotFound": "Page not found",
     "tooManyRequest": "Too many requests. Please wait and try again later or contact the system administrator for assistance.",
     "unauthorized": "Not Authorized",
     "validationError": "Validation Error",

--- a/src/features/common/Layout/DashboardView/index.tsx
+++ b/src/features/common/Layout/DashboardView/index.tsx
@@ -70,7 +70,12 @@ export default function DashboardView({
             xs={12}
             md={10}
           >
-            <Grid item component="h1" className="dashboardTitle">
+            {/* Avoid rendering an empty <h1>; use a <div> when there is no title. */}
+            <Grid
+              item
+              component={title ? 'h1' : 'div'}
+              className="dashboardTitle"
+            >
               {title}
             </Grid>
             {subtitle !== undefined && (

--- a/src/features/projectsV2/ProjectDetails/components/AboutProject.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/AboutProject.tsx
@@ -22,7 +22,7 @@ const AboutProject = ({ description, wordCount = 60 }: Props) => {
   const endText = descriptionWords?.slice(wordCount - 1).join(' ');
   return (
     <div className={styles.projectDescription}>
-      <div className={styles.infoTitle}>{tDonate('aboutProject')}</div>
+      <h2 className={styles.infoTitle}>{tDonate('aboutProject')}</h2>
       <div className={styles.infoText}>
         {startingText} {hasOverflow && !isExpanded && <span>...</span>}
         {hasOverflow && (

--- a/src/features/user/BulkCodes/components/RecipientHeader.tsx
+++ b/src/features/user/BulkCodes/components/RecipientHeader.tsx
@@ -11,9 +11,10 @@ interface Props {
 
 const RecipientHeader = ({ header }: Props) => {
   const { displayText, helpText } = header;
+  // MUI renders this TableCell as <th scope="col"> because it sits inside <TableHead>
   return (
     <TableCell>
-      <h3>
+      <span>
         {displayText}
         {helpText !== undefined && helpText.length > 0 && (
           <>
@@ -25,7 +26,7 @@ const RecipientHeader = ({ header }: Props) => {
             </Tooltip>
           </>
         )}
-      </h3>
+      </span>
     </TableCell>
   );
 };

--- a/src/features/user/Profile/ProfileCard/ShareModal/ShareModal.module.scss
+++ b/src/features/user/Profile/ProfileCard/ShareModal/ShareModal.module.scss
@@ -23,7 +23,7 @@
     color: $dsWhite;
     cursor: pointer;
 
-    label {
+    span {
       white-space: nowrap;
       cursor: pointer;
     }

--- a/src/features/user/Profile/ProfileCard/ShareModal/index.tsx
+++ b/src/features/user/Profile/ProfileCard/ShareModal/index.tsx
@@ -18,8 +18,8 @@ import { useTenantStore } from '../../../../../stores/tenantStore';
 const CustomCopyButton = () => {
   const t = useTranslations('Profile');
   return (
-    <button className={styles.copyButton}>
-      <label>{t('shareFeature.copyLink')}</label>
+    <button type="button" className={styles.copyButton}>
+      <span>{t('shareFeature.copyLink')}</span>
     </button>
   );
 };

--- a/src/features/user/TreemapperMigration/index.tsx
+++ b/src/features/user/TreemapperMigration/index.tsx
@@ -39,7 +39,7 @@ const TreemapperMigration = (): ReactElement => {
         />
         <div className={styles.spacer} />
         <div className={styles.contentContainer}>
-          <p className={styles.title}>{t('migrationTitle')}</p>
+          <h1 className={styles.title}>{t('migrationTitle')}</h1>
           <p className={styles.subtitle}>{t('migrationSubtitle')}</p>
         </div>
         <div className={styles.spacer} />

--- a/src/features/user/Widget/DonationLink/DonationLinkForm.tsx
+++ b/src/features/user/Widget/DonationLink/DonationLinkForm.tsx
@@ -198,7 +198,7 @@ const DonationLinkForm = ({
               {tDonationLink('treeCounterTitle')}
             </div>
             <InlineFormDisplayGroup type="other">
-              <h6>{tDonationLink('treeCounterSubtitle')}</h6>
+              <p>{tDonationLink('treeCounterSubtitle')}</p>
               <NewToggleSwitch
                 id="treeCounter"
                 name="treeCounter"
@@ -210,7 +210,7 @@ const DonationLinkForm = ({
               />
             </InlineFormDisplayGroup>
             {user.isPrivate && (
-              <h6>{tDonationLink('treeCounterPrivateAccountSubtitle')}</h6>
+              <p>{tDonationLink('treeCounterPrivateAccountSubtitle')}</p>
             )}
           </div>
           <InlineFormDisplayGroup type="other">
@@ -229,8 +229,8 @@ const DonationLinkForm = ({
           </InlineFormDisplayGroup>
           {isTesting && (
             <>
-              <h6> {tDonationLink('testingModeSubtitle1')}</h6>
-              <h6>
+              <p> {tDonationLink('testingModeSubtitle1')}</p>
+              <p>
                 {tDonationLink('testingModeSubtitle2')}{' '}
                 <a
                   className="planet-links"
@@ -240,7 +240,7 @@ const DonationLinkForm = ({
                 >
                   stripe
                 </a>{' '}
-              </h6>
+              </p>
             </>
           )}
           <div className={styles.formSection}>


### PR DESCRIPTION
## Summary

Addresses **A11Y-028: Heading misuse and hierarchy problems** and **A11Y-035: `<label>` element used as button text** by replacing decorative markup with semantic HTML and correcting the document heading structure.

Previously, several components used heading elements purely for styling or omitted semantic headings where they were needed. These changes improve the page outline for assistive technologies without affecting the visual UI.

## Changes

- **404**
  - Added a document `<title>` and wrapped content in `<main>`.
  - Replaced the empty/out-of-order heading with a single `<h1>` that falls back to the translated "Page not found" text.

- **AboutProject**
  - Replaced the section title `<div>` with an `<h2>` to match the surrounding heading hierarchy.

- **RecipientHeader**
  - Removed the decorative `<h3>` and relied on MUI's semantic `<th scope="col">`.

- **DonationLinkForm**
  - Replaced decorative `<h6>` helper text with `<p>` elements.

- **TreemapperMigration**
  - Made the card title the page `<h1>`.
  - Prevented `DashboardView` from rendering an empty `<h1>` when a page provides its own heading.

- **ShareModal**
  - Replaced the orphan `<label>` inside the copy button with a `<span>`.

## Why

These changes improve semantic HTML and provide a consistent heading hierarchy for screen reader users without introducing any visual or behavioural changes.

This addresses:

- **WCAG 1.3.1 – Info and Relationships (Level A)**
- **WCAG 2.4.2 – Page Titled (Level A)**
- **WCAG 2.4.6 – Headings and Labels (Level AA)**

## Testing

- Verified pages expose a logical heading hierarchy.
- Verified the 404 page has a single `<h1>` and document title.
- Confirmed semantic changes produce no visual or behavioural regressions.