### PR TITLE
Fix localStorage language writer

### DIFF
--- a/src/features/common/StoreInitializer/StoreInitializer.tsx
+++ b/src/features/common/StoreInitializer/StoreInitializer.tsx
@@ -7,6 +7,7 @@ import { useInitializeIntervention } from '../../../hooks/useInitializeIntervent
 import { useInitializeView } from '../../../hooks/useInitializeView';
 import { useInitializeSingleProject } from '../../../hooks/useInitializeSingleProject';
 import { useInitializeTenant } from '../../../hooks/useInitializeTenant';
+import { useInitializeLanguage } from '../../../hooks/useInitializeLanguage';
 
 interface StoreInitializerProps {
   tenantConfig?: Tenant;
@@ -31,6 +32,7 @@ export const StoreInitializer = ({
 }: StoreInitializerProps) => {
   useInitializeTenant(tenantConfig);
   useInitializeParams();
+  useInitializeLanguage(); // Sync route locale to legacy localStorage readers.
   useInitializeCurrency();
   useInitializeView(isMobile);
   useInitializeProject();

--- a/src/hooks/useInitializeLanguage.ts
+++ b/src/hooks/useInitializeLanguage.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocale } from 'next-intl';
+
+export const useInitializeLanguage = () => {
+  const locale = useLocale();
+
+  useEffect(() => {
+    if (localStorage.getItem('language') !== locale) {
+      localStorage.setItem('language', locale);
+    }
+  }, [locale]);
+};


### PR DESCRIPTION
Fixes #3015.

Restore the functionality to synchronize the application's language setting with localStorage. This change ensures that the language preference is correctly stored and updated based on the current locale. 

This makes sure that legacy readers of localStorage.language get the correct value, fixing 
- the missing locale in donation links
- Auth0 screens always appearing in English
- Dates appearing in English format

This is a minimal fix for the immediate issue.

Left for later
- migrating away from localStorage.language across the app, 
- minor issues in refreshing date format when language is changed (due to conflicts with current WIP like #2837, #2989)

## Changes in this pull request:

- Added a custom hook to manage language synchronization with localStorage.
- Integrated the language initialization into the StoreInitializer component.

