### PR TITLE
fix(embed): restore project data when the details pane is hidden

### DIFF
--- a/docs/architecture/context-to-store.md
+++ b/docs/architecture/context-to-store.md
@@ -1,0 +1,97 @@
+# Moving state from context to a store
+
+Guidance for the ongoing move from React context to Zustand stores. The mechanical
+part of these changes is easy. The part that has caused production bugs is timing:
+a context value is often available on the first render, and a store value written
+from an effect is not.
+
+## Which values are risky
+
+Only values that are **synchronous today**.
+
+- **Risky:** anything available on the very first render now. A prop, something
+  from `getStaticProps`, or a value computed during render. Consumers have never
+  had to handle it being unset, so they do not
+- **Not risky:** anything the provider already fetches or reads asynchronously,
+  such as the signed in user. It has always been `null` at first, so every
+  consumer already handles that, and moving it changes nothing about timing
+
+So the first step is to sort the values you are moving into those two groups. Only
+the first group needs the rest of this page.
+
+## Where it goes wrong
+
+The window is at least one render long, between mount and the effect that writes
+the value.
+
+That window is harmless where the value only affects **what is drawn**, because
+the next render corrects it. The worst case is a flash.
+
+It is not harmless where the value decides **whether something renders at all**. A
+component that never mounts never runs its effects, and nothing corrects that
+later. Look for the value in conditions that return `null`, pick between
+branches, or gate `children`.
+
+## Two mistakes already made in this migration, in opposite directions
+
+**Unset value reaches a render gate.** `viewStore.page` starts as `null`, which is
+the honest choice and has a comment explaining that a concrete default would
+wrongly trigger route-specific effects. But `null` reached the layout gate for the
+project pages, that gate decided whether the details pane mounted, and the only
+project fetch lived inside the pane. Embeds that hide the pane fetched nothing at
+all. See issue #3010.
+
+**Plausible default gets acted on.** `currencyStore.currencyCode` starts as
+`'EUR'`, which is indistinguishable from a real choice. Nothing waited for the
+stored value, so the first request went out with the placeholder and a second one
+followed once `localStorage` was read. Fixed by adding an explicit
+`isCurrencyResolved` flag that callers wait for.
+
+The shared lesson: `null` was overloaded to mean both "not known yet" and "not
+applicable", and `'EUR'` hid the fact that nothing was known yet. Neither made the
+unset phase visible.
+
+## Choosing the initial value
+
+In order of preference:
+
+1. **Derive the value during render, so there is no unset phase.** Best when the
+   source is synchronous. A value derived from `router.pathname` is correct on the
+   first render, on the server and the client, with no effect and no flag
+2. **Keep a placeholder, and add an explicit resolved flag** that callers check,
+   as `isCurrencyResolved` does. Use this when the real value genuinely arrives
+   later. Do not let callers infer readiness from the value itself
+3. **Start unset, usually `null`.** Acceptable, but then check every consumer that
+   uses it in a render gate
+
+Whichever you pick, say which one you picked and why in a comment on the state
+field. Both stores above have such a comment, and it is the reason the reasoning
+survived long enough to be reviewed.
+
+## Before opening the PR
+
+- List the values you moved, and which of them were synchronous before
+- For each synchronous one, list every consumer that uses it in a render gate.
+  Those are the consumers whose behavior changed, and they are what a reviewer
+  needs to look at
+- Say all of this in the PR description. It is much cheaper to review this way
+  than to reconstruct it from the diff
+
+## Remaining contexts
+
+As of 2026-07-29:
+
+```
+src/features/common/Layout/UserPropsContext.tsx
+src/features/common/Layout/PlanetCashContext.tsx
+src/features/common/Layout/BulkCodeContext.tsx
+src/features/common/Layout/DonationReceiptContext.tsx
+src/features/common/Layout/PayoutsContext.tsx
+src/theme/themeContext.tsx
+```
+
+## Related
+
+- [Data fetching and render gates](./data-fetching.md), where a fetch belongs
+  relative to the gate that decides if a component renders
+- Issue #3010, the regression that prompted this page

--- a/docs/architecture/data-fetching.md
+++ b/docs/architecture/data-fetching.md
@@ -1,0 +1,78 @@
+# Data fetching and render gates
+
+Where a fetch lives decides when it runs. Put it in the wrong place and it stops
+running in configurations nobody tested.
+
+This is not a rule that all fetching belongs in one place. Most fetches in
+`src/features` are in components and are correct there. The rule is about the
+relationship between a fetch and whatever decides if a component renders.
+
+## The two questions
+
+Before writing a fetch inside a component, ask:
+
+1. **Does anything outside this component use the data?**
+2. **Can something outside this component stop it from rendering?** A URL
+   parameter, a layout gate, a mobile map and list switch, a tab.
+
+If either answer is yes, the fetch does not belong in the component. Move it above
+the gate, into an initializer hook.
+
+If both answers are no, keep it in the component. That stays lazy, keeps the data
+next to its only reader, and does not run on pages that do not need it.
+
+## Where app-wide fetches go
+
+`StoreInitializer` is mounted once in `pages/_app.tsx`, above `Layout`, so it runs
+for the whole page lifetime no matter what the layout renders. It calls one hook
+per concern:
+
+```
+useInitializeTenant, useInitializeParams, useInitializeCurrency,
+useInitializeView, useInitializeProject, useInitializeSingleProject,
+useInitializeIntervention
+```
+
+A new one follows the same shape: read what it needs from the router and the
+stores, guard, call a store action. The store action owns de-duplication, so the
+hook can be called on every render without firing repeat requests. See
+`src/utils/fetchKey.ts` and `fetchProject` in `src/stores/singleProjectStore.ts`.
+
+## Worked example, what happens when this is mixed up
+
+The project list and the project details page had the same needs and were built
+differently.
+
+The list fetch sat in `useInitializeProject`, above the layout. The details fetch
+sat inside `ProjectDetails`, which is the component that `project_details=false`
+is designed to hide, and it was the only API call site in that whole subtree.
+
+Both answers above were yes for it. The map draws the project's interventions and
+sites, so other things used the data. And `ProjectsLayout` decides whether the
+pane renders at all, so something else controlled its mounting.
+
+For a while this worked by luck. `page` was a synchronous prop, so on one render
+the gate was open while the embed parameters were still unread. The component
+mounted for that single render, its effect fired, and the data outlived the
+unmount. When `page` moved into a store and started as `null`, that render
+disappeared and the fetch went with it. Embeds with the pane hidden showed an
+empty map, with no request made for the project, its interventions, or its
+time travel config, and no error either.
+
+Details in issue #3010.
+
+## Watch the gate itself, not only the fetch
+
+A gate is only as reliable as the values it reads. #3010 happened because the gate
+started reading a value that is unset on the first render, which turned "hidden for
+one render" into "never mounted".
+
+If you are changing where a gating value comes from, rather than where a fetch
+lives, see [Moving state from context to a store](./context-to-store.md).
+
+## Related
+
+- `src/features/common/StoreInitializer/StoreInitializer.tsx`
+- `src/utils/fetchKey.ts`, request de-duplication and discarding stale responses
+- [Moving state from context to a store](./context-to-store.md)
+- Issue #3010, the regression this page describes

--- a/src/features/projectsV2/ProjectDetails/index.tsx
+++ b/src/features/projectsV2/ProjectDetails/index.tsx
@@ -7,7 +7,6 @@ import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import ProjectSnippet from '../ProjectSnippet';
 import ProjectInfo from './components/ProjectInfo';
-import { useLocale } from 'next-intl';
 import styles from './ProjectDetails.module.scss';
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
@@ -17,25 +16,16 @@ import { getActiveSingleTree } from '../../../utils/projectV2';
 import ProjectDetailsMeta from '../../../utils/getMetaTags/ProjectDetailsMeta';
 import OtherInterventionInfo from './components/OtherInterventionInfo';
 import { isNonPlantationType } from '../../../utils/constants/intervention';
-import { useApi } from '../../../hooks/useApi';
-import useLocalizedPath from '../../../hooks/useLocalizedPath';
-import { useTenantStore } from '../../../stores/tenantStore';
-import { useCurrencyStore } from '../../../stores/currencyStore';
 import { useInterventionStore, useSingleProjectStore } from '../../../stores';
 
 const ProjectDetails = ({ isMobile }: { isMobile: boolean }) => {
-  const locale = useLocale();
   const router = useRouter();
-  const { getApi } = useApi();
-  const { localizedPath } = useLocalizedPath();
 
   const { p: projectSlug } = router.query;
   //local state
   const [hasVideoConsent, setHasVideoConsent] = useState(false);
   // store: state
-  const currencyCode = useCurrencyStore((state) => state.currencyCode);
   const singleProject = useSingleProjectStore((state) => state.singleProject);
-  const fetchError = useSingleProjectStore((state) => state.fetchError);
   const selectedSampleIntervention = useInterventionStore(
     (state) => state.selectedSampleIntervention
   );
@@ -45,34 +35,6 @@ const ProjectDetails = ({ isMobile }: { isMobile: boolean }) => {
   const selectedIntervention = useInterventionStore(
     (state) => state.selectedIntervention
   );
-  const tenantConfig = useTenantStore((state) => state.tenantConfig);
-
-  // store: action
-  const fetchProjectData = useSingleProjectStore((state) => state.fetchProject);
-
-  useEffect(() => {
-    if (typeof projectSlug === 'string' && currencyCode && router.isReady) {
-      const config = {
-        queryParams: {
-          _scope: 'extended',
-          currency: currencyCode,
-          //passing locale/tenant as a query param to break cache when locale changes,
-          //as the browser uses the cached response even though the x-locale header is different
-          locale: locale,
-          tenant: tenantConfig.id,
-        },
-      };
-      fetchProjectData(getApi, config, projectSlug);
-    }
-  }, [router.isReady, projectSlug, locale, currencyCode, tenantConfig?.id]);
-
-  // Redirect home if the project fails to load. The store handles the error
-  // message, and this prevents an endless loading state.
-  useEffect(() => {
-    if (fetchError) {
-      router.push(localizedPath('/'));
-    }
-  }, [fetchError]);
 
   useEffect(() => {
     setHasVideoConsent(false);

--- a/src/features/projectsV2/ProjectSnippet/index.tsx
+++ b/src/features/projectsV2/ProjectSnippet/index.tsx
@@ -11,7 +11,7 @@ import type {
   CurrencyCode,
 } from '@planet-sdk/common';
 
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import ProjectInfoSection from './microComponents/ProjectInfoSection';
@@ -204,19 +204,6 @@ export default function ProjectSnippet({
     return path;
   }, [project.slug, embed, callbackUrl, router.asPath]);
 
-  // The useEffect hook checks if the backNavigationUrl query parameter exists and is a string, and if so,
-  // it decodes this value and stores it in session storage
-  useEffect(() => {
-    if (
-      router.query.backNavigationUrl &&
-      typeof router.query.backNavigationUrl === 'string'
-    ) {
-      sessionStorage.setItem(
-        'backNavigationUrl',
-        decodeURIComponent(router.query.backNavigationUrl)
-      );
-    }
-  }, [router.query]);
   return (
     <>
       <div className={projectSnippetContainerClasses}>

--- a/src/hooks/useInitializeParams.ts
+++ b/src/hooks/useInitializeParams.ts
@@ -36,4 +36,22 @@ export const useInitializeParams = () => {
       isContextLoaded: true,
     });
   }, [router.isReady, router.query, isContextLoaded]);
+
+  /**
+   * Remember where to return to, for the back button on project details.
+   *
+   * Kept out of the latched effect above so a client-side navigation carrying a
+   * new `backNavigationUrl` still updates it. It lives here rather than in
+   * `ProjectSnippet` because that component is not rendered when the details
+   * pane is hidden in embed mode.
+   */
+  useEffect(() => {
+    const { backNavigationUrl } = router.query;
+    if (typeof backNavigationUrl !== 'string') return;
+
+    sessionStorage.setItem(
+      'backNavigationUrl',
+      decodeURIComponent(backNavigationUrl)
+    );
+  }, [router.query.backNavigationUrl]);
 };

--- a/src/hooks/useInitializeParams.ts
+++ b/src/hooks/useInitializeParams.ts
@@ -23,6 +23,10 @@ export const useInitializeParams = () => {
   );
   const isContextLoaded = useQueryParamStore((state) => state.isContextLoaded);
 
+  /**
+   * Read the embed params once per full page load. The `isContextLoaded` latch means a client-side navigation that changes them is ignored, so these values do not track the URL.
+   * Link builders forward only `embed` and `callback` anyway, see #3014.
+   */
   useEffect(() => {
     if (!router.isReady || isContextLoaded) return;
     const { query } = router;

--- a/src/hooks/useInitializeParams.ts
+++ b/src/hooks/useInitializeParams.ts
@@ -49,9 +49,15 @@ export const useInitializeParams = () => {
     const { backNavigationUrl } = router.query;
     if (typeof backNavigationUrl !== 'string') return;
 
-    sessionStorage.setItem(
-      'backNavigationUrl',
-      decodeURIComponent(backNavigationUrl)
-    );
+    try {
+      sessionStorage.setItem(
+        'backNavigationUrl',
+        decodeURIComponent(backNavigationUrl)
+      );
+    } catch {
+      // Malformed percent-encoding, such as a bare `%`, throws a `URIError`.
+      // Session storage can also be blocked in a cross-origin embed.
+      // Neither is worth failing the page for, the back button just falls back to home.
+    }
   }, [router.query.backNavigationUrl]);
 };

--- a/src/hooks/useInitializeProject.ts
+++ b/src/hooks/useInitializeProject.ts
@@ -13,6 +13,9 @@ export const useInitializeProject = () => {
   const router = useRouter();
   // store: state
   const currencyCode = useCurrencyStore((state) => state.currencyCode);
+  const isCurrencyResolved = useCurrencyStore(
+    (state) => state.isCurrencyResolved
+  );
   const currentPage = useViewStore((state) => state.page);
   // store: action
   const fetchProjects = useProjectStore((state) => state.fetchProjects);
@@ -25,7 +28,10 @@ export const useInitializeProject = () => {
   const clearFilterStates = useProjectStore((state) => state.clearFilterStates);
 
   useEffect(() => {
-    if (currentPage !== 'project-list' || !currencyCode) return;
+    if (currentPage !== 'project-list') return;
+    // Wait for the real currency. `currencyCode` starts at a placeholder, and
+    // fetching with it would only be superseded once `localStorage` is read.
+    if (!isCurrencyResolved || !currencyCode) return;
     // `fetchProjects` skips redundant requests itself, keyed on locale, currency
     // and tenant.
     fetchProjects(getApi, {
@@ -39,7 +45,7 @@ export const useInitializeProject = () => {
         'filter[purpose]': 'trees,conservation',
       },
     });
-  }, [currencyCode, locale, tenantId, currentPage]);
+  }, [currencyCode, isCurrencyResolved, locale, tenantId, currentPage]);
 
   useEffect(() => {
     if (router.isReady && currentPage === 'project-list') {

--- a/src/hooks/useInitializeProject.ts
+++ b/src/hooks/useInitializeProject.ts
@@ -14,11 +14,6 @@ export const useInitializeProject = () => {
   // store: state
   const currencyCode = useCurrencyStore((state) => state.currencyCode);
   const currentPage = useViewStore((state) => state.page);
-  const projectsCurrencyCode = useProjectStore(
-    (state) => state.projectsCurrencyCode
-  );
-  const projectsLocale = useProjectStore((state) => state.projectsLocale);
-  const projects = useProjectStore((state) => state.projects);
   // store: action
   const fetchProjects = useProjectStore((state) => state.fetchProjects);
   const setSelectedClassification = useProjectStore(
@@ -31,14 +26,8 @@ export const useInitializeProject = () => {
 
   useEffect(() => {
     if (currentPage !== 'project-list' || !currencyCode) return;
-    // Avoid refetching if projects are already loaded for the same locale and currency
-    if (
-      projectsLocale === locale &&
-      projectsCurrencyCode === currencyCode &&
-      projects !== null
-    )
-      return;
-
+    // `fetchProjects` skips redundant requests itself, keyed on locale, currency
+    // and tenant.
     fetchProjects(getApi, {
       queryParams: {
         _scope: 'map',

--- a/src/hooks/useInitializeSingleProject.ts
+++ b/src/hooks/useInitializeSingleProject.ts
@@ -39,6 +39,9 @@ export const useInitializeSingleProject = () => {
   // store: state
   const currentPage = useViewStore((state) => state.page);
   const currencyCode = useCurrencyStore((state) => state.currencyCode);
+  const isCurrencyResolved = useCurrencyStore(
+    (state) => state.isCurrencyResolved
+  );
   const tenantId = useTenantStore((state) => state.tenantConfig.id);
   const singleProject = useSingleProjectStore((state) => state.singleProject);
   const selectedSite = useSingleProjectStore((state) => state.selectedSite);
@@ -66,11 +69,16 @@ export const useInitializeSingleProject = () => {
    * `router.query.p` is used as the signal rather than `viewStore.page`, since
    * the page is derived from that same param but only after an effect, and this
    * fetch should not wait on it.
+   *
+   * It does wait on `isCurrencyResolved`, because `currencyCode` starts at a
+   * placeholder that would otherwise be fetched with and then immediately
+   * superseded. Waiting here cannot stall: `initializeCurrencyCode` runs
+   * unconditionally on mount in the browser and resolves in every path.
    */
   useEffect(() => {
     if (!router.isReady) return;
     if (!isString(projectSlug)) return;
-    if (!currencyCode) return;
+    if (!isCurrencyResolved || !currencyCode) return;
 
     fetchProject(
       getApi,
@@ -86,7 +94,14 @@ export const useInitializeSingleProject = () => {
       },
       projectSlug
     );
-  }, [router.isReady, projectSlug, locale, currencyCode, tenantId]);
+  }, [
+    router.isReady,
+    projectSlug,
+    locale,
+    currencyCode,
+    isCurrencyResolved,
+    tenantId,
+  ]);
 
   // Redirect home if the project fails to load. The store handles the error message, and this prevents an endless loading state.
   useEffect(() => {

--- a/src/hooks/useInitializeSingleProject.ts
+++ b/src/hooks/useInitializeSingleProject.ts
@@ -3,12 +3,16 @@ import type { ProjectSiteFeature } from '../features/common/types/map';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import {
+  useCurrencyStore,
   useInterventionStore,
   useSingleProjectStore,
+  useTenantStore,
   useViewStore,
 } from '../stores';
 import { useLocale } from 'next-intl';
 import { FIRST_SITE_INDEX, hasNoSites, isString } from '../utils/projectV2';
+import { useApi } from './useApi';
+import useLocalizedPath from './useLocalizedPath';
 
 const getSiteIndexById = (
   sites: ProjectSiteFeature[],
@@ -22,24 +26,74 @@ const getSiteIndexById = (
 export const useInitializeSingleProject = () => {
   const locale = useLocale();
   const router = useRouter();
-  const { site: requestedSite, ploc: requestedIntervention } = router.query;
+  const { getApi } = useApi();
+  const { localizedPath } = useLocalizedPath();
+  const {
+    p: projectSlug,
+    site: requestedSite,
+    ploc: requestedIntervention,
+  } = router.query;
   const hasOnlyRequestedIntervention = Boolean(
     !requestedSite && requestedIntervention
   );
   // store: state
   const currentPage = useViewStore((state) => state.page);
+  const currencyCode = useCurrencyStore((state) => state.currencyCode);
+  const tenantId = useTenantStore((state) => state.tenantConfig.id);
   const singleProject = useSingleProjectStore((state) => state.singleProject);
   const selectedSite = useSingleProjectStore((state) => state.selectedSite);
+  const fetchError = useSingleProjectStore((state) => state.fetchError);
   const selectedIntervention = useInterventionStore(
     (state) => state.selectedIntervention
   );
   // store: action
+  const fetchProject = useSingleProjectStore((state) => state.fetchProject);
   const selectSiteAndSyncUrl = useSingleProjectStore(
     (state) => state.selectSiteAndSyncUrl
   );
   const clearProjectStates = useSingleProjectStore(
     (state) => state.clearProjectStates
   );
+
+  /**
+   * Fetch the project whenever the URL names one.
+   *
+   * This lives here rather than in `ProjectDetails` because that component is
+   * not rendered when the details pane is hidden (`embed=true` with
+   * `project_details=false`), which used to leave the map, interventions and
+   * time travel config with no data at all.
+   *
+   * `router.query.p` is used as the signal rather than `viewStore.page`, since
+   * the page is derived from that same param but only after an effect, and this
+   * fetch should not wait on it.
+   */
+  useEffect(() => {
+    if (!router.isReady) return;
+    if (!isString(projectSlug)) return;
+    if (!currencyCode) return;
+
+    fetchProject(
+      getApi,
+      {
+        queryParams: {
+          _scope: 'extended',
+          currency: currencyCode,
+          //passing locale/tenant as a query param to break cache when locale changes,
+          //as the browser uses the cached response even though the x-locale header is different
+          locale,
+          tenant: tenantId,
+        },
+      },
+      projectSlug
+    );
+  }, [router.isReady, projectSlug, locale, currencyCode, tenantId]);
+
+  // Redirect home if the project fails to load. The store handles the error message, and this prevents an endless loading state.
+  useEffect(() => {
+    if (fetchError) {
+      router.push(localizedPath('/'));
+    }
+  }, [fetchError]);
 
   const projectSites = singleProject?.sites ?? [];
   // A project has no sites if all site geometries are null.

--- a/src/stores/currencyStore.ts
+++ b/src/stores/currencyStore.ts
@@ -72,22 +72,21 @@ export const useCurrencyStore = create<CurrencyStore>()(
       initializeCurrencyCode: () => {
         if (typeof window === 'undefined') return;
 
-        const storedCurrency = localStorage.getItem(
-          'currencyCode'
-        ) as CurrencyCode | null;
-
-        // Nothing stored, so the initial `'EUR'` stands. Still resolved.
-        if (!storedCurrency) {
-          set(
-            { isCurrencyResolved: true },
-            undefined,
-            'currencyStore/currency_code_resolved'
-          );
-          return;
+        let storedCurrency: CurrencyCode | null = null;
+        try {
+          storedCurrency = localStorage.getItem(
+            'currencyCode'
+          ) as CurrencyCode | null;
+        } catch {
+          // Storage can be blocked outright in a cross-origin embed, keep the default currency in this case
         }
 
+        // Resolve either way. Nothing stored, or no readable storage, means the initial `'EUR'` is the answer. Callers gate their fetches on this, so leaving it false would mean never fetching at all.
         set(
-          { currencyCode: storedCurrency, isCurrencyResolved: true },
+          {
+            isCurrencyResolved: true,
+            ...(storedCurrency ? { currencyCode: storedCurrency } : {}),
+          },
           undefined,
           'currencyStore/initialize_currency_code'
         );

--- a/src/stores/currencyStore.ts
+++ b/src/stores/currencyStore.ts
@@ -13,6 +13,16 @@ type CurrencyList = {
 interface CurrencyStore {
   supportedCurrencies: Set<CurrencyCode>;
   currencyCode: CurrencyCode;
+  /**
+   * Whether `currencyCode` has been resolved against `localStorage`.
+   *
+   * `currencyCode` starts at a placeholder `'EUR'`, which is indistinguishable
+   * from a real choice, so callers that key requests on currency must wait for
+   * this rather than reading the code straight away. `initializeCurrencyCode`
+   * sets it in every browser path, including when nothing is stored and the
+   * placeholder turns out to be the answer.
+   */
+  isCurrencyResolved: boolean;
   isFetching: boolean;
 
   fetchSupportedCurrencies: (
@@ -27,6 +37,7 @@ export const useCurrencyStore = create<CurrencyStore>()(
     (set, get) => ({
       supportedCurrencies: new Set<CurrencyCode>(),
       currencyCode: 'EUR',
+      isCurrencyResolved: false,
       isFetching: false,
 
       fetchSupportedCurrencies: async (getApi) => {
@@ -65,10 +76,18 @@ export const useCurrencyStore = create<CurrencyStore>()(
           'currencyCode'
         ) as CurrencyCode | null;
 
-        if (!storedCurrency) return;
+        // Nothing stored, so the initial `'EUR'` stands. Still resolved.
+        if (!storedCurrency) {
+          set(
+            { isCurrencyResolved: true },
+            undefined,
+            'currencyStore/currency_code_resolved'
+          );
+          return;
+        }
 
         set(
-          { currencyCode: storedCurrency },
+          { currencyCode: storedCurrency, isCurrencyResolved: true },
           undefined,
           'currencyStore/initialize_currency_code'
         );

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -92,6 +92,9 @@ export const useProjectStore = create<ProjectStore>()(
         try {
           const projects = await getApi<MapProject[]>('/app/projects', config);
 
+          // Superseded while in flight, so drop the response. Unlike `singleProjectStore`, nothing here throws after the success write, so comparing `pendingFetch` is enough on both settle paths.
+          if (!isSameFetchKey(get().pendingFetch, requested)) return;
+
           set(
             {
               projects,
@@ -105,6 +108,8 @@ export const useProjectStore = create<ProjectStore>()(
             'projectStore/projects_fetch_success'
           );
         } catch (error) {
+          if (!isSameFetchKey(get().pendingFetch, requested)) return;
+
           set(
             {
               isProjectsFetching: false,

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -7,6 +7,17 @@ import { devtools } from 'zustand/middleware';
 import { useErrorHandlingStore } from './errorHandlingStore';
 import { handleError } from '@planet-sdk/common';
 import { getTopProjects } from '../utils/projectV2';
+import { isSameFetchKey } from '../utils/fetchKey';
+
+/**
+ * Conditions a fetched project list depends on. No slug, unlike the single
+ * project key, since there is one list. See `src/utils/fetchKey.ts`.
+ */
+type ProjectsFetchKey = {
+  locale: string;
+  currency: string;
+  tenant: string;
+};
 
 interface ProjectStore {
   projects: MapProject[] | null;
@@ -15,10 +26,13 @@ interface ProjectStore {
   isProjectsFetching: boolean;
   isProjectsError: boolean;
   showDonatableProjects: boolean;
-  /** Locale used when projects were last fetched */
-  projectsLocale: string | null;
-  /** Currency used when projects were last fetched */
-  projectsCurrencyCode: string | null;
+  /**
+   * Conditions of the last successful fetch. `null` when nothing has been
+   * fetched yet or after a failure, so a failed request can always be retried.
+   */
+  lastFetch: ProjectsFetchKey | null;
+  /** Conditions of the request in flight, `null` when idle. */
+  pendingFetch: ProjectsFetchKey | null;
   selectedClassification: TreeProjectClassification[];
   isSearching: boolean;
   /** Debounced search input used to avoid excessive filtering/API calls */
@@ -46,21 +60,32 @@ interface ProjectStore {
  */
 export const useProjectStore = create<ProjectStore>()(
   devtools(
-    (set) => ({
+    (set, get) => ({
       projects: null,
       topProjects: null,
       isProjectsFetching: false,
       isProjectsError: false,
       showDonatableProjects: false,
-      projectsLocale: null,
-      projectsCurrencyCode: null,
+      lastFetch: null,
+      pendingFetch: null,
       selectedClassification: [],
       isSearching: false,
       debouncedSearchValue: '',
 
       fetchProjects: async (getApi, config) => {
+        const { lastFetch, pendingFetch, projects: cached } = get();
+        const requested: ProjectsFetchKey = {
+          locale: String(config.queryParams?.locale ?? ''),
+          currency: String(config.queryParams?.currency ?? ''),
+          tenant: String(config.queryParams?.tenant ?? ''),
+        };
+        // The same request is already in flight.
+        if (isSameFetchKey(pendingFetch, requested)) return;
+        // This exact list is already held.
+        if (isSameFetchKey(lastFetch, requested) && cached !== null) return;
+
         set(
-          { isProjectsFetching: true },
+          { isProjectsFetching: true, pendingFetch: requested },
           undefined,
           'projectStore/projects_fetch_start'
         );
@@ -72,8 +97,8 @@ export const useProjectStore = create<ProjectStore>()(
               projects,
               topProjects: getTopProjects(projects),
               isProjectsFetching: false,
-              projectsLocale: config.queryParams?.locale,
-              projectsCurrencyCode: config.queryParams?.currency,
+              lastFetch: requested,
+              pendingFetch: null,
               isProjectsError: false,
             },
             undefined,
@@ -84,6 +109,8 @@ export const useProjectStore = create<ProjectStore>()(
             {
               isProjectsFetching: false,
               isProjectsError: true,
+              lastFetch: null,
+              pendingFetch: null,
             },
             undefined,
             'projectStore/projects_fetch_fail'

--- a/src/stores/singleProjectStore.ts
+++ b/src/stores/singleProjectStore.ts
@@ -126,11 +126,25 @@ export const useSingleProjectStore = create<SingleProjectStore>()(
           currency: String(config.queryParams?.currency ?? ''),
           tenant: String(config.queryParams?.tenant ?? ''),
         };
-        // The same request is already in flight.
+        // Should this request start at all? An identical one is already running, so do not duplicate it.
         if (isSameFetchKey(pendingFetch, requested)) return;
-        // This exact project is already held.
+        // This exact project is already held, so there is nothing to fetch. The key alone is not enough, the data has to be there too.
         if (isSameFetchKey(lastFetch, requested) && singleProject !== null)
           return;
+
+        /**
+         * Should this request's outcome be applied? Asked after each `await`, so unlike the guards above it is about writing to singleProject, not about starting the fetch.
+         *
+         * - `pendingFetch` matches: still the request in flight
+         * - `lastFetch` matches: already wrote its own success and cleared its `pendingFetch`, and is now later in its own chain. Without this arm its own error would look superseded and be swallowed
+         */
+        const isCurrent = () => {
+          const state = get();
+          return (
+            isSameFetchKey(state.pendingFetch, requested) ||
+            isSameFetchKey(state.lastFetch, requested)
+          );
+        };
 
         set(
           { isFetching: true, fetchError: false, pendingFetch: requested },
@@ -142,6 +156,9 @@ export const useSingleProjectStore = create<SingleProjectStore>()(
             `/app/projects/${projectSlug}`,
             config
           );
+
+          // Superseded while in flight. Otherwise the last response to arrive wins over the last request to start, and the stale key it records then blocks its own correction.
+          if (!isCurrent()) return;
 
           set(
             {
@@ -167,6 +184,9 @@ export const useSingleProjectStore = create<SingleProjectStore>()(
               project.id,
               project.geoLocation
             );
+            // Second await, so check again before writing to the map store.
+            if (!isCurrent()) return;
+
             useProjectMapStore.getState().setTimeTravelConfig(timeTravelConfig);
           } else {
             throw new ClientError(404, {
@@ -175,6 +195,9 @@ export const useSingleProjectStore = create<SingleProjectStore>()(
             });
           }
         } catch (error) {
+          // A superseded request must not raise an error or blank the project.
+          if (!isCurrent()) return;
+
           useErrorHandlingStore
             .getState()
             .setErrors(handleError(error as APIError));
@@ -183,9 +206,7 @@ export const useSingleProjectStore = create<SingleProjectStore>()(
               fetchError: true,
               isFetching: false,
               singleProject: null,
-              // Reset so the same project can be retried. The purpose check
-              // sits below the success write, so `lastFetch` may already hold
-              // this key by the time we get here.
+              // Reset so a retry is possible. The purpose check throws below the success write, so this key may already be recorded.
               lastFetch: null,
               pendingFetch: null,
             },

--- a/src/stores/singleProjectStore.ts
+++ b/src/stores/singleProjectStore.ts
@@ -136,13 +136,14 @@ export const useSingleProjectStore = create<SingleProjectStore>()(
          * Should this request's outcome be applied? Asked after each `await`, so unlike the guards above it is about writing to singleProject, not about starting the fetch.
          *
          * - `pendingFetch` matches: still the request in flight
-         * - `lastFetch` matches: already wrote its own success and cleared its `pendingFetch`, and is now later in its own chain. Without this arm its own error would look superseded and be swallowed
+         * - nothing pending and `lastFetch` matches: already wrote its own success and cleared its `pendingFetch`, and is now later in its own chain. Without this arm its own error would look superseded and be swallowed. The `null` check matters: a newer request can start during the time travel await, and this call must not write once it has
          */
         const isCurrent = () => {
           const state = get();
           return (
             isSameFetchKey(state.pendingFetch, requested) ||
-            isSameFetchKey(state.lastFetch, requested)
+            (state.pendingFetch === null &&
+              isSameFetchKey(state.lastFetch, requested))
           );
         };
 

--- a/src/stores/singleProjectStore.ts
+++ b/src/stores/singleProjectStore.ts
@@ -14,9 +14,29 @@ import {
   buildProjectDetailsQuery,
   getSiteIdFromIndex,
 } from '../utils/projectV2';
+import { isSameFetchKey } from '../utils/fetchKey';
+
+/**
+ * Conditions a fetched project depends on. Includes the slug, since a session
+ * moves between projects. See `src/utils/fetchKey.ts`.
+ */
+type SingleProjectFetchKey = {
+  slug: string;
+  locale: string;
+  currency: string;
+  tenant: string;
+};
 
 interface SingleProjectStore {
   singleProject: ExtendedProject | null;
+  /**
+   * Conditions of the last successful fetch. `null` when nothing has been
+   * fetched yet, after a failure, or after `clearProjectStates`, so a failed
+   * request can always be retried.
+   */
+  lastFetch: SingleProjectFetchKey | null;
+  /** Conditions of the request in flight, `null` when idle. */
+  pendingFetch: SingleProjectFetchKey | null;
   /**
    * Index of the currently selected site in `singleProject.sites`.
    * `null` indicates no site is selected.
@@ -90,6 +110,8 @@ export const useSingleProjectStore = create<SingleProjectStore>()(
   devtools(
     (set, get) => ({
       singleProject: null,
+      lastFetch: null,
+      pendingFetch: null,
       selectedSite: null,
 
       // status flags
@@ -97,8 +119,21 @@ export const useSingleProjectStore = create<SingleProjectStore>()(
       fetchError: false,
 
       fetchProject: async (getApi, config, projectSlug) => {
+        const { lastFetch, pendingFetch, singleProject } = get();
+        const requested: SingleProjectFetchKey = {
+          slug: projectSlug,
+          locale: String(config.queryParams?.locale ?? ''),
+          currency: String(config.queryParams?.currency ?? ''),
+          tenant: String(config.queryParams?.tenant ?? ''),
+        };
+        // The same request is already in flight.
+        if (isSameFetchKey(pendingFetch, requested)) return;
+        // This exact project is already held.
+        if (isSameFetchKey(lastFetch, requested) && singleProject !== null)
+          return;
+
         set(
-          { isFetching: true, fetchError: false },
+          { isFetching: true, fetchError: false, pendingFetch: requested },
           undefined,
           'singleProjectStore/project_fetch_start'
         );
@@ -111,6 +146,8 @@ export const useSingleProjectStore = create<SingleProjectStore>()(
           set(
             {
               singleProject: project,
+              lastFetch: requested,
+              pendingFetch: null,
               isFetching: false,
             },
             undefined,
@@ -146,6 +183,11 @@ export const useSingleProjectStore = create<SingleProjectStore>()(
               fetchError: true,
               isFetching: false,
               singleProject: null,
+              // Reset so the same project can be retried. The purpose check
+              // sits below the success write, so `lastFetch` may already hold
+              // this key by the time we get here.
+              lastFetch: null,
+              pendingFetch: null,
             },
             undefined,
             'singleProjectStore/project_fetch_error'
@@ -220,6 +262,8 @@ export const useSingleProjectStore = create<SingleProjectStore>()(
         set(
           {
             singleProject: null,
+            lastFetch: null,
+            pendingFetch: null,
             selectedSite: null,
             fetchError: false,
           },

--- a/src/utils/fetchKey.ts
+++ b/src/utils/fetchKey.ts
@@ -1,0 +1,23 @@
+/**
+ * Helpers for de-duplicating store fetches.
+ *
+ * A fetch key records the conditions a response depends on, so a store can tell
+ * whether a request would return what it already holds. Stores keep two of them:
+ * one for the request in flight, one for the last successful fetch. Two are
+ * needed because a boolean `isFetching` flag says that a request is running, not
+ * which one, so it cannot distinguish a duplicate call from a legitimate fetch
+ * for different conditions.
+ */
+
+/** Conditions a fetched response depends on. Values are compared with `===`. */
+export type FetchKey = Record<string, string>;
+
+/**
+ * Whether `a` records the same conditions as `b`. A `null` `a` means nothing has
+ * been fetched, or nothing is in flight, and never matches.
+ */
+export const isSameFetchKey = <T extends FetchKey>(
+  a: T | null,
+  b: T
+): boolean =>
+  a !== null && (Object.keys(b) as Array<keyof T>).every((k) => a[k] === b[k]);


### PR DESCRIPTION
## Problem

Embeds that hide the details pane render an empty map. No project or intervention request is made at all.

`/en/proj_WZkyugryh35sMmZMmXCwq7YY?embed=true&project_details=false&locale=en`

Regression from #2857. Affects desktop and mobile.

Fixes #3010 

## Cause

The project fetch lived inside `ProjectDetails`, the very component that `project_details=false` is designed to hide, and it was the only API call site in the details subtree.

That combination used to work by accident. Before #2857, `page` was a synchronous prop, so for exactly one render the layout gate was true while `embed` was still undefined. `ProjectDetails` mounted, its effect fired, and the data outlived the unmount. #2857 moved `page` into a store where it starts as `null`, closing that one render window and taking the fetch with it.

Lost with it: interventions, the time travel config, the error redirect for a bad slug, and the `backNavigationUrl` write.

## Changes

- Move the project fetch and its error redirect into `useInitializeSingleProject`, which runs above the layout gate for the whole page lifetime. It keys on the `p` route param rather than the asynchronously derived page, so it does not wait a render
- Move the `backNavigationUrl` session write into `useInitializeParams`, alongside the other query param handling
- De-duplicate fetches in both project stores on locale, currency, tenant and, for a single project, slug, so the new call site cannot fetch repeatedly
- Discard responses from superseded requests, so a slow earlier response cannot overwrite newer data or report a stale error
- Wait for the real currency before fetching. `currencyCode` starts at a placeholder `EUR` that is replaced once `localStorage` is read, which was causing a second request with a different currency
- Reduce `ProjectDetails` to a presenter

## Testing

Tested by hand on desktop and mobile. Each case checks the **network tab**, not just the screen, because the bug was a request that never happened.

**The embed that was broken**

- [x] Project page with `embed=true&project_details=false`: the project and intervention requests now fire, and interventions/sites appear on the map with no details pane
- [x] Same URL with `ploc=<id>`: the intervention is preselected
- [x] Same URL with `site=<id>`: the site is preselected and zoomed
- [x] Time travel works in embed mode. Its config was also missing before

**Nothing else changed**

- [x] Normal project page: works as before, and makes exactly one project request instead of two
- [x] List embed, `?embed=true&project_list=false`: still works. This path was already correct
- [x] Project page with a bad project slug and the project details hidden: redirects to home instead of showing a loading skeleton forever

**Edge cases**

- [x] A project whose sites have no geometry: the URL does not update in a loop, and the browser back button still leaves the page
- [x] Currency: with `localStorage.currencyCode` set, with it cleared, and when changing currency in the UI. One request each time, using the currency actually shown (in UI)
- [x] Storage blocked: the app inside a cross-origin iframe in an incognito window, where the browser blocks storage for embeds. It loads and falls back to EUR. Before this change it never loaded, because reading `localStorage` threw an error

## Follow-ups, not in this PR

- Deriving the page synchronously from `router.pathname` would remove this class of bug rather than route around it. Scoped separately, since it changes what gets server rendered on project routes and needs the details subtree audited for render time browser API access first (Issue #3012)
- First visit currency ignores the geo config until a reload, because `storeConfig` writes `localStorage` but never the store. Pre-existing and app wide (Issue #3013)
