### PR TITLE
Add review process and testing roadmaps documentation

### DIFF
--- a/docs/plans/review-process-roadmap.md
+++ b/docs/plans/review-process-roadmap.md
@@ -1,0 +1,166 @@
+# Review process roadmap
+
+A playbook you can use now on any PR, plus a roadmap of tooling and author-side changes to
+build later. Tests are large enough to sit in their own doc: see
+[testing-roadmap.md](./testing-roadmap.md).
+
+> Status: roadmap. The playbook below is usable now; the tooling and PR-splitting items are not
+> built yet.
+
+## Where this came from
+
+Written after reviewing a large Context to Zustand migration (108 files, PR 2837). The review
+was solid but slow. This doc keeps what worked (a deep read of the risky files) and fixes what
+was slow: manual origin checks, hand renumbering, style rules that surfaced late, a large tail
+that went unreviewed, and no tests. It is written to fit any PR, not just that migration. The
+running second example is a feature PR, the shadcn Payments hub (#2989, 82 files, targets
+`feature/shadcn-base`).
+
+## The playbook (use now, any PR)
+
+### 1. Pick the diff base
+
+Measure everything against the PR's target branch, not always `develop`. The migration in #2837
+targeted `develop`; #2989 targets `feature/shadcn-base`. "What changed" and origin are all
+relative to that base.
+
+### 2. Tier by risk, spend time top-heavy
+
+Rank changed files by how much damage a bug would do, then read in that order:
+
+- Tier 1: shared state and data flow (stores, hooks, context, fetching, caching).
+- Tier 2: security and money (auth, permissions, payments, PII, headers).
+- Tier 3: fresh decisions (genuinely new logic, merge-conflict resolutions, removed or replaced
+  code paths).
+- Tier 4: gated consumers (screens that read the above but sit behind a gate).
+- Tier 5: rote changes (renames, mechanical swaps). Skim as a group.
+
+Deep-walk Tiers 1 to 3. Set the tier contents per PR. For #2989: Tier 1 is the payments data
+hooks and the filter/deep-link state; Tier 2 is payment-method remove and the auth gate;
+Tier 3 is the removed `/profile/history` and `/recurrency` pages and the PlanetCash redirect.
+
+### 3. Classify origin (mainly for refactors and ports)
+
+For each finding ask: Regression (this PR broke it), Pre-existing (inherited), or New (this
+PR's own new code). This matters most for refactors, ports, and migrations. For a greenfield
+feature PR, the useful version is: "what existing behavior does this change or remove, and is
+that intended?"
+
+Evidence commands (base = the target branch):
+
+- exists on base? `git show <base>:<file>`
+- what changed: `git diff <base>...HEAD -- <file>`
+- who introduced a line: `git log -S "<snippet>"`
+
+Moved code (important): when a PR moves code between files (the migration moved context into
+the store), diffing the same path shows nothing useful, because the new path has no history on
+the base. Handle it one of two ways:
+
+- compare the new file against the OLD file by its old path: `git show <base>:<oldpath>`
+  against the new file;
+- or use `git log -S "<snippet>"`, which finds where a line came from regardless of file.
+
+### 4. Split coverage: deep read plus parallel tail
+
+Deep-walk Tiers 1 to 3 by hand. In parallel, send review agents across the Tier 4 to 5 tail so
+it does not go unreviewed (the migration review never reached that tail). Verify each agent
+finding against the diff (exact file and line, observed behavior) and drop the ones you cannot
+confirm; agent findings include false positives, so this check comes before they reach the
+author. Then merge and dedupe the rest into the same list. This adds coverage; it does not
+replace the deep read.
+
+### 5. Findings doc: one number each, assigned once
+
+Each finding: number, one-line title, `file:line`, severity, origin tag, action tag, why it
+matters. Assign numbers once, in reading order, after the first full draft. Do not renumber by
+hand while drafting. If you must reorder later, use the renumber helper (see Tooling below).
+
+### 6. Style contract
+
+- simple, short English;
+- avoid words with more than one reading (for example "invariant"); say the plain meaning;
+- no shorthand labels in the doc (for example "E3/E4");
+- drop extra qualifiers ("honest", "basically", "just", "actually");
+- avoid em dash;
+- only edit `en` locale files.
+
+## What the review produces (output docs)
+
+One doc is always produced; the rest are situational, scaled to the PR.
+
+- Findings doc (always): the numbered findings from step 5, grouped P1 then P2. This is what
+  goes to the author. Example name: `<pr>-review-points.md`.
+- Self-review guide (large PRs): a tiered, file-by-file map so the author/reviewer can manually
+  review the PR, with where to spend time and what to check per file. Example:
+  `<pr>-self-review-guide.md`.
+- Architecture notes and diagrams (shape-level PRs): when the PR has design problems that span
+  files, a short notes section plus Mermaid diagrams of the current and target shape. Example:
+  `<pr>-architecture-diagram.md`.
+- Migration reference (ports and migrations only): a table of what moved where, to check the
+  port is faithful. Example: `<pr>-values-moved.md`.
+
+Where these live is the team's call. Keep them in `docs/reviews/` while reviewing, but do not
+commit the findings. Before the PR merges, convert what remains into issues or plan documents
+and close out the rest, so the findings do not ship in the repo.
+
+## Tooling to build later
+
+Small helpers that remove the repeated manual steps. None exist in the repo today (confirmed:
+no `.claude/` commands or skills, one repo script, `npm run lint` plus eslint/Cypress CI).
+
+### origin helper
+
+Prints the origin evidence for a file in one call: merge-base, exists-on-base, diff against
+base, and an optional `git log -S` snippet search. Two modes:
+
+- same-file: `origin <file>`
+- moved code: `origin <newfile> --old <oldpath>`, since moved code has no history at the new
+  path.
+
+Build it in Node to match the repo stack (the throwaway version used during the migration
+review was Python). Default the base to the branch's PR target.
+
+### renumber helper
+
+Reads the findings doc, numbers findings by reading order, and updates every `#N` and
+`point N` reference across the review docs. Protects non-finding hashes: hex colors, PR
+numbers, and phrases like "merge conflict #N". Node, same reason. (The migration-review version
+was a throwaway Python script.)
+
+### review slash command
+
+A `.claude/commands/review-pr.md` that runs the playbook end to end: pick base, tier the
+files, fan out the tail agents, deep-walk Tiers 1 to 3, call the origin helper per finding, and
+run the renumber helper before finishing.
+
+## Author-side: split large PRs
+
+The root cause of slow reviews is PR size. For large refactors and migrations, ship a stack of
+review-sized PRs instead of one blob. Pattern for a Context to store move: stand the new store
+up next to the old context, migrate consumers in groups, delete the old context last. Add one
+line to `.github/pull_request_template.md` pointing large or migration PRs here.
+
+## Refining this over time
+
+Treat this as a living doc. After each review, note what worked and what slowed you down, and
+propose changes here, so the process improves review to review rather than staying fixed.
+
+Before adopting a change that affects how the whole team reviews (the tiers, the style
+contract, the output-doc policy, what gets committed, or tooling behavior), check whether the
+team has been consulted, or needs to be. A personal workflow tweak can just be adopted; a
+shared-process change needs team sign-off first. State which kind each proposed change is.
+
+## Tasks (build backlog)
+
+The playbook above is usable now with no build. These make it faster. The slash command depends
+on the two helpers. See the sections above for detail.
+
+- [ ] PR template: add a line to `.github/pull_request_template.md` pointing large or migration
+      PRs to the splitting pattern above.
+- [ ] origin helper (Node): `origin <file>` and `origin <newfile> --old <oldpath>`; prints
+      merge-base, exists-on-base, diff against base, and an optional `git log -S`; default the
+      base to the PR target.
+- [ ] renumber helper (Node): number findings by reading order; update `#N` and `point N`
+      references across the review docs; protect hex colors, PR numbers, and "merge conflict #N".
+- [ ] review slash command `.claude/commands/review-pr.md`: run the playbook end to end (uses
+      the two helpers).

--- a/docs/plans/testing-roadmap.md
+++ b/docs/plans/testing-roadmap.md
@@ -1,0 +1,108 @@
+# Testing roadmap
+
+Tests are the highest-leverage way to make reviews faster, and the repo has no reliable
+automated tests today (the Cypress suite is broken and needs migration or retirement). This is
+a separate, larger track. It supports the review process in
+[review-process-roadmap.md](./review-process-roadmap.md). It can start small.
+
+> Status: roadmap. Nothing here is built yet; start with the quick wins.
+
+## Why this exists
+
+The deepest cause of slow reviews is that the repo has no working automated tests, so every
+"behavior preserved" claim is proven by hand. This compounds with PR size.
+
+## How tests cut review time
+
+Review time goes into two things a test can replace:
+- proving a refactor kept behavior (the migration review diffed new against old, file by file);
+- confirming a claim by manual repro (log in, redeem twice, watch the balance).
+
+A green suite on the risky logic lets a reviewer trust both instead of re-deriving them. CI
+gating (typecheck plus tests) moves a class of issues out of review entirely.
+
+## What to test, by payoff (not by coverage percent)
+
+Target the risk map, not a coverage number. In order:
+1. Pure logic and store actions (highest payoff, lowest effort). For this codebase:
+   `userStore` actions (fetch success and each error branch, enter and exit impersonation, the
+   refetch trigger), `setHeader.ts` (malformed JSON, the localStorage fallback, param
+   precedence), `validateToken.ts` (expired vs valid). These are where the real findings were,
+   and they need little or no React.
+2. Init hooks (timing and gates): `useInitializeUser`, `useInitializeAuth`,
+   `useProfileErrorHandler`, tested with `renderHook` (from `@testing-library/react`) and mocked
+   Auth0, router, and fetch. The gate and redirect logic where the subtle bugs live.
+3. Page and component render (integration): tests "the page renders without crashing and shows
+   the expected content," given seeded state. Needs a shared `renderWithProviders` helper that
+   mocks `next/router`, wraps next-intl messages, mocks Auth0 (`useAuth0`), seeds the zustand
+   stores, and stubs `useApi`/fetch with fixtures. Build the helper once; each page test is
+   cheap after. This is where the render-gate and null-profile bugs from the review would be
+   caught (render with `userProfile: null` vs set). It tests the client render only, not SSR,
+   `getServerSideProps`, routing, or middleware. Feasible, but do it after the priority 1 and 2
+   wins.
+4. End-to-end (a real browser at a URL): highest fidelity, highest cost. Needs a running app, a
+   way through Auth0 login (programmatic token injection, not driving the login UI), backend
+   data or network stubbing, and tenant and env config. Prefer Playwright over reviving the
+   broken Cypress suite. Reserve it for a few critical-path smoke flows, not many pages. Defer.
+
+Test behavior, not implementation (assert outcomes, not internal calls), so tests survive the
+next refactor, which is the whole point.
+
+## Quick wins to get the ball rolling (does not need to be perfect)
+
+1. Stand up the runner. Add vitest and jsdom (jsdom gives tests a browser environment, so
+   `localStorage` and `window` work); add `test`, `test:watch`, and `typecheck` (`tsc --noEmit`)
+   scripts and a minimal `vitest.config.ts` (set `environment: 'jsdom'` in it, since vitest
+   defaults to a node environment). Prove the pipe with one passing test. Vitest fits
+   Next pages-router and TS, runs fast, and uses its own build, so it will not disturb the
+   pinned webpack. Add `@testing-library/react` later, only when you start the hook tests
+   (priority 2 above); the pure-logic tests do not need it.
+2. First real tests on pure logic: `validateToken.ts`, then `setHeader.ts`, then the `userStore`
+   actions. Fast green, little mocking.
+3. Turn findings into tests. A review finding becomes a regression test: what was found by hand
+   becomes a guard for next time. Two concrete examples from the migration review:
+   - Refetch runs only once: a boolean refetch flag never resets, so a second refetch is a
+     no-op. Test: trigger the refetch twice and assert the fetch fires both times.
+   - Redirect-loop guard never trips: the counter resets on the full-page redirect, so it never
+     reaches the limit. Test: remount the hook to model the redirect and assert the guard trips
+     at the limit.
+4. A CI job running typecheck plus tests. Start it non-blocking, then make it required once it is
+   stable. Caveat for typecheck: `next.config.js` sets `ignoreBuildErrors: true` and the codebase
+   reports many `tsc --noEmit` errors today, so a typecheck gate cannot demand zero errors on day
+   one. Baseline the current errors (block new ones) or fix them first; keep typecheck
+   non-blocking until then.
+
+Dependency on the migration (PR 2837, the zustand user migration reviewed here): the harness and
+the `validateToken` and `setHeader` tests can land on `develop` now, since those files already
+exist there. The `userStore`, `authStore`, and init-hook tests target files that 2837 creates,
+so they need 2837 merged first, or must be written on top of the migration branch. 2837 lists
+testability as a goal, so those tests can ride with it or follow right after it merges.
+
+Then, separately, decide the fate of Cypress (migrate per `cypress/MIGRATION_NEEDED.md`, or
+retire it) so the CI signal is honest.
+
+## Keep it effective
+
+- Risk-first, not coverage-first.
+- Behavior over implementation.
+- For a refactor or migration, write characterization tests first (pin current behavior) so the
+  port is provable by a green run instead of a line-by-line read.
+- When a finding is verified by manual repro, note what to test and how in the finding, so it is
+  ready to write once the harness lands.
+
+## Tasks (quick wins first)
+
+Ordered. Items marked "needs 2837" depend on the migration (PR 2837) landing first, since they
+target files that PR creates. See the sections above for detail.
+
+- [ ] Stand up the runner: vitest + jsdom, `test` / `test:watch` / `typecheck` scripts,
+      `vitest.config.ts`, one passing test.
+- [ ] Pure-logic tests: `validateToken.ts`, then `setHeader.ts`.
+- [ ] CI job: run typecheck + tests. Keep typecheck non-blocking until the existing `tsc`
+      errors are baselined or fixed.
+- [ ] Store tests (needs 2837): `userStore` actions, `authStore`.
+- [ ] Add `@testing-library/react`; init-hook tests (needs 2837): `useInitializeUser`,
+      `useInitializeAuth`, `useProfileErrorHandler`.
+- [ ] `renderWithProviders` helper, then page render tests.
+- [ ] Decide Cypress: migrate (per `cypress/MIGRATION_NEEDED.md`) or retire.
+- [ ] Later: Playwright for a few critical-path end-to-end smoke flows.


### PR DESCRIPTION
This pull request introduces two new roadmap documents outlining plans to improve the pull request review process and to establish a testing strategy for the codebase. These documents provide actionable playbooks, identify tooling and process gaps, and lay out concrete tasks to streamline reviews and add automated tests.

**Review process improvements:**

* Added a comprehensive playbook for reviewing pull requests, including risk-based file tiering, origin classification, and guidelines for findings documentation and style.
* Outlined future tooling to automate origin tracking, findings renumbering, and an end-to-end review slash command, with a task backlog for implementation.
* Provided recommendations for splitting large PRs and maintaining the review process as a living document.

**Testing strategy:**

* Introduced a testing roadmap focused on high-payoff, risk-first testing rather than coverage percentage, with a staged approach starting from pure logic to end-to-end tests.
* Listed quick-win tasks to bootstrap testing (e.g., setting up Vitest, adding initial tests, integrating CI), and addressed dependencies on an ongoing migration PR.

These documents serve as guides for both immediate process improvements and longer-term automation and testing goals.