### PR TITLE
fix: move AddressManagement guard below hooks

### DIFF
--- a/src/features/user/Settings/EditProfile/AddressManagement/index.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/index.tsx
@@ -25,9 +25,6 @@ import { useUserStore } from '../../../../../stores';
 const AddressManagement = () => {
   // store: state
   const userAddresses = useUserStore((state) => state.userProfile?.addresses);
-  // If addresses is null (not an empty array), it indicates a malformed API response
-  // Normal users without addresses will have an empty array, not null
-  if (!userAddresses) return null;
   const tAddressManagement = useTranslations('EditProfile.addressManagement');
   const [addressAction, setAddressAction] = useState<AddressAction | null>(
     null
@@ -37,7 +34,7 @@ const AddressManagement = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const sortedAddresses = useMemo(() => {
-    return [...userAddresses].sort((a, b) => {
+    return [...(userAddresses ?? [])].sort((a, b) => {
       return (
         addressTypeOrder.indexOf(a.type) - addressTypeOrder.indexOf(b.type)
       );
@@ -49,11 +46,11 @@ const AddressManagement = () => {
     setAddressAction(ADDRESS_ACTIONS.ADD);
   };
   const primaryAddress = useMemo(
-    () => findAddressByType(userAddresses, ADDRESS_TYPE.PRIMARY),
+    () => findAddressByType(userAddresses ?? [], ADDRESS_TYPE.PRIMARY),
     [userAddresses]
   );
   const billingAddress = useMemo(
-    () => findAddressByType(userAddresses, ADDRESS_TYPE.MAILING),
+    () => findAddressByType(userAddresses ?? [], ADDRESS_TYPE.MAILING),
     [userAddresses]
   );
 
@@ -128,6 +125,10 @@ const AddressManagement = () => {
     addressAction,
     setAddressAction,
   ]);
+
+  // If addresses is null (not an empty array), it indicates a malformed API response
+  // Normal users without addresses will have an empty array, not null
+  if (!userAddresses) return null;
 
   const canAddMoreAddresses = userAddresses.length < MAX_ADDRESS_LIMIT;
   const shouldRenderAddressList = userAddresses.length > 0;


### PR DESCRIPTION
Resolves:  #3035

## Summary

Fixes the Rules of Hooks issue in `AddressManagement` by moving the early `return null` check below all React hook calls.

Part of #3030, tracked as **I5**.

## Problem

`AddressManagement` returned early when `userAddresses` was unavailable:

```tsx
if (!userAddresses) return null;
```

This check was placed before hooks such as `useTranslations`, `useState`, and `useMemo`.

If `userAddresses` changed from unavailable to available while the component remained mounted, the component could call a different number of hooks between renders, violating React's Rules of Hooks.

## Changes

* Moved the `userAddresses` early-return guard below all React hooks.
* Ensured hooks are called unconditionally and in a consistent order.
* Preserved the existing component behavior and UI.

## Testing

* Verified that all hooks are called before the conditional return.
* Verified that the component still returns `null` when `userAddresses` is unavailable.
* Confirmed no unrelated behavior changes were introduced.

## Related

* Epic: #3030
* Follow-up item: **I5**