### PR TITLE
fix: move bulkCodeStore's Recipient and PlanetCashAccount types into BulkCodesTypes

### DIFF
--- a/src/features/user/BulkCodes/BulkCodesTypes.d.ts
+++ b/src/features/user/BulkCodes/BulkCodesTypes.d.ts
@@ -1,5 +1,5 @@
 // TODO - review types and make more specific where possible
-import type { CurrencyCode } from '@planet-sdk/common';
+import type { CountryCode, CurrencyCode } from '@planet-sdk/common';
 
 export interface PaymentOptionsBase {
   currency: CurrencyCode;
@@ -28,7 +28,8 @@ export type PaymentOptions =
   | ConservationPaymentOptions
   | FundPaymentOptions;
 
-export interface Recipient {
+// A row parsed from the uploaded recipient CSV/XLSX, before it is turned into a donation payload.
+export interface RecipientUploadRow {
   recipient_name: string;
   recipient_email: string;
   recipient_notify: string;
@@ -37,8 +38,25 @@ export interface Recipient {
   // recipient_occasion: string;
 }
 
+// The recipient shape sent to the donations API.
+export interface RecipientPayload {
+  units: number;
+  recipientName: string;
+  recipientEmail: string;
+  message: string;
+  notifyRecipient: boolean;
+  // occasion: string;
+}
+
+// The subset of a PlanetCash account needed to issue bulk codes.
+export interface BulkCodesPlanetCashAccount {
+  guid: string;
+  currency: CurrencyCode;
+  country: CountryCode;
+}
+
 type TableHeader = {
-  key: keyof Recipient;
+  key: keyof RecipientUploadRow;
   displayText: string;
   helpText?: string;
 };
@@ -47,7 +65,7 @@ interface OtherRecipientProperties {
   [key: string]: string;
 }
 
-type ExtendedRecipient = Recipient & OtherRecipientProperties;
+type ExtendedRecipient = RecipientUploadRow & OtherRecipientProperties;
 
 type FileImportErrorCode =
   | 'fileInvalidType'

--- a/src/features/user/BulkCodes/components/AddRecipient.tsx
+++ b/src/features/user/BulkCodes/components/AddRecipient.tsx
@@ -1,5 +1,5 @@
 import type { SetState } from '../../../common/types/common';
-import type { Recipient } from '../BulkCodesTypes';
+import type { RecipientUploadRow } from '../BulkCodesTypes';
 
 import { TableRow, TableCell, IconButton } from '@mui/material';
 import { useEffect } from 'react';
@@ -11,7 +11,7 @@ import RecipientFormFields from './RecipientFormFields';
 import ActionContainer from './ActionContainer';
 
 interface Props {
-  setLocalRecipients: SetState<Recipient[]>;
+  setLocalRecipients: SetState<RecipientUploadRow[]>;
   setIsAddingRecipient: SetState<boolean>;
   afterSaveCallback: () => void;
 }
@@ -27,7 +27,7 @@ const AddRecipient = ({
     handleSubmit,
     formState: { errors, dirtyFields },
     reset,
-  } = useForm<Recipient>({
+  } = useForm<RecipientUploadRow>({
     mode: 'onBlur',
     defaultValues: {
       recipient_name: '',
@@ -40,7 +40,7 @@ const AddRecipient = ({
 
   const hasErrors = Object.keys(errors).length > 0;
 
-  const handleSave = (newRecipient: Recipient): void => {
+  const handleSave = (newRecipient: RecipientUploadRow): void => {
     setLocalRecipients((currentRecipients) => [
       newRecipient,
       ...currentRecipients,

--- a/src/features/user/BulkCodes/components/RecipientFormFields.tsx
+++ b/src/features/user/BulkCodes/components/RecipientFormFields.tsx
@@ -1,5 +1,5 @@
 import type { Control, FieldErrors } from 'react-hook-form';
-import type { Recipient } from '../BulkCodesTypes';
+import type { RecipientUploadRow } from '../BulkCodesTypes';
 
 import { TableCell, TextField, MenuItem } from '@mui/material';
 import { Controller } from 'react-hook-form';
@@ -8,15 +8,15 @@ import { isEmailValid } from '../../../../utils/isEmailValid';
 import ReactHookFormSelect from '../../../common/InputTypes/ReactHookFormSelect';
 
 interface Props {
-  control: Control<Recipient>;
-  errors: FieldErrors<Recipient>;
+  control: Control<RecipientUploadRow>;
+  errors: FieldErrors<RecipientUploadRow>;
 }
 
 const RecipientFormFields = ({ control, errors }: Props) => {
   const t = useTranslations('BulkCodes');
   const validateRequiredIfNotify = (
     value: string,
-    formValues: Recipient
+    formValues: RecipientUploadRow
   ): string | true => {
     return formValues.recipient_notify === 'yes' && value.length === 0
       ? t('errorAddRecipient.requiredForNotifications')

--- a/src/features/user/BulkCodes/components/RecipientsTable.tsx
+++ b/src/features/user/BulkCodes/components/RecipientsTable.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ChangeEvent } from 'react';
 import type { SetState } from '../../../common/types/common';
-import type { Recipient, TableHeader } from '../BulkCodesTypes';
+import type { RecipientUploadRow, TableHeader } from '../BulkCodesTypes';
 
 import { useState } from 'react';
 import Paper from '@mui/material/Paper';
@@ -22,8 +22,8 @@ import RecipientHeader from './RecipientHeader';
 
 interface RecipientsTableProps {
   headers: TableHeader[];
-  localRecipients: Recipient[];
-  setLocalRecipients: SetState<Recipient[]>;
+  localRecipients: RecipientUploadRow[];
+  setLocalRecipients: SetState<RecipientUploadRow[]>;
   canAddRecipients?: boolean;
   setIsAddingRecipient: SetState<boolean>;
   setIsEditingRecipient: SetState<boolean>;
@@ -67,7 +67,7 @@ const RecipientsTable = ({
     exitEditMode();
   };
 
-  const updateRecipient = (updatedRecipient: Recipient): void => {
+  const updateRecipient = (updatedRecipient: RecipientUploadRow): void => {
     if (editIndex !== null) {
       const absoluteEditIndex = page * rowsPerPage + editIndex;
       const _localRecipients = [...localRecipients];

--- a/src/features/user/BulkCodes/components/RecipientsUploadForm.tsx
+++ b/src/features/user/BulkCodes/components/RecipientsUploadForm.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import type { ParseResult } from 'papaparse';
 import type { SetState } from '../../../common/types/common';
 import type {
-  Recipient,
+  RecipientUploadRow,
   TableHeader,
   FileImportError,
   UploadStates,
@@ -17,7 +17,7 @@ import RecipientsTable from './RecipientsTable';
 import styles from '../BulkCodes.module.scss';
 import { isEmailValid } from '../../../../utils/isEmailValid';
 
-const acceptedHeaders: (keyof Recipient)[] = [
+const acceptedHeaders: (keyof RecipientUploadRow)[] = [
   'recipient_name',
   'recipient_email',
   'recipient_notify',
@@ -30,8 +30,8 @@ const MAX_RECIPIENTS = 1000;
 const RECIPIENT_NAME_MAX_LENGTH = 35;
 
 interface RecipientsUploadFormProps {
-  setLocalRecipients: SetState<Recipient[]>;
-  localRecipients: Recipient[];
+  setLocalRecipients: SetState<RecipientUploadRow[]>;
+  localRecipients: RecipientUploadRow[];
   setIsAddingRecipient: SetState<boolean>;
   setIsEditingRecipient: SetState<boolean>;
 }
@@ -81,7 +81,7 @@ const RecipientsUploadForm = ({
 
   const validateRecipients = (
     recipients: ExtendedRecipient[]
-  ): Recipient[] | false => {
+  ): RecipientUploadRow[] | false => {
     //   Check recipient data is present
     if (!recipients.length) {
       setParseError({

--- a/src/features/user/BulkCodes/components/UpdateRecipient.tsx
+++ b/src/features/user/BulkCodes/components/UpdateRecipient.tsx
@@ -1,4 +1,4 @@
-import type { Recipient } from '../BulkCodesTypes';
+import type { RecipientUploadRow } from '../BulkCodesTypes';
 
 import { TableRow, TableCell, IconButton } from '@mui/material';
 import { useForm } from 'react-hook-form';
@@ -10,8 +10,8 @@ import RecipientFormFields from './RecipientFormFields';
 import ActionContainer from './ActionContainer';
 
 interface Props {
-  recipient: Recipient;
-  updateRecipient: (updatedRecipient: Recipient) => void;
+  recipient: RecipientUploadRow;
+  updateRecipient: (updatedRecipient: RecipientUploadRow) => void;
   exitEditMode: () => void;
 }
 
@@ -25,14 +25,14 @@ const UpdateRecipient = ({
     handleSubmit,
     formState: { errors },
     reset,
-  } = useForm<Recipient>({
+  } = useForm<RecipientUploadRow>({
     mode: 'onBlur',
     defaultValues: recipient,
   });
 
   const hasErrors = Object.keys(errors).length > 0;
 
-  const handleUpdate = (updatedRecipient: Recipient): void => {
+  const handleUpdate = (updatedRecipient: RecipientUploadRow): void => {
     updateRecipient(updatedRecipient);
     reset();
   };

--- a/src/features/user/BulkCodes/forms/IssueCodesForm.tsx
+++ b/src/features/user/BulkCodes/forms/IssueCodesForm.tsx
@@ -5,8 +5,7 @@ import type {
   Donation,
   PrepaidDonationRequest,
 } from '@planet-sdk/common';
-import type { Recipient } from '../../../../stores/bulkCodeStore';
-import type { Recipient as LocalRecipient } from '../BulkCodesTypes';
+import type { RecipientPayload, RecipientUploadRow } from '../BulkCodesTypes';
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
@@ -39,7 +38,9 @@ const IssueCodesForm = (): ReactElement | null => {
   const { localizedPath } = useLocalizedPath();
   const { postApiAuthenticated } = useApi();
   // local state
-  const [localRecipients, setLocalRecipients] = useState<LocalRecipient[]>([]);
+  const [localRecipients, setLocalRecipients] = useState<RecipientUploadRow[]>(
+    []
+  );
   const [comment, setComment] = useState('');
   const [occasion, setOccasion] = useState('');
   const [codeQuantity, setCodeQuantity] = useState('');
@@ -85,8 +86,8 @@ const IssueCodesForm = (): ReactElement | null => {
     }
   };
 
-  const getProcessedRecipients = (): Recipient[] => {
-    const recipients: Recipient[] = [];
+  const getProcessedRecipients = (): RecipientPayload[] => {
+    const recipients: RecipientPayload[] = [];
     localRecipients.forEach((recipient) => {
       const temp = {
         recipientName: recipient.recipient_name,

--- a/src/stores/bulkCodeStore.ts
+++ b/src/stores/bulkCodeStore.ts
@@ -1,9 +1,5 @@
-import type {
-  APIError,
-  CountryCode,
-  CountryProject,
-  CurrencyCode,
-} from '@planet-sdk/common';
+import type { APIError, CountryProject } from '@planet-sdk/common';
+import type { BulkCodesPlanetCashAccount } from '../features/user/BulkCodes/BulkCodesTypes';
 import type { BulkCodeMethods } from '../utils/constants/bulkCodeConstants';
 import type { ApiRequestFn } from '../hooks/useApi';
 
@@ -13,31 +9,18 @@ import { useErrorHandlingStore } from './errorHandlingStore';
 import { handleError } from '@planet-sdk/common';
 import { filterEligibleProjects } from '../features/user/BulkCodes/utils';
 
-export interface PlanetCashAccount {
-  guid: string;
-  currency: CurrencyCode;
-  country: CountryCode;
-}
-
-export interface Recipient {
-  units: number;
-  recipientName: string;
-  recipientEmail: string;
-  message: string;
-  notifyRecipient: boolean;
-  // occasion: string;
-}
-
 interface BulkCodeStore {
   bulkMethod: BulkCodeMethods | null;
-  planetCashAccount: PlanetCashAccount | null;
+  planetCashAccount: BulkCodesPlanetCashAccount | null;
   project: CountryProject | null;
   projectList: CountryProject[] | null;
   isFetchingProjectList: boolean;
 
   fetchProjectList: (getApi: ApiRequestFn) => Promise<void>;
   setBulkMethod: (bulkMethod: BulkCodeMethods | null) => void;
-  setPlanetCashAccount: (planetCashAccount: PlanetCashAccount | null) => void;
+  setPlanetCashAccount: (
+    planetCashAccount: BulkCodesPlanetCashAccount | null
+  ) => void;
   setProject: (project: CountryProject | null) => void;
   resetBulkCodeStore: () => void;
 }


### PR DESCRIPTION
## Summary

Fixes #3087.

`bulkCodeStore` declared its own `Recipient` and `PlanetCashAccount` types instead of importing them, unlike its sibling stores (`planetCashStore` imports from `features/common/types/planetcash`, `managePayoutStore` imports from `features/common/types/payouts`). Both names clashed with unrelated types already used in the bulk codes feature:

- `Recipient`: the store's version is the API payload shape (`recipientName`, `recipientEmail`, ...). `BulkCodesTypes.d.ts` already had a `Recipient` for the CSV upload row shape (`recipient_name`, `recipient_email`, ...). `IssueCodesForm` needed both, so it aliased one on import.
- `PlanetCashAccount`: the store's version is a 3-field summary (`guid`, `currency`, `country`). `features/common/types/planetcash.d.ts` has the full account (`id`, `balance`, `creditLimit`, `paymentMethods`, ...).

- Moved both types into `BulkCodesTypes.d.ts`, giving each a name that says what it is:
  - `Recipient` (upload row) renamed to `RecipientUploadRow`
  - New `RecipientPayload` for the API payload shape (previously the store's `Recipient`)
  - New `BulkCodesPlanetCashAccount` for the summary shape (previously the store's `PlanetCashAccount`)
- `bulkCodeStore` now imports `BulkCodesPlanetCashAccount` instead of declaring its own types.
- `IssueCodesForm` imports `RecipientPayload` and `RecipientUploadRow` from one source, no alias needed.
- Updated the other components that referenced the upload-row `Recipient` type (`AddRecipient`, `RecipientFormFields`, `RecipientsTable`, `RecipientsUploadForm`, `UpdateRecipient`) to use `RecipientUploadRow`.

The `ApiRequestFn` duplicate mentioned in the issue's "Related" section is out of scope here, it's being handled separately in PR #2878.

## Test plan

- [x] `tsc --noEmit` passes with no new errors in any touched file
- [x] Verified no remaining references to the old ambiguous type names in the repo
- [ ] Manual smoke test of the bulk codes issue-codes flow (generic and import methods) in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)