### PR TITLE
fix(api): stop impersonation headers from leaking onto public requests

### DIFF
--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -141,7 +141,11 @@ export const useApi = () => {
       }
       headers.Authorization = `Bearer ${token}`;
     }
-    const finalHeader = setHeaderForImpersonation(headers);
+    // Impersonation headers (and the localStorage read behind them) only apply to
+    // authenticated requests, so public requests never carry the target's email/pin.
+    const finalHeader = authRequired
+      ? setHeaderForImpersonation(headers)
+      : headers;
     const requestOptions =
       method === 'POST' || method === 'PUT'
         ? { method, url, data, queryParams, additionalHeaders: finalHeader }


### PR DESCRIPTION
Fixes #3031

## What

While a support agent is impersonating a user, `callApi` (in `useApi.ts`) added `X-SWITCH-USER` and `X-USER-SUPPORT-PIN` to every request, including public/unauthenticated ones that never needed a logged-in user.

`setHeaderForImpersonation` reads the stored impersonation credentials from `localStorage` as a fallback whenever the caller passes nothing, and `useApi` called it unconditionally for both the authenticated and public request helpers.

## Change

`callApi` now only runs the header through `setHeaderForImpersonation` when `authRequired` is true:

```ts
const finalHeader = authRequired
  ? setHeaderForImpersonation(headers)
  : headers;
```

Public requests (`getApi`, `postApi`, `putApi`) get the plain header object and never touch impersonation state. Authenticated requests (`getApiAuthenticated`, `postApiAuthenticated`, `putApiAuthenticated`, `deleteApiAuthenticated`) are unchanged.

## Why

The target user's email and support pin were leaking onto requests that had no reason to carry them. Because the fallback reads straight from `localStorage`, this could also fire on any lingering `impersonationData` even when the agent believed impersonation had ended.

## Testing

- `npx vitest run`: 21 tests pass (unchanged, this PR does not touch `setHeader.ts`, so its existing coverage still applies to the authenticated path).
- `npx tsc --noEmit`: no new errors introduced by this change.
- `npx eslint src/hooks/useApi.ts`: clean.
- Manual repro before/after, seeding `localStorage.impersonationData` and reloading:
  - Before: the public `GET /app/currencies` request (fired on every load by `useInitializeCurrency`) carried `X-SWITCH-USER` / `X-USER-SUPPORT-PIN`.
  - After: the same request carries only `x-locale`, `tenant-key`, `X-SESSION-ID`.
  - Authenticated requests (e.g. profile fetch) still carry both impersonation headers when impersonation data is present.

No behavior change for authenticated requests or for the impersonation feature itself.