### PR TITLE
fix(currency): resolve geo-detected currency without a reload

### DIFF
--- a/src/hooks/useInitializeSingleProject.ts
+++ b/src/hooks/useInitializeSingleProject.ts
@@ -72,8 +72,9 @@ export const useInitializeSingleProject = () => {
    *
    * It does wait on `isCurrencyResolved`, because `currencyCode` starts at a
    * placeholder that would otherwise be fetched with and then immediately
-   * superseded. Waiting here cannot stall: `initializeCurrencyCode` runs
-   * unconditionally on mount in the browser and resolves in every path.
+   * superseded. Waiting here cannot stall: it resolves either immediately from
+   * a stored value, or once `storeConfig`'s geo lookup settles (success or
+   * failure), which always runs when this hook does.
    */
   useEffect(() => {
     if (!router.isReady) return;

--- a/src/hooks/useInitializeTenant.ts
+++ b/src/hooks/useInitializeTenant.ts
@@ -6,16 +6,21 @@ import { storeConfig } from '../utils/storeConfig';
 
 export const useInitializeTenant = (tenantConfig: Tenant | undefined) => {
   const setTenantConfig = useTenantStore((state) => state.setTenantConfig);
-  const isInitialized = useTenantStore((state) => state.isInitialized);
 
   useEffect(() => {
     if (!tenantConfig) return;
     // Prevent re-initializing the tenant store on re-renders or client-side route changes.
     // Tenant config should be set only once per app lifecycle.
-    if (isInitialized) return;
+    //
+    // Read live state rather than a subscribed snapshot: React's Strict Mode
+    // double-invokes an effect on mount against that same render's closure, so a
+    // snapshot `isInitialized` would still read `false` on the second invocation
+    // even though `setTenantConfig` already flipped it during the first. That
+    // let `storeConfig` fire twice, racing two geo lookups against each other.
+    if (useTenantStore.getState().isInitialized) return;
 
     storeConfig(tenantConfig);
 
     setTenantConfig(tenantConfig);
-  }, [tenantConfig, setTenantConfig, isInitialized]);
+  }, [tenantConfig, setTenantConfig]);
 };

--- a/src/stores/currencyStore.ts
+++ b/src/stores/currencyStore.ts
@@ -14,13 +14,17 @@ interface CurrencyStore {
   supportedCurrencies: Set<CurrencyCode>;
   currencyCode: CurrencyCode;
   /**
-   * Whether `currencyCode` has been resolved against `localStorage`.
+   * Whether `currencyCode` is settled and safe to key requests on.
    *
    * `currencyCode` starts at a placeholder `'EUR'`, which is indistinguishable
    * from a real choice, so callers that key requests on currency must wait for
-   * this rather than reading the code straight away. `initializeCurrencyCode`
-   * sets it in every browser path, including when nothing is stored and the
-   * placeholder turns out to be the answer.
+   * this rather than reading the code straight away. It becomes `true` as soon
+   * as one of these settles: a stored `localStorage` value (`initializeCurrencyCode`),
+   * an explicit user selection (`setCurrencyCode`), or the geo-lookup piggybacked
+   * on the tenant config fetch, success or failure (`resolveGeoCurrencyCode`,
+   * called from `storeConfig`). On a first visit with nothing stored, this stays
+   * `false` until the geo lookup settles, so no request goes out with the EUR
+   * placeholder.
    */
   isCurrencyResolved: boolean;
   isFetching: boolean;
@@ -30,6 +34,7 @@ interface CurrencyStore {
   ) => void;
   setCurrencyCode: (code: CurrencyCode) => void;
   initializeCurrencyCode: () => void;
+  resolveGeoCurrencyCode: (code: CurrencyCode | null) => void;
 }
 
 export const useCurrencyStore = create<CurrencyStore>()(
@@ -67,7 +72,12 @@ export const useCurrencyStore = create<CurrencyStore>()(
         }
       },
 
-      setCurrencyCode: (code) => set({ currencyCode: code }),
+      setCurrencyCode: (code) =>
+        set(
+          { currencyCode: code, isCurrencyResolved: true },
+          undefined,
+          'currencyStore/set_currency_code'
+        ),
 
       initializeCurrencyCode: () => {
         if (typeof window === 'undefined') return;
@@ -78,17 +88,33 @@ export const useCurrencyStore = create<CurrencyStore>()(
             'currencyCode'
           ) as CurrencyCode | null;
         } catch {
-          // Storage can be blocked outright in a cross-origin embed, keep the default currency in this case
+          // Storage can be blocked outright in a cross-origin embed. `resolveGeoCurrencyCode`
+          // still resolves this to the default once `storeConfig`'s fetch settles.
         }
 
-        // Resolve either way. Nothing stored, or no readable storage, means the initial `'EUR'` is the answer. Callers gate their fetches on this, so leaving it false would mean never fetching at all.
+        // Resolve immediately only when a stored or explicitly selected currency exists.
+        // Otherwise, wait for `resolveGeoCurrencyCode` to avoid using the EUR placeholder.
+        if (!storedCurrency) return;
+
+        set(
+          { isCurrencyResolved: true, currencyCode: storedCurrency },
+          undefined,
+          'currencyStore/initialize_currency_code'
+        );
+      },
+
+      resolveGeoCurrencyCode: (code) => {
+        // A stored value or an explicit selection already resolved this in the
+        // meantime, the geo lookup is stale and must not override it.
+        if (get().isCurrencyResolved) return;
+
         set(
           {
             isCurrencyResolved: true,
-            ...(storedCurrency ? { currencyCode: storedCurrency } : {}),
+            ...(code ? { currencyCode: code } : {}),
           },
           undefined,
-          'currencyStore/initialize_currency_code'
+          'currencyStore/resolve_geo_currency_code'
         );
       },
     }),

--- a/src/utils/storeConfig.ts
+++ b/src/utils/storeConfig.ts
@@ -1,9 +1,13 @@
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
+import type { CurrencyCode } from '@planet-sdk/common';
 
 import getsessionId from './apiRequests/getSessionId';
 import countriesData from '../utils/countryCurrency/countriesData.json';
+import { useCurrencyStore } from '../stores/currencyStore';
 
 export async function storeConfig(tenantConfig: Tenant) {
+  const { resolveGeoCurrencyCode } = useCurrencyStore.getState();
+
   await fetch(`${process.env.CONFIG_URL}`, {
     headers: {
       'tenant-key': `${tenantConfig?.id}`,
@@ -26,11 +30,23 @@ export async function storeConfig(tenantConfig: Tenant) {
           localStorage.setItem('countryCode', 'DE');
         }
       }
-      if (!localStorage.getItem('currencyCode')) {
-        localStorage.setItem('currencyCode', config.currency);
+
+      // Piggyback on this same fetch for the geo-detected currency rather than
+      // firing a second request. Only used when nothing is stored yet; a
+      // stored or explicitly selected currency always takes precedence.
+      let geoCurrencyCode: CurrencyCode | null = null;
+      if (!localStorage.getItem('currencyCode') && config.currency) {
+        geoCurrencyCode = config.currency as CurrencyCode;
+        localStorage.setItem('currencyCode', geoCurrencyCode);
       }
+      resolveGeoCurrencyCode(geoCurrencyCode);
     })
-    .catch((err) => console.log(`Something went wrong: ${err}`));
+    .catch((err) => {
+      console.log(`Something went wrong: ${err}`);
+      // A missing/failed geo response must still unblock currency-dependent
+      // requests, falling back to the default currency rather than stalling.
+      resolveGeoCurrencyCode(null);
+    });
 }
 
 export function getStoredConfig(key: string) {


### PR DESCRIPTION
## Summary

Fixes first-visit currency initialization so the geo-detected currency is applied without requiring a page reload.

Previously, when no `localStorage.currencyCode` existed, the currency store marked the default EUR value as resolved before the geo lookup completed. As a result, all currency-dependent requests used EUR until the next page load.

This PR keeps currency resolution pending until either:

* A stored or explicitly selected currency is available
* The geo-currency lookup completes successfully or fails

The geo currency is resolved through the existing tenant configuration request, avoiding an additional network request.

## Changes

* Keep `isCurrencyResolved` false when no stored currency is available
* Add `resolveGeoCurrencyCode` to complete currency resolution after the geo lookup settles
* Reuse the tenant configuration request for geo-currency detection
* Preserve stored and explicitly selected currencies
* Mark currency resolution complete even when the geo lookup fails
* Update `useInitializeTenant` to read the latest tenant store state
* Prevent duplicate `storeConfig` calls caused by React Strict Mode’s double-invoked mount effect
* Avoid races between multiple geo-currency lookups

## Expected Behavior

On a first visit with no stored currency:

1. Currency-dependent requests wait for currency resolution
2. The tenant configuration request returns the geo-detected currency
3. Prices and donations render using that currency
4. No page reload or second geo request is required

If a stored or explicitly selected currency exists, it continues to take precedence.

## Test Plan

* Clear `localStorage.currencyCode` and load the site from a non-eurozone location
* Confirm the initial currency-dependent requests use the geo-detected currency instead of EUR
* Confirm prices and donations display correctly without reloading
* Refresh the page and confirm the currency remains unchanged
* Set a currency manually and confirm it is not overwritten by the geo currency
* Confirm a stored currency resolves immediately
* Simulate a failed geo lookup and confirm the application does not remain stuck in a loading state
* Run the application in React Strict Mode and confirm `storeConfig` is called only once
* Confirm no duplicate currency-dependent requests or geo lookups occur

## Related Issue

Closes #3013
