### PR TITLE
fix(a11y): show a visible keyboard focus ring (WCAG 2.4.7)

### DIFF
--- a/src/features/user/Account/AccountHistory.module.scss
+++ b/src/features/user/Account/AccountHistory.module.scss
@@ -327,11 +327,6 @@
       display: flex;
       gap: 5px;
       align-items: center;
-
-      &:focus-visible {
-        border: 2px solid $dsPrimaryColor;
-        border-radius: 3px;
-      }
     }
   }
 }

--- a/src/theme/global.scss
+++ b/src/theme/global.scss
@@ -40,8 +40,14 @@ body {
   border-bottom: 2px solid $primaryColor !important;
 }
 
-:focus {
-  outline: none !important;
+// Hide the focus ring for mouse/programmatic focus, but show a visible ring for keyboard navigation (WCAG 2.4.7). `outline` is used (not `border`) so the ring takes no layout space; modern browsers make it follow the element's radius.
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+:focus-visible {
+  outline: 2px solid $dsPrimaryColor;
+  outline-offset: 2px;
 }
 
 .planet-links {


### PR DESCRIPTION
## Summary

Restores a visible keyboard focus indicator across the app (**WCAG 2.4.7 Focus Visible**, AA).

`src/theme/global.scss` had a blanket `:focus { outline: none !important; }` that stripped the focus outline from every focusable element, with essentially no replacement (a single `border`-based ring in `AccountHistory` was the only survivor, and only because `border` isn't affected by `outline: none`). The recent a11y work made controls keyboard-*operable*, but a keyboard user often couldn't *see* where focus was.

## Changes

- Scope the suppression to non-keyboard focus (`:focus:not(:focus-visible)`) and add a `:focus-visible` ring in the primary colour, so the ring shows only for keyboard/AT navigation and mouse clicks stay ringless (the original intent of the blanket rule).
- Use `outline` rather than `border`: it takes no layout space (no reflow on focus) and follows each element's `border-radius`.
- Remove the now-redundant `:focus-visible` border ring in `AccountHistory` (superseded by the global ring; it also shifted layout by 2px).

## Accessibility impact

- **WCAG 2.4.7 Focus Visible (AA):** keyboard users get a consistent, on-brand focus ring.
- Makes the keyboard operability from the prior a11y batch actually visible.

## Testing

- [ ] Keyboard-tab through buttons, `IconButton`s, TimeTravelDropdown toggles, form fields, links — ring appears on keyboard focus.
- [ ] Mouse-click the same controls — no ring.
- [ ] Open modals (see review list) — focus behaviour is sane; interactive controls inside show the ring.

## Reviewer note — components with their own `outline: none`

Confirm each only suppresses the ring on non-interactive containers (mostly modal roots), not interactive controls:

`EmbedModal:12`, `StepForm:719`, `AccountHistory:415`, `RedeemModal:10`, `SelectLanguageAndCountry:13`, `RedeemPopup:24`, `CustomModal:11`, `CookiePolicy:23`, `ErrorPopup:24`

## Known limitation / follow-up

The ring uses `$dsPrimaryColor` (#007A49): ~5:1 on white (passes WCAG 1.4.11 non-text contrast) but nearly invisible on primary-green backgrounds. A contrasting/two-tone ring could follow if needed.
