### PR TITLE
fix: move PlanetCash accounts fetch into store to prevent duplicate requests

### DIFF
--- a/public/static/locales/en/planetcash.json
+++ b/public/static/locales/en/planetcash.json
@@ -19,6 +19,7 @@
     "accountInactiveHelpText": "This account is inactive and cannot be used to make contributions. To activate this account, please contact <supportLink>support@plant-for-the-planet.org</supportLink>.",
     "noAccountsText": "You don't seem to have created a PlanetCash account yet.",
     "createPlanetCashButton": "Create Planet Cash Account",
+    "loadAccountsError": "Something went wrong while loading your PlanetCash accounts. Please try again later.",
     "accountQuotaReachedText": "You cannot create more accounts as you have exhausted your account quota.",
     "accountCreationSuccess": "Your PlanetCash account was successfully created",
     "labelCountry": "Country",

--- a/src/features/user/PlanetCash/index.tsx
+++ b/src/features/user/PlanetCash/index.tsx
@@ -1,5 +1,4 @@
 import type { TabItem } from '../../common/Layout/TabbedView/TabbedViewTypes';
-import type { APIError } from '@planet-sdk/common';
 import type { PlanetCashAccount } from '../../common/types/planetcash';
 import type { ReactElement } from 'react';
 
@@ -10,15 +9,10 @@ import TabbedView from '../../common/Layout/TabbedView';
 import CreateAccount from './screens/CreateAccount';
 import Accounts from './screens/Accounts';
 import Transactions from './screens/Transactions';
-import { handleError } from '@planet-sdk/common';
 import { useApi } from '../../../hooks/useApi';
 import useLocalizedPath from '../../../hooks/useLocalizedPath';
 import { useRouter } from 'next/router';
-import {
-  useAuthStore,
-  useErrorHandlingStore,
-  usePlanetCashStore,
-} from '../../../stores';
+import { useAuthStore, usePlanetCashStore } from '../../../stores';
 
 export enum PlanetCashTabs {
   ACCOUNTS = 'accounts',
@@ -42,34 +36,18 @@ export default function PlanetCash({
   const locale = useLocale();
   // local state
   const [tabConfig, setTabConfig] = useState<TabItem[]>([]);
-  const [isDataLoading, setIsDataLoading] = useState(false);
   // store: state
   const planetCashAccounts = usePlanetCashStore(
     (state) => state.planetCashAccounts
   );
+  const status = usePlanetCashStore((state) => state.status);
   const isAuthReady = useAuthStore(
     (state) => state.token !== null && state.isAuthResolved
   );
   // store: action
-  const setPlanetCashAccounts = usePlanetCashStore(
-    (state) => state.setPlanetCashAccounts
+  const fetchPlanetCashAccounts = usePlanetCashStore(
+    (state) => state.fetchPlanetCashAccounts
   );
-  const setIsPlanetCashActive = usePlanetCashStore(
-    (state) => state.setIsPlanetCashActive
-  );
-  const setErrors = useErrorHandlingStore((state) => state.setErrors);
-
-  const sortAccountsByActive = (
-    accounts: PlanetCashAccount[]
-  ): PlanetCashAccount[] => {
-    return accounts.sort((accountA, accountB) => {
-      if (accountA.isActive === accountB.isActive) {
-        return 0;
-      } else {
-        return accountA.isActive ? -1 : 1;
-      }
-    });
-  };
 
   // Redirect routes based on whether at least one account is created.
   // Prevents multiple account creation.
@@ -94,37 +72,22 @@ export default function PlanetCash({
     [step]
   );
 
-  const fetchAccounts = async () => {
-    // If accounts were already fetched, just handle redirects
-    if (planetCashAccounts) {
-      redirectIfNeeded(planetCashAccounts);
-      return;
-    }
-
-    try {
-      setIsDataLoading(true);
-      setProgress && setProgress(70);
-      const accounts = await getApiAuthenticated<PlanetCashAccount[]>(
-        '/app/planetCash'
-      );
-      redirectIfNeeded(accounts);
-      const sortedAccounts = sortAccountsByActive(accounts);
-      setIsPlanetCashActive(accounts.some((account) => account.isActive));
-      setPlanetCashAccounts(sortedAccounts);
-    } catch (err) {
-      setErrors(handleError(err as APIError));
-    } finally {
-      setIsDataLoading(false);
+  useEffect(() => {
+    if (!isAuthReady || status !== 'idle') return;
+    setProgress && setProgress(70);
+    fetchPlanetCashAccounts(getApiAuthenticated).finally(() => {
       if (setProgress) {
         setProgress(100);
         setTimeout(() => setProgress(0), 1000);
       }
-    }
-  };
+    });
+  }, [isAuthReady, status]);
 
   useEffect(() => {
-    if (isAuthReady) fetchAccounts();
-  }, [isAuthReady]);
+    if (status === 'ready' && planetCashAccounts) {
+      redirectIfNeeded(planetCashAccounts);
+    }
+  }, [status, planetCashAccounts, redirectIfNeeded]);
 
   const renderStep = () => {
     switch (step) {
@@ -134,7 +97,7 @@ export default function PlanetCash({
         return <CreateAccount />;
       case PlanetCashTabs.ACCOUNTS:
       default:
-        return <Accounts isDataLoading={isDataLoading} />;
+        return <Accounts />;
     }
   };
   useEffect(() => {

--- a/src/features/user/PlanetCash/screens/Accounts.tsx
+++ b/src/features/user/PlanetCash/screens/Accounts.tsx
@@ -1,20 +1,28 @@
 import type { ReactElement } from 'react';
 
+import { useTranslations } from 'next-intl';
 import AccountListLoader from '../../../../../public/assets/images/icons/AccountListLoader';
 import AccountDetails from '../components/AccountDetails';
+import CenteredContainer from '../../../common/Layout/CenteredContainer';
 import { usePlanetCashStore } from '../../../../stores';
 import NoPlanetCashAccount from '../components/NoPlanetCashAccount';
 
-interface AccountsProps {
-  isDataLoading: boolean;
-}
-
-const Accounts = ({ isDataLoading }: AccountsProps): ReactElement | null => {
+const Accounts = (): ReactElement | null => {
+  const t = useTranslations('PlanetCash');
   const planetCashAccounts = usePlanetCashStore(
     (state) => state.planetCashAccounts
   );
+  const status = usePlanetCashStore((state) => state.status);
 
-  if (isDataLoading) return <AccountListLoader />;
+  if (status === 'idle' || status === 'loading') return <AccountListLoader />;
+
+  if (status === 'error') {
+    return (
+      <CenteredContainer>
+        <p className="centered-text">{t('loadAccountsError')}</p>
+      </CenteredContainer>
+    );
+  }
 
   if (planetCashAccounts && planetCashAccounts.length > 0) {
     return (
@@ -26,7 +34,7 @@ const Accounts = ({ isDataLoading }: AccountsProps): ReactElement | null => {
     );
   }
 
-  // This will never be seen, as the user is being redirected to create a new PCA when none exists
+  // This will not normally be seen, as the page redirects to create a new account once the fetch confirms the list is empty.
   return <NoPlanetCashAccount />;
 };
 

--- a/src/stores/planetCashStore.ts
+++ b/src/stores/planetCashStore.ts
@@ -1,29 +1,80 @@
+import type { ApiConfigBase } from '../hooks/useApi';
 import type { PlanetCashAccount } from '../features/common/types/planetcash';
+import type { APIError } from '@planet-sdk/common';
 
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
+import { handleError } from '@planet-sdk/common';
+import { useErrorHandlingStore } from './errorHandlingStore';
+
+type PlanetCashFetchStatus = 'idle' | 'loading' | 'ready' | 'error';
 
 interface PlanetCashStore {
   // State
   planetCashAccounts: PlanetCashAccount[] | null;
   isPlanetCashActive: boolean;
+  status: PlanetCashFetchStatus;
 
   // Actions
+  fetchPlanetCashAccounts: (
+    getApiAuthenticated: <T>(
+      url: string,
+      config?: ApiConfigBase
+    ) => Promise<T>
+  ) => Promise<void>;
   setPlanetCashAccounts: (accounts: PlanetCashAccount[] | null) => void;
   setIsPlanetCashActive: (isActive: boolean) => void;
   updateAccount: (updatedAccount: PlanetCashAccount) => void;
   resetPlanetCashStore: () => void;
 }
 
+const sortAccountsByActive = (
+  accounts: PlanetCashAccount[]
+): PlanetCashAccount[] => {
+  return accounts.sort((accountA, accountB) => {
+    if (accountA.isActive === accountB.isActive) {
+      return 0;
+    } else {
+      return accountA.isActive ? -1 : 1;
+    }
+  });
+};
+
 const initialState = {
   planetCashAccounts: null,
   isPlanetCashActive: false,
+  status: 'idle' as PlanetCashFetchStatus,
 };
 
 export const usePlanetCashStore = create<PlanetCashStore>()(
   devtools(
-    (set) => ({
+    (set, get) => ({
       ...initialState,
+
+      fetchPlanetCashAccounts: async (getApiAuthenticated) => {
+        // Guards against duplicate requests. Set before the `await`, so a second caller (e.g. React strict mode's double effect run) sees 'loading' and stops here.
+        if (get().status !== 'idle') return;
+        set({ status: 'loading' }, undefined, 'planetCash/fetch_start');
+        try {
+          const accounts = await getApiAuthenticated<PlanetCashAccount[]>(
+            '/app/planetCash'
+          );
+          set(
+            {
+              planetCashAccounts: sortAccountsByActive(accounts),
+              isPlanetCashActive: accounts.some((account) => account.isActive),
+              status: 'ready',
+            },
+            undefined,
+            'planetCash/fetch_success'
+          );
+        } catch (err) {
+          useErrorHandlingStore
+            .getState()
+            .setErrors(handleError(err as APIError));
+          set({ status: 'error' }, undefined, 'planetCash/fetch_error');
+        }
+      },
 
       setPlanetCashAccounts: (accounts) =>
         set(


### PR DESCRIPTION
## Summary

Fixes #3083.

The PlanetCash page component owned the fetch and used `planetCashAccounts === null` to mean four different things: never fetched, request in flight, request failed, and store just reset. That caused:

- The fetch running twice under React strict mode in dev, since the "already fetched" check reads a result that isn't written until the request finishes.
- The list never refetching after a profile change, since the reset clears the store but nothing re-triggers the fetch.
- A failed request rendering the same "no account" screen as an empty list.
- A one-frame window before the fetch even starts where the "create account" screen is offered to a user who already has an account.

This moves the fetch into `planetCashStore` behind a `status` field (`idle | loading | ready | error`):

- `fetchPlanetCashAccounts` guards on `status !== 'idle'`, set before the `await`, so a second caller (e.g. strict mode's double effect run) stops immediately.
- `useInitializePlanetCash`'s existing reset already puts `status` back to `idle`, so it now marks the data stale for free and the page effect refetches on its own, no changes needed there.
- `Accounts` renders a loader for `idle`/`loading`, a distinct error message for `error`, and only falls back to `NoPlanetCashAccount` once the fetch is `ready` with an empty list.

## Changes

- `src/stores/planetCashStore.ts`: add `status` field and `fetchPlanetCashAccounts` action (moved `sortAccountsByActive` here from the page).
- `src/features/user/PlanetCash/index.tsx`: drop local fetch/loading state, call the store action, split fetch and redirect into separate effects keyed on `status`.
- `src/features/user/PlanetCash/screens/Accounts.tsx`: read `status` from the store instead of an `isDataLoading` prop, add an error state.
- `public/static/locales/en/planetcash.json`: add `loadAccountsError` string.

## Test plan

- [ ] Load the PlanetCash accounts page with `reactStrictMode: true` and confirm `/app/planetCash` is only requested once.
- [ ] Switch profile (e.g. via impersonation) while on the PlanetCash page and confirm the account list refetches instead of showing "no account".
- [ ] Simulate a failed `/app/planetCash` request and confirm the error message shows instead of the "create account" screen.
- [ ] Confirm the create-account flow and existing-accounts list still render correctly on first load.