### PR TITLE
fix(404): pass tenantConfig to Footer on 404 page

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -4,6 +4,7 @@ import type {
   GetStaticPropsResult,
 } from 'next';
 import type { AbstractIntlMessages } from 'next-intl';
+import type { Tenant } from '@planet-sdk/common';
 
 import Custom404Image from '../public/assets/images/Custom404Image';
 import Head from 'next/head';
@@ -11,6 +12,7 @@ import { useRouter } from 'next/router';
 import { useTranslations } from 'next-intl';
 import Footer from '../src/features/common/Layout/Footer';
 import getMessagesForPage from '../src/utils/language/getMessagesForPage';
+import { defaultTenant } from '../tenant.config';
 
 interface Props {
   pageProps: PageProps;
@@ -49,6 +51,7 @@ export default function Custom404({ pageProps }: Props) {
 
 interface PageProps {
   messages: AbstractIntlMessages;
+  tenantConfig: Tenant;
 }
 
 export const getStaticProps: GetStaticProps<PageProps> = async (
@@ -62,6 +65,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async (
   return {
     props: {
       messages,
+      tenantConfig: defaultTenant,
     },
   };
 };


### PR DESCRIPTION
Fixes #3004
## Title

fix: pass `tenantConfig` to Footer on 404 page

## Summary

The root 404 page (`pages/404.tsx`) rendered blank because `Footer` requires a `tenantConfig` prop, but the page’s `getStaticProps` did not provide one.

This change adds `tenantConfig: defaultTenant` to the page’s static props, matching how other pages supply it.

## Changes

* Add the `Tenant` type import from `@planet-sdk/common`
* Import `defaultTenant` from `tenant.config`
* Add `tenantConfig` to `PageProps`
* Return `tenantConfig` from `getStaticProps`

## Test Plan

* Visit an unknown route, such as `/some-random-path`, and confirm the 404 page renders with the Footer instead of appearing blank
* Confirm the Footer content and links load correctly on the 404 page
