### PR TITLE
fix: update user profile store directly instead of triggering a refetch

### DIFF
--- a/src/features/user/Profile/ForestProgress/TargetsModal.tsx
+++ b/src/features/user/Profile/ForestProgress/TargetsModal.tsx
@@ -64,9 +64,7 @@ const TargetsModal = ({
   );
   //store: action
   const setUserInfo = useMyForestStore((state) => state.setUserInfo);
-  const refetchUserProfile = useUserStore(
-    (state) => state.refetchUserProfile
-  );
+  const setUserProfile = useUserStore((state) => state.setUserProfile);
   const setErrors = useErrorHandlingStore((state) => state.setErrors);
 
   const handleClose = () => {
@@ -106,7 +104,7 @@ const TargetsModal = ({
           payload,
         });
         const forestUserInfo = transformProfileToForestUserInfo(res);
-        refetchUserProfile();
+        setUserProfile(res);
         if (forestUserInfo !== undefined) {
           setUserInfo(forestUserInfo);
           setTreesPlantedTargetLocal(forestUserInfo.targets.treesDonated ?? 0);


### PR DESCRIPTION
Resolves #3038 

## Summary

When saving targets, `TargetsModal` called `refetchUserProfile()`, which increments a counter and triggers a separate network request to fetch the profile again.

This is unnecessary because the save request response (`res`) already contains the updated profile. It also means the UI has to wait for a second round trip before the profile data is refreshed.

This change uses `setUserProfile(res)` to update the store directly with the response from the save request, matching the pattern already used in `EditProfileForm`, `EmbedModal`, and other places that update the profile after a mutation.

## Why

* Removes an unnecessary network request on every target save.
* Avoids a window where the store contains stale data while the refetch is in flight.
* Updates the UI immediately using the mutation response.

## Test Plan

* Open the Targets modal from the Forest Progress section.
* Update a target and save.
* Confirm the updated target values appear immediately without a visible delay.
* Confirm no additional profile fetch is triggered in the Network tab after saving.