### PR TITLE
refactor(setHeader): return a new header instead of mutating the argument

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: 'Unit tests'
 on:
   pull_request:
-  push:
-    branches:
-      - develop
 jobs:
   vitest:
     name: 'Vitest on Ubuntu'

--- a/src/utils/apiRequests/setHeader.test.ts
+++ b/src/utils/apiRequests/setHeader.test.ts
@@ -122,6 +122,16 @@ describe('setHeaderForImpersonation', () => {
     });
   });
 
+  it('does not mutate the header it is given', () => {
+    initStoredImpersonationData(STORED);
+
+    const header = { 'x-locale': 'en' };
+    const result = setHeaderForImpersonation(header);
+
+    expect(header).toEqual({ 'x-locale': 'en' });
+    expect(result).not.toBe(header);
+  });
+
   it('sets no headers when the stored data is not valid JSON', () => {
     // Set directly rather than via the helper, which stringifies and so cannot produce invalid JSON.
     localStorage.setItem('impersonationData', 'not json');

--- a/src/utils/apiRequests/setHeader.ts
+++ b/src/utils/apiRequests/setHeader.ts
@@ -5,7 +5,8 @@ import {
 } from '../impersonation';
 
 /**
- * Sets keys for header in impersonation mode
+ * Returns a new header with the impersonation keys added when there is valid impersonation data.
+ * Does not mutate the header passed in.
  */
 export const setHeaderForImpersonation = (
   header: Record<string, string>,
@@ -19,9 +20,11 @@ export const setHeaderForImpersonation = (
     validImpersonationData = impersonationData;
   }
 
+  const finalHeader = { ...header };
+
   if (validImpersonationData) {
-    header['X-SWITCH-USER'] = validImpersonationData.targetEmail;
-    header['X-USER-SUPPORT-PIN'] = validImpersonationData.supportPin;
+    finalHeader['X-SWITCH-USER'] = validImpersonationData.targetEmail;
+    finalHeader['X-USER-SUPPORT-PIN'] = validImpersonationData.supportPin;
   }
-  return header;
+  return finalHeader;
 };


### PR DESCRIPTION
## What

Two small changes, unrelated to each other.

### 1. `setHeaderForImpersonation` no longer mutates the header it is given

Closes the remaining pending item in #3036.

It used to write `X-SWITCH-USER` and `X-USER-SUPPORT-PIN` onto the object the caller passed in, then return that same object. The name reads like it builds a new header, so the side effect was easy to miss. It now copies the header first and writes onto the copy.

Both call sites, `useApi.ts` and `userStore.ts`, use only the return value, so nothing else needed a change.

### 2. Unit tests no longer run twice on every merge to develop

`test.yml` had a `pull_request` trigger with no branch filter *and* a `push` trigger on develop. Because the `develop → main` release PR stays open, every merge into develop fired both, on the same SHA. For example `81ada245` ran twice, once as `push` and once as `pull_request` on "Release: DRAFT".

Dropping the `push` trigger is safe. A `pull_request` run tests `refs/pull/N/merge`, which is the merge result, so develop's new head is already covered before the merge lands. The release PR keeps its own check.

`test.yml` was the only workflow with both triggers. eslint and cypress use `pull_request` alone.

## Testing

`npx vitest run src/utils/apiRequests/setHeader.test.ts` passes, 13 tests. One is new and locks in the no-mutation contract.

No behavior change. 

- [x] Optional spot check: impersonate a user from Settings and confirm the profile request still carries both impersonation headers.
