### PR TITLE
fix: distinguish idle, loading, and error states in payout accounts fetch

### DIFF
--- a/src/features/user/ManagePayouts/index.tsx
+++ b/src/features/user/ManagePayouts/index.tsx
@@ -47,7 +47,6 @@ export default function ManagePayouts({
   const { getApi, getApiAuthenticated } = useApi();
   // local state
   const [tabConfig, setTabConfig] = useState<TabItem[]>([]);
-  const [isDataLoading, setIsDataLoading] = useState(false);
   // store: state
   const isAuthReady = useAuthStore(
     (state) => state.token !== null && state.isAuthResolved
@@ -58,15 +57,16 @@ export default function ManagePayouts({
       isTpo: state.userProfile?.type === 'tpo',
     }))
   );
-  const hasFetchedAccounts = useManagePayoutStore(
-    (state) => state.accounts !== null
-  );
+  const accountsStatus = useManagePayoutStore((state) => state.accountsStatus);
   const hasPayoutMinAmounts = useManagePayoutStore(
     (state) => state.payoutMinAmounts !== null
   );
   // store: action
   const setErrors = useErrorHandlingStore((state) => state.setErrors);
   const setAccounts = useManagePayoutStore((state) => state.setAccounts);
+  const setAccountsStatus = useManagePayoutStore(
+    (state) => state.setAccountsStatus
+  );
   const setPayoutMinAmounts = useManagePayoutStore(
     (state) => state.setPayoutMinAmounts
   );
@@ -87,17 +87,18 @@ export default function ManagePayouts({
   }, [step, userId]);
 
   const fetchAccounts = async () => {
-    if (hasFetchedAccounts) return;
+    if (accountsStatus !== 'idle') return;
 
-    setIsDataLoading(true);
+    setAccountsStatus('loading');
     setProgress && setProgress(70);
     try {
       const res = await getApiAuthenticated<BankAccount[]>('/app/accounts');
       setAccounts(res);
+      setAccountsStatus('ready');
     } catch (err) {
       setErrors(handleError(err as APIError));
+      setAccountsStatus('error');
     }
-    setIsDataLoading(false);
     if (setProgress) {
       setProgress(100);
       setTimeout(() => setProgress(0), 1000);
@@ -111,7 +112,7 @@ export default function ManagePayouts({
     }
 
     if (isAuthReady) fetchAccounts();
-  }, [isAuthReady, userId, hasFetchedAccounts]);
+  }, [isAuthReady, userId, accountsStatus]);
 
   useEffect(() => {
     if (isTpo) {
@@ -142,13 +143,9 @@ export default function ManagePayouts({
       case ManagePayoutTabs.ADD_BANK_DETAILS:
         return <AddBankAccount />;
       case ManagePayoutTabs.OVERVIEW:
-        return isEdit ? (
-          <EditBankAccount />
-        ) : (
-          <Overview isDataLoading={isDataLoading} />
-        );
+        return isEdit ? <EditBankAccount /> : <Overview />;
       default:
-        return <Overview isDataLoading={isDataLoading} />;
+        return <Overview />;
     }
   };
 

--- a/src/features/user/ManagePayouts/screens/Overview.tsx
+++ b/src/features/user/ManagePayouts/screens/Overview.tsx
@@ -5,14 +5,16 @@ import BankAccountDetails from '../components/BankAccountDetails';
 import NoBankAccount from '../components/NoBankAccount';
 import { useManagePayoutStore } from '../../../../stores';
 
-interface Props {
-  isDataLoading: boolean;
-}
-
-const Overview = ({ isDataLoading }: Props): ReactElement | null => {
+const Overview = (): ReactElement | null => {
   const accounts = useManagePayoutStore((state) => state.accounts);
+  const accountsStatus = useManagePayoutStore((state) => state.accountsStatus);
 
-  if (isDataLoading) return <BankAccountLoader />;
+  if (accountsStatus === 'idle' || accountsStatus === 'loading') {
+    return <BankAccountLoader />;
+  }
+
+  // A failed fetch is reported through the global error popup; avoid claiming "no accounts" here.
+  if (accountsStatus === 'error') return null;
 
   if (!accounts || accounts.length === 0) return <NoBankAccount />;
 

--- a/src/stores/managePayoutStore.ts
+++ b/src/stores/managePayoutStore.ts
@@ -6,9 +6,13 @@ import type {
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
+export type AccountsFetchStatus = 'idle' | 'loading' | 'ready' | 'error';
+
 interface ManagePayoutStore {
   accounts: BankAccount[] | null;
+  accountsStatus: AccountsFetchStatus;
   setAccounts: (accounts: BankAccount[] | null) => void;
+  setAccountsStatus: (status: AccountsFetchStatus) => void;
   payoutMinAmounts: PayoutMinAmounts | null;
   setPayoutMinAmounts: (payoutMinAmounts: PayoutMinAmounts | null) => void;
   resetManagePayoutStore: () => void;
@@ -16,6 +20,7 @@ interface ManagePayoutStore {
 
 const initialState = {
   accounts: null,
+  accountsStatus: 'idle' as AccountsFetchStatus,
   payoutMinAmounts: null,
 };
 
@@ -26,6 +31,9 @@ export const useManagePayoutStore = create<ManagePayoutStore>()(
 
       setAccounts: (accounts) =>
         set({ accounts }, undefined, 'managePayout/set_accounts'),
+
+      setAccountsStatus: (accountsStatus) =>
+        set({ accountsStatus }, undefined, 'managePayout/set_accounts_status'),
 
       setPayoutMinAmounts: (payoutMinAmounts) =>
         set(


### PR DESCRIPTION
## Summary

Fixes #3084.

`Overview` inferred fetch state from `accounts` (`null` or not) plus a component-local `isDataLoading` flag. On first render, before the fetch effect had run, neither guard was true, so the page fell through to the "no accounts" empty state and showed a working "add bank details" button to TPOs who already had accounts on file. The same collapse also made a failed fetch look identical to "no accounts".

- `managePayoutStore` gains an `accountsStatus: 'idle' | 'loading' | 'ready' | 'error'` field, reset to `'idle'` by the existing `resetManagePayoutStore` (so a profile switch still marks the data stale and triggers a refetch).
- `ManagePayouts/index.tsx` drives `accountsStatus` through `idle → loading → ready|error` in `fetchAccounts`, replacing the local `isDataLoading` state.
- `Overview.tsx` reads `accountsStatus` directly from the store: `idle`/`loading` show the loader, `error` renders nothing (the global error popup already reports the failure), and only `ready` with an empty list shows `NoBankAccount`.

## Test plan

- [x] `tsc --noEmit` shows no new errors (one pre-existing, unrelated error in `BankAccountDetails.tsx` is present on develop too)
- [x] `eslint` clean on the three changed files
- [ ] Manually verify: fresh page load / hard refresh on `/profile/payouts` no longer flashes "add bank details" for a TPO with existing accounts
- [ ] Manually verify: switching profile (impersonation) shows the loader, not the empty state, while the new profile's accounts are fetched
- [ ] Manually verify: adding a second/third account and editing one right after another still shows the correct list (reviewed the append/update logic, looks correct on read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)