### PR TITLE
fix(questionnaire): honour optional fields and stack field descriptions

### DIFF
--- a/public/static/locales/en/manageProjects.json
+++ b/public/static/locales/en/manageProjects.json
@@ -134,6 +134,7 @@
     "questionnaireDescription": "Please answer the following questions about your project. These help us evaluate your project for donations.",
     "noQuestionnaire": "No questionnaire questions are required for this project type.",
     "backToProjectSpending": "Back to Project Spending",
+    "optionalFieldSuffix": "(optional)",
     "requiredField": "This field is required",
     "incompleteFieldsBanner": "You have not filled in all fields. You can come back later to provide the missing information.",
     "incompleteMedia": "Project Media is incomplete. Please upload at least one image before submitting.",

--- a/src/features/common/types/project.d.ts
+++ b/src/features/common/types/project.d.ts
@@ -99,6 +99,12 @@ export interface QuestionnaireFieldSchema {
   label: string;
   description: string | null;
   classifications: string[] | null;
+  /**
+   * The project owner may leave this question blank. Optional questions never
+   * count towards completeness, so they cannot block a review submission.
+   * Older schema payloads omit the flag, so absent means required.
+   */
+  optional?: boolean;
   choices?: string[];
   /** Used by row_list and matrix */
   rows?: QuestionnaireFieldRow[];

--- a/src/features/user/ManageProjects/StepForm.module.scss
+++ b/src/features/user/ManageProjects/StepForm.module.scss
@@ -115,6 +115,15 @@
   min-width: 320px;
 }
 
+// Questionnaire fields stack their label, help text and control vertically.
+// .formFieldLarge is a row, which put a field's description beside its label
+// whenever the label was short enough to leave room on the line. Applied on top
+// of .formFieldLarge, so the widths and spacing above still hold.
+.questionnaireField {
+  flex-direction: column;
+  align-items: stretch;
+}
+
 .formFieldFix {
   position: relative;
 }

--- a/src/features/user/ManageProjects/components/ProjectQuestionnaire.tsx
+++ b/src/features/user/ManageProjects/components/ProjectQuestionnaire.tsx
@@ -51,11 +51,17 @@ function humanizeLabel(value: string): string {
   return value.replace(/-/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase());
 }
 
-/** Returns true when the given field value counts as "filled" (at least one cell non-empty). */
+/**
+ * Returns true when the given field value counts as "filled" (at least one cell
+ * non-empty). Optional questions always count as filled — leaving one blank is
+ * a valid answer, so it must never hold back a review submission.
+ */
 export function isFieldFilled(
   field: QuestionnaireFieldSchema,
   val: unknown
 ): boolean {
+  if (field.optional) return true;
+
   if (field.type === 'multi_choice')
     return Array.isArray(val) && val.length > 0;
 
@@ -297,13 +303,19 @@ export default function ProjectQuestionnaire({
     field: QuestionnaireFieldSchema
   ): ReactElement {
     const annotation = questionnaireAnnotations[`questionnaire.${name}`];
+    const fieldClassName = `${styles.formFieldLarge} ${styles.questionnaireField}`;
+    // The schema carries the hint as a flag, so the suffix is translated here
+    // rather than baked into the label the API returns.
+    const labelText = field.optional
+      ? `${field.label} ${t('optionalFieldSuffix')}`
+      : field.label;
 
     // ── multi_choice ─────────────────────────────────────────────────────
     if (field.type === 'multi_choice' && field.choices) {
       return (
-        <div key={name} className={styles.formFieldLarge}>
+        <div key={name} className={fieldClassName}>
           <FormLabel component="legend" sx={{ mb: 0.5 }}>
-            {field.label}
+            {labelText}
           </FormLabel>
           {field.description && (
             <FieldDescription>{field.description}</FieldDescription>
@@ -311,7 +323,11 @@ export default function ProjectQuestionnaire({
           <Controller
             name={name}
             control={control}
-            rules={{ validate: (v) => (Array.isArray(v) ? v.length > 0 : !!v) }}
+            rules={
+              field.optional
+                ? undefined
+                : { validate: (v) => (Array.isArray(v) ? v.length > 0 : !!v) }
+            }
             render={({ field: { value, onChange } }) => {
               const current = Array.isArray(value) ? (value as string[]) : [];
               return (
@@ -366,9 +382,9 @@ export default function ProjectQuestionnaire({
     // ── number / integer ──────────────────────────────────────────────────
     if (field.type === 'number' || field.type === 'integer') {
       return (
-        <div key={name} className={styles.formFieldLarge}>
+        <div key={name} className={fieldClassName}>
           <FormLabel component="legend" sx={{ mb: 0.5 }}>
-            {field.label}
+            {labelText}
           </FormLabel>
           {field.description && (
             <FieldDescription>{field.description}</FieldDescription>
@@ -376,7 +392,7 @@ export default function ProjectQuestionnaire({
           <Controller
             name={name}
             control={control}
-            rules={{ required: true }}
+            rules={field.optional ? undefined : { required: true }}
             render={({ field: { onChange, onBlur, value } }) => (
               <TextField
                 type="number"
@@ -395,9 +411,9 @@ export default function ProjectQuestionnaire({
     // ── row_list ──────────────────────────────────────────────────────────
     if (field.type === 'row_list' && field.rows) {
       return (
-        <div key={name} className={styles.formFieldLarge}>
+        <div key={name} className={fieldClassName}>
           <FormLabel component="legend" sx={{ mb: 0.5 }}>
-            {field.label}
+            {labelText}
           </FormLabel>
           {field.description && (
             <FieldDescription>{field.description}</FieldDescription>
@@ -443,9 +459,9 @@ export default function ProjectQuestionnaire({
     if (field.type === 'species_list' && field.columns) {
       const columns = field.columns;
       return (
-        <div key={name} className={styles.formFieldLarge}>
+        <div key={name} className={fieldClassName}>
           <FormLabel component="legend" sx={{ mb: 0.5 }}>
-            {field.label}
+            {labelText}
           </FormLabel>
           {field.description && (
             <FieldDescription>{field.description}</FieldDescription>
@@ -477,11 +493,11 @@ export default function ProjectQuestionnaire({
       return (
         <div
           key={name}
-          className={styles.formFieldLarge}
+          className={fieldClassName}
           style={{ overflowX: 'auto' }}
         >
           <FormLabel component="legend" sx={{ mb: 0.5 }}>
-            {field.label}
+            {labelText}
           </FormLabel>
           {field.description && (
             <FieldDescription>{field.description}</FieldDescription>
@@ -564,9 +580,9 @@ export default function ProjectQuestionnaire({
 
     // ── text / string / default ───────────────────────────────────────────
     return (
-      <div key={name} className={styles.formFieldLarge}>
+      <div key={name} className={fieldClassName}>
         <FormLabel component="legend" sx={{ mb: 0.5 }}>
-          {field.label}
+          {labelText}
         </FormLabel>
         {field.description && (
           <FieldDescription>{field.description}</FieldDescription>
@@ -574,7 +590,7 @@ export default function ProjectQuestionnaire({
         <Controller
           name={name}
           control={control}
-          rules={{ required: true }}
+          rules={field.optional ? undefined : { required: true }}
           render={({ field: { onChange, onBlur, value } }) => (
             <TextField
               multiline


### PR DESCRIPTION
## Problem

Submitting the project questionnaire showed **"Questionnaire is incomplete. Please fill in all required fields before submitting."** even when every real question was answered.

Two questions are optional — *Cost composition explanation* and *Species additional information* — but "optional" was only a suffix in the label text. `isFieldFilled` had no notion of it and returned `false` for an empty string, so `allFieldsFilled` stayed `false`, `qIncomplete` stayed `true`, and *Submit for review* stayed disabled. The default text branch also set `rules={{ required: true }}` on them.

Separately, field descriptions rendered **beside** their label instead of underneath. `.formFieldLarge` is `display: flex; flex-direction: row`, so `FormLabel` and `FieldDescription` are siblings on one line; a short label left room and the description filled it, wrapping only when it no longer fit. The earlier `ml: 0` fix in `FieldDescription` addressed indentation, not placement.

## Change

- `QuestionnaireFieldSchema` gains `optional?: boolean` (absent means required, so older payloads behave as before).
- `isFieldFilled` short-circuits to `true` for optional fields, which fixes both the tab completeness dot and the submit gate — `ManageProjects/index.tsx` imports the same function.
- Optional fields pass no react-hook-form `rules`.
- The `(optional)` hint is rendered from the flag via a new `optionalFieldSuffix` key, so it stays translatable and no longer has to be baked into the label the API returns.
- New `.questionnaireField` class sets `flex-direction: column; align-items: stretch` on top of `.formFieldLarge`, so labels, descriptions and controls stack.

Gender Equity and the other matrix tables are unchanged: as before, one non-empty cell marks the table answered.

## Depends on

Plant-for-the-Planet-org/treecounter-platform#584 — adds the `optional` flag to the schema payload. Until that ships, this PR is a no-op for the two fields (the flag is absent, so they stay required); the description layout fix applies immediately.

## Testing

- `npx tsc --noEmit` — no new errors in the touched files
- `npx eslint` on the touched files — only the four pre-existing warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)