### PR TITLE
fix(profile): log the real API error cause instead of a generic message

### DIFF
--- a/src/hooks/useProfileErrorHandler.ts
+++ b/src/hooks/useProfileErrorHandler.ts
@@ -11,6 +11,24 @@ import {
   registerRedirectAttempt,
 } from '../utils/authRedirectGuard';
 
+// `APIError.message` is always hardcoded to "Something went wrong" by the SDK.
+// The real failure text lives in `.errors`, which is a plain string for
+// HTTP errors and an object with a `message` field for wrapped errors
+// (see fetchUserProfile in userStore.ts). Fall back to `err.message`
+// only if neither shape matches.
+const getProfileErrorMessage = (err: APIError): string => {
+  if (typeof err.errors === 'string') return err.errors;
+  if (
+    err.errors &&
+    typeof err.errors === 'object' &&
+    'message' in err.errors &&
+    typeof err.errors.message === 'string'
+  ) {
+    return err.errors.message;
+  }
+  return err.message;
+};
+
 const useProfileErrorHandler = () => {
   const router = useRouter();
   const locale = useLocale();
@@ -84,12 +102,15 @@ const useProfileErrorHandler = () => {
         }
         // 500: server error, nothing the client can do, just log it
         case 500:
-          console.error('[Profile API] Internal Server Error:', err.message);
+          console.error(
+            '[Profile API] Internal Server Error:',
+            getProfileErrorMessage(err)
+          );
           break;
 
         // Any other status, log it for debugging
         default:
-          console.error('[Profile API] Error:', err.message);
+          console.error('[Profile API] Error:', getProfileErrorMessage(err));
           break;
       }
     },


### PR DESCRIPTION
## Summary

- `useProfileErrorHandler` logged `err.message` for the 500 and default cases, but `APIError.message` is hardcoded by `@planet-sdk/common` to the literal string `"Something went wrong"`, so both log lines always printed that instead of the actual failure.
- The real cause lives in `err.errors`, which `fetchUserProfile` (in `userStore.ts`) builds in two different shapes: a plain string for HTTP failures (e.g. `'Failed to fetch user profile'`), or an object `{ message }` for wrapped non-API errors (e.g. network failures).
- Added a local `getProfileErrorMessage` helper that reads `err.errors` and handles both shapes, falling back to `err.message` only if neither matches, and used it in place of the two `err.message` log calls.

This only changes `console.error` output for debugging. Nothing here is rendered in the UI: the 401 redirect-limit path shows a static, hardcoded `AuthFailed` screen that never reads `profileApiError` or any error text.

Fixes #3037

## Test plan

- [x] `npx tsc --noEmit` shows no errors introduced in `useProfileErrorHandler.ts`
- [x] `npx eslint src/hooks/useProfileErrorHandler.ts` passes clean
- [ ] Manually trigger a profile 500 and a network failure and confirm the console now prints the real cause instead of "Something went wrong"

🤖 Generated with [Claude Code](https://claude.com/claude-code)