### PR TITLE
refactor(user-store): route fetchUserProfile through the shared apiCl…

### DIFF
--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -3,6 +3,7 @@ import type { ImpersonationData } from '../utils/impersonation';
 
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
+import apiClient from '../utils/apiRequests/apiClient';
 import getsessionId from '../utils/apiRequests/getSessionId';
 import { setHeaderForImpersonation } from '../utils/apiRequests/setHeader';
 import {
@@ -130,25 +131,14 @@ export const useUserStore = create<UserStore>()(
             'x-locale': locale,
           };
 
-          const response = await fetch(
-            `${process.env.API_ENDPOINT}/app/profile`,
-            {
-              method: 'GET',
-              headers: setHeaderForImpersonation(header, impersonationData),
-            }
-          );
-
-          if (!response.ok) {
-            throw new APIError(response.status, 'Failed to fetch user profile');
-          }
-
-          const result = await response.json();
-          if (!result) {
-            throw new APIError(
-              response.status,
-              'User profile response was empty'
-            );
-          }
+          const result = await apiClient<User>({
+            method: 'GET',
+            url: '/app/profile',
+            additionalHeaders: setHeaderForImpersonation(
+              header,
+              impersonationData
+            ),
+          });
 
           // Superseded by a newer fetch: do not commit to store, and do not return a stale identity back to the caller (e.g. ImpersonateUserForm enters impersonation from this return value).
           if (isStale()) {


### PR DESCRIPTION
Fixes #3042

## Changes in this pull request:

- Replace the raw `fetch()` call in `fetchUserProfile` (userStore.ts) with the shared `apiClient` utility, so error handling matches the rest of the codebase.
- Remove the redundant `!result` empty-response check, since `apiClient` already parses and returns the JSON body.
- Thrown errors now carry the server's actual response payload instead of the hardcoded `'Failed to fetch user profile'` string.

Header assembly and impersonation logic stay in the store as-is. Full API path unification (via `useApi`, token-expiry checks) is deferred to a later cleanup phase, per the linked issue.

Success, 401, impersonation-403, and network-failure paths are unchanged - only the transport and error-payload source changed.
