### PR TITLE
fix(user): split RedeemPopup effect dependency

### DIFF
--- a/src/features/common/Layout/RedeemPopup/index.tsx
+++ b/src/features/common/Layout/RedeemPopup/index.tsx
@@ -32,7 +32,7 @@ export default function RedeemPopup() {
     if (isAuthResolved && userProfile) {
       setShowRedeemPopup(false);
     }
-  }, [isAuthResolved && userProfile]);
+  }, [isAuthResolved, userProfile]);
 
   const isMountedRef = useRef(false);
 


### PR DESCRIPTION
## Summary
- `RedeemPopup`'s effect watched `[isAuthResolved && userProfile]`, a single collapsed boolean, so React's dependency comparison could miss the moment `userProfile` actually changed and the effect could run with stale data or not at all.
- Split it into `[isAuthResolved, userProfile]` so each value is compared separately, matching how the effect body already uses both.

This addresses item I2 from the Zustand user/auth migration follow-up list (Part 1, Review ref #11).

## Test plan
- [ ] Sign in and confirm the redeem popup still hides once the profile loads
- [ ] `npm run lint` / `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)