### PR TITLE
feat(ci): auto-label PRs by review state

### DIFF
--- a/.github/workflows/pr-review-labels.yml
+++ b/.github/workflows/pr-review-labels.yml
@@ -1,0 +1,183 @@
+name: 'PR review labels'
+
+# Keeps exactly one "PR: *" label on each pull request, matching its review state.
+# Replaces the pr-triage[bot] GitHub App, which stopped working in mid-2023.
+
+on:
+  # pull_request_target, not pull_request: the job never runs head-branch code, and the token keeps write access.
+  # It also means pull requests opened before this file existed get labelled without a rebase.
+  # pull_request_target and workflow_dispatch need this file on the default branch, so they do nothing until merged.
+  # pull_request_review is the exception: it runs from the PR merge ref
+  # See "Events that trigger workflows" in the GitHub Actions docs.
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+      - closed
+      - review_requested
+      - review_request_removed
+  # "synchronize" is deliberately absent: pushing new commits must not change the label.
+  pull_request_review:
+    types:
+      - submitted
+      - dismissed
+  # Backfills every open pull request, and doubles as a manual re-sync button.
+  # Run it from the "Run workflow" button on the Actions tab, or with the GitHub CLI:
+  #   gh workflow run pr-review-labels.yml --ref develop -f dry_run=true
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Log the computed label without applying it'
+        type: boolean
+        default: true
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: pr-review-labels-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: 'Sync review-state label'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Apply the review-state label'
+        uses: actions/github-script@v8
+        env:
+          # Dry run logs the decision and writes nothing.
+          # Repo variable PR_LABELS_DRY_RUN=true forces it on for every run, event-driven included.
+          # Use it to watch real traffic before arming this, or as an off switch if it misbehaves.
+          # Both raw values are passed through and compared in the script rather than combined in a
+          # ${{ }} expression, so the log always shows what actually arrived and there is no
+          # expression type coercion to reason about. Either one set to 'true' forces dry run.
+          DRY_RUN_VAR: ${{ vars.PR_LABELS_DRY_RUN }}
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
+        with:
+          script: |
+            const LABELS = {
+              draft: 'PR: draft',
+              unreviewed: 'PR: unreviewed',
+              partiallyApproved: 'PR: partially-approved',
+              approved: 'PR: reviewed-approved',
+              changesRequested: 'PR: reviewed-changes-requested',
+              merged: 'PR: merged',
+              closed: 'PR: closed',
+            };
+            const PREFIX = 'PR: ';
+            const COUNTED = ['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'];
+            // Parked on purpose, so a review state would be misleading. Left completely untouched.
+            // "blocked" is not here: those still need review, they just must not be merged yet.
+            const OPT_OUT = ['reference-only', 'postponed'];
+            const dryRun =
+              process.env.DRY_RUN_VAR === 'true' || process.env.DRY_RUN_INPUT === 'true';
+            core.info(
+              `dryRun=${dryRun} (PR_LABELS_DRY_RUN="${process.env.DRY_RUN_VAR ?? ''}", dry_run input="${process.env.DRY_RUN_INPUT ?? ''}")`
+            );
+
+            async function targets() {
+              if (context.eventName !== 'workflow_dispatch') {
+                return [context.payload.pull_request.number];
+              }
+              const open = await github.paginate(github.rest.pulls.list, {
+                ...context.repo,
+                state: 'open',
+                per_page: 100,
+              });
+              return open.map((pr) => pr.number);
+            }
+
+            async function desiredLabel(pr) {
+              if (pr.merged) return LABELS.merged;
+              if (pr.state === 'closed') return LABELS.closed;
+              if (pr.draft) return LABELS.draft;
+
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                ...context.repo,
+                pull_number: pr.number,
+                per_page: 100,
+              });
+
+              // Reviews come back oldest first, so setting by login leaves each reviewer's latest verdict.
+              // Ignoring COMMENTED is what stops a plain comment from wiping that reviewer's earlier approval.
+              const latest = new Map();
+              for (const review of reviews) {
+                const login = review.user?.login;
+                if (!login || login === pr.user.login) continue;
+                if (!COUNTED.includes(review.state)) continue;
+                latest.set(login, review.state);
+              }
+
+              const verdicts = [...latest.values()].filter((state) => state !== 'DISMISSED');
+              const approvals = verdicts.filter((state) => state === 'APPROVED').length;
+              const changesRequested = verdicts.includes('CHANGES_REQUESTED');
+              const pending =
+                (pr.requested_reviewers ?? []).length + (pr.requested_teams ?? []).length;
+
+              core.info(
+                `#${pr.number}: approvals=${approvals} changesRequested=${changesRequested} pendingReviewers=${pending}`
+              );
+
+              if (changesRequested) return LABELS.changesRequested;
+              if (approvals > 0 && pending > 0) return LABELS.partiallyApproved;
+              if (approvals > 0) return LABELS.approved;
+              return LABELS.unreviewed;
+            }
+
+            async function apply(pr, desired) {
+              const current = pr.labels.map((label) => label.name);
+              const mine = current.filter((name) => name.startsWith(PREFIX));
+              const stale = mine.filter((name) => name !== desired);
+              const missing = !current.includes(desired);
+
+              if (!stale.length && !missing) {
+                core.info(`#${pr.number}: already correct (${desired})`);
+                return;
+              }
+
+              core.info(
+                `#${pr.number}: ${mine.join(', ') || 'none'} -> ${desired}${dryRun ? ' [dry run]' : ''}`
+              );
+              if (dryRun) return;
+
+              for (const name of stale) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    ...context.repo,
+                    issue_number: pr.number,
+                    name,
+                  });
+                } catch (error) {
+                  // Someone removed it by hand between our read and write.
+                  if (error.status !== 404) throw error;
+                }
+              }
+              if (missing) {
+                await github.rest.issues.addLabels({
+                  ...context.repo,
+                  issue_number: pr.number,
+                  labels: [desired],
+                });
+              }
+            }
+
+            for (const number of await targets()) {
+              // Re-read rather than trusting the event payload, which can be stale.
+              const { data: pr } = await github.rest.pulls.get({
+                ...context.repo,
+                pull_number: number,
+              });
+              // Skip before the merged/closed/draft ladder, so a parked pull request is never
+              // touched in either direction. Clearing its label would destroy truthful history.
+              const parked = pr.labels
+                .map((label) => label.name)
+                .filter((name) => OPT_OUT.includes(name));
+              if (parked.length) {
+                core.info(`#${pr.number}: skipped, parked via ${parked.join(', ')}`);
+                continue;
+              }
+              await apply(pr, await desiredLabel(pr));
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,3 +10,11 @@ Please note we have a [code of conduct](https://github.com/Plant-for-the-Planet-
 2. Update the [README.md](https://github.com/Plant-for-the-Planet-org/planet-webapp/blob/develop/README.md) if you change something in the development process.
 3. You may merge the Pull Request in once you have the sign-off of another developer, or if you
    do not have permission to do that, you may request the reviewer to merge it for you.
+
+## Review-state labels
+
+Each pull request carries exactly one `PR: *` label showing where it stands. While it is open that is `PR: draft`, `PR: unreviewed`, `PR: partially-approved`, `PR: reviewed-approved`, or `PR: reviewed-changes-requested`. Once it ends it becomes `PR: merged`, or `PR: closed` if it was closed without merging.
+
+These are set automatically by the [PR review labels](.github/workflows/pr-review-labels.yml) workflow, so please do not edit them by hand. Any `PR: *` label you set yourself will be overwritten the next time the pull request is opened, reviewed, closed, or merged. The workflow only ever touches labels with the `PR:` prefix, so your other labels are safe. To change how they are chosen, edit that workflow. It can also be re-run manually from the Actions tab to re-sync every open pull request.
+
+If a pull request is parked rather than waiting on anyone, label it `reference-only` or `postponed`. The automation then leaves it alone and keeps it out of the review queue. Note that `blocked` does not do this: a blocked pull request must not be merged until the label is removed, but it may still need review, so it keeps a review-state label.


### PR DESCRIPTION
## What

Restores automatic `PR: *` review-state labelling with a workflow we own, in [.github/workflows/pr-review-labels.yml](.github/workflows/pr-review-labels.yml).

## Why

These labels used to be set by the third-party `pr-triage[bot]` GitHub App. It was config-free, so nothing was ever committed here and there is nothing in git history to restore. Its last action was on #1760 (2023-05-04); from #1800 (2023-06-16) onward every `PR:` label was applied by hand, and often skipped.

Of the 27 currently open PRs, 18 are mislabelled or unlabelled, so the queue cannot be filtered by review state. Doing this in-repo means no external service can silently take it away again.

## How it picks a label

One `PR: *` label per PR, decided in this order:

| State | Label |
|---|---|
| Merged | `PR: merged` |
| Closed, not merged | `PR: closed` |
| Draft | `PR: draft` |
| Anyone requested changes | `PR: reviewed-changes-requested` |
| Approved, reviewers still pending | `PR: partially-approved` |
| Approved, none pending | `PR: reviewed-approved` |
| No approvals | `PR: unreviewed` |

Decisions worth knowing about:

- **Comment-only reviews are ignored.** Only each reviewer's latest `APPROVED` or `CHANGES_REQUESTED` verdict counts. `DISMISSED` is tracked too, so that dismissing a review correctly supersedes that person's earlier verdict, then dropped before the decision. Without ignoring `COMMENTED`, a reviewer leaving a plain comment after approving would wipe their own approval. CodeRabbit reviews every PR here as `COMMENTED`, so this matters in practice.
- **Pushing commits does not change the label.** The `synchronize` activity type is deliberately not wired up. Nothing dismisses stale approvals on `develop`, so relabelling on every fixup commit would be churn.
- **`reference-only` and `postponed` PRs are skipped entirely**, nothing added or removed. Parked PRs should not sit in the review queue as "unreviewed" forever, and clearing a truthful label would destroy real history.
- **`blocked` is deliberately not in that list.** A blocked PR must not be merged until the label goes, but it may still need review, so it keeps an honest review state.
- Reviews by the PR author are excluded. Dependabot PRs are labelled like any other.

## Dry run and off switch

Two levels of control, so the workflow never has to write to be useful:

- The **Run workflow** button has a `dry_run` checkbox, **on by default**. It logs every decision and writes nothing.
- Repo variable **`PR_LABELS_DRY_RUN=true`** forces dry run on *every* run, event-driven included. Set it to watch real PR traffic before arming the workflow, then delete it. It also works as an off switch if the thing ever misbehaves. **It is set to `true` right now**, which is why the runs on this PR have written nothing.

Both values are passed to the script as raw env vars and compared in JS, rather than combined in a `${{ }}` expression. That is deliberate and worth not "simplifying": an expression-based version silently evaluated to empty with the variable set, and a live run wrote a label anyway. Doing the comparison in JS removes the expression type-coercion question, and the run log now prints both raw values so the decision is always auditable.

Related trap, since `github.event.inputs.*` yields strings rather than the declared type. Per the [workflow_dispatch docs](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch): *"The information in the `inputs` context and `github.event.inputs` context is identical except that the `inputs` context preserves Boolean values as Booleans instead of converting them to strings."*

## Testing

The script was extracted from the YAML and run against this repo with the GitHub API stubbed out, so every path was exercised against real data with no writes:

| Path | Verified on |
|---|---|
| draft | #2927 |
| no reviews | #3022, #3002, #2989 and others |
| changes requested | #2877 (currently mislabelled `PR: unreviewed`) |
| approved, reviewers pending | #1984 |
| approved, none pending | #1979 |
| merged, unlabelled / stale label | #3029, #3028 |
| closed unmerged | #2847 (`PR: reviewed-approved` to `PR: closed`) |
| parked, skipped | #1979, #1984, #2163 |
| `blocked` only, still labelled | #2544, #2971 |

It has also run for real three times on this PR, on `pull_request_review`, and the live results match the local ones exactly:

| Run | Event | Result |
|---|---|---|
| 2026-08-12 12:50 | CodeRabbit review | `none -> PR: unreviewed`, **written**, before the dry-run comparison was moved into JS |
| 2026-08-13 04:07 | CodeRabbit review | `already correct (PR: unreviewed)`, no write attempted |
| 2026-08-13 05:50 | changes requested | `PR: unreviewed -> PR: reviewed-changes-requested [dry run]`, correctly held back by the repo variable |

That first run is the one that proves `permissions: pull-requests: write` genuinely works in this repo. The third proves the off switch works on live traffic, and that the changes-requested path is right.

## Trigger behaviour, which is not symmetric

Worth knowing before review, because it is easy to assume otherwise:

| Trigger | Needs the file on `develop`? |
|---|---|
| `pull_request_target` | **Yes.** A probe PR based on this branch produced no run at all. |
| `workflow_dispatch` | **Yes.** No Run workflow button exists until this merges. |
| `pull_request_review` | **No.** Its `GITHUB_REF` is the PR merge ref, so it runs the PR's own copy of this file. |

That last row is why this PR has already run the workflow three times during development, and it is deliberate rather than accidental:

- It is safe here because the job never checks out or executes any PR code, only the workflow file itself, and every PR in this repo is same-repo, where the author already has write access. There is no privilege escalation.
- On a **fork** PR, any pull-request event other than `pull_request_target` has its write permissions [downgraded to read](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token). So a fork PR would fail to label rather than become an escalation vector. Worth knowing, but it cannot arise today.
- There is no `pull_request_review_target` event, so this asymmetry cannot be designed away.

## Known limitations

- **Already-closed PRs will not gain `PR: closed`.** The backfill only sweeps *open* PRs, so only PRs closed from now on get it. Retroactively labelling thousands of dead PRs would be a lot of writes for no benefit.
- **`PR: closed` replaces the review state on close.** #2847 closed while carrying `PR: reviewed-approved` and becomes `PR: closed`. The terminal state was judged more useful than the last review state.
- **Staleness is out of scope.** A PR untouched for a year still reads `PR: unreviewed`. No `actions/stale` workflow here.
- **`partially-approved` needs reviewers to be formally requested.** If they never are, one approval goes straight to `PR: reviewed-approved`.

## After merge

1. `PR_LABELS_DRY_RUN=true` is already set, so you can watch real traffic in the Actions log for as long as you like before arming it.
2. Actions → *PR review labels* → **Run workflow**, `dry_run` checked (the default), read the log. One run evaluates all 27: 3 skipped as parked, 6 already correct, 18 corrected.
3. Delete the `PR_LABELS_DRY_RUN` variable, then re-run with `dry_run` unchecked to apply the backfill.

Also changed `PR: reviewed-changes-requested` from pale green `#c2e0c6` to `#e99695`, since it read as an approval, and added the `PR: closed` label to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
