### PR TITLE
Improve the skeleton UI across the app

### DIFF
--- a/docs/accessibility/ACCESSIBILITY_FINDINGS.md
+++ b/docs/accessibility/ACCESSIBILITY_FINDINGS.md
@@ -1207,7 +1207,7 @@ useEffect(() => {
 ```tsx
 <CancelIcon aria-hidden="true" focusable="false" />
 ```
-Good existing patterns to mirror: `ContentLoaders/ButtonLoader.tsx` and `ContentLoaders/UserProfile/UserProfileLoader.tsx`.
+Good existing patterns to mirror: `ContentLoaders/ButtonLoader.tsx` and `ContentLoaders/UserLayout/UserLayoutLoader.tsx`.
 
 **Testing Steps:** Screen reader skips decorative icons. Automated: axe `svg-img-alt`.
 

--- a/pages/sites/[slug]/[locale]/login.tsx
+++ b/pages/sites/[slug]/[locale]/login.tsx
@@ -10,7 +10,9 @@ import type { Tenant } from '@planet-sdk/common';
 
 import { defaultTenant } from '../../../../tenant.config';
 import { useEffect } from 'react';
-import { UserProfileLoader } from '../../../../src/features/common/ContentLoaders/UserProfile/UserProfileLoader';
+import { UserLayoutLoader } from '../../../../src/features/common/ContentLoaders/UserLayout/UserLayoutLoader';
+import ProfileOuterContainer from '../../../../src/features/user/Profile/ProfileOuterContainer';
+import ProfileGridSkeleton from '../../../../src/features/user/Profile/ProfileLayout/ProfileGridSkeleton';
 import { useRouter } from 'next/router';
 import {
   constructPathsForTenantSlug,
@@ -81,9 +83,21 @@ export default function Login(): ReactElement {
 
   if (!isInitialized) return <></>;
 
+  // No stored redirect means login will land on /profile (the default target
+  // below), so show its skeleton here instead of the content-agnostic one.
+  const hasRedirectLink = !!localStorage.getItem('redirectLink');
+
   return (
     <div>
-      <UserProfileLoader />
+      <UserLayoutLoader
+        skeleton={
+          hasRedirectLink ? undefined : (
+            <ProfileOuterContainer>
+              <ProfileGridSkeleton />
+            </ProfileOuterContainer>
+          )
+        }
+      />
     </div>
   );
 }

--- a/pages/sites/[slug]/[locale]/profile/api-key.tsx
+++ b/pages/sites/[slug]/[locale]/profile/api-key.tsx
@@ -12,6 +12,7 @@ import Head from 'next/head';
 import { useTranslations } from 'next-intl';
 import ApiKey from '../../../../../src/features/user/Settings/ApiKey';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
+import SettingsFormSkeleton from '../../../../../src/features/user/Settings/SettingsFormSkeleton';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
@@ -28,7 +29,15 @@ function EditProfilePage(): ReactElement {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout>
+    <UserLayout
+      skeleton={
+        <SettingsFormSkeleton
+          title={t('apiKey')}
+          subtitleLines={2}
+          fieldsPerSection={1}
+        />
+      }
+    >
       <Head>
         <title>{t('apiKey')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/bulk-codes/[method]/[id].tsx
+++ b/pages/sites/[slug]/[locale]/profile/bulk-codes/[method]/[id].tsx
@@ -14,6 +14,7 @@ import UserLayout from '../../../../../../../src/features/common/Layout/UserLayo
 import BulkCodes, {
   BulkCodeSteps,
 } from '../../../../../../../src/features/user/BulkCodes';
+import BulkCodesSkeleton from '../../../../../../../src/features/user/BulkCodes/BulkCodesSkeleton';
 import Head from 'next/head';
 import { BulkCodeMethods } from '../../../../../../../src/utils/constants/bulkCodeConstants';
 import { useRouter } from 'next/router';
@@ -61,6 +62,7 @@ export default function BulkCodeIssueCodesPage(): ReactElement {
   const { method } = router.query;
   const isValidMethod =
     method === BulkCodeMethods.GENERIC || method === BulkCodeMethods.IMPORT;
+  const isContentReady = router.isReady && isValidMethod;
 
   // Checks context and sets project; keeps the store's bulk method in sync
   // with the route method, so navigating between methods doesn't leave a
@@ -124,14 +126,22 @@ export default function BulkCodeIssueCodesPage(): ReactElement {
     checkContext();
   }, [checkContext]);
 
-  if (!isInitialized || !router.isReady || !isValidMethod) return <></>;
+  if (!isInitialized) return <></>;
+
+  const skeleton = <BulkCodesSkeleton step={BulkCodeSteps.ISSUE_CODES} />;
 
   return (
-    <UserLayout>
-      <Head>
-        <title>{t('bulkCodesTitleStep3')}</title>
-      </Head>
-      <BulkCodes step={BulkCodeSteps.ISSUE_CODES} />
+    <UserLayout skeleton={skeleton}>
+      {isContentReady ? (
+        <>
+          <Head>
+            <title>{t('bulkCodesTitleStep3')}</title>
+          </Head>
+          <BulkCodes step={BulkCodeSteps.ISSUE_CODES} />
+        </>
+      ) : (
+        skeleton
+      )}
     </UserLayout>
   );
 }

--- a/pages/sites/[slug]/[locale]/profile/bulk-codes/[method]/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/bulk-codes/[method]/index.tsx
@@ -13,6 +13,7 @@ import UserLayout from '../../../../../../../src/features/common/Layout/UserLayo
 import BulkCodes, {
   BulkCodeSteps,
 } from '../../../../../../../src/features/user/BulkCodes';
+import BulkCodesSkeleton from '../../../../../../../src/features/user/BulkCodes/BulkCodesSkeleton';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import useLocalizedPath from '../../../../../../../src/hooks/useLocalizedPath';
@@ -43,6 +44,7 @@ export default function BulkCodeSelectProjectPage(): ReactElement {
   const { method } = router.query;
   const isValidMethod =
     method === BulkCodeMethods.GENERIC || method === BulkCodeMethods.IMPORT;
+  const isContentReady = router.isReady && isValidMethod;
 
   // Keeps the store in sync with the route method, so navigating between
   // methods (e.g. via browser back/forward) doesn't leave a stale value.
@@ -55,14 +57,22 @@ export default function BulkCodeSelectProjectPage(): ReactElement {
     if (bulkMethod !== method) setBulkMethod(method);
   }, [router.isReady, isValidMethod, method, bulkMethod]);
 
-  if (!isInitialized || !router.isReady || !isValidMethod) return <></>;
+  if (!isInitialized) return <></>;
+
+  const skeleton = <BulkCodesSkeleton step={BulkCodeSteps.SELECT_PROJECT} />;
 
   return (
-    <UserLayout>
-      <Head>
-        <title>{t('bulkCodesTitleStep2')}</title>
-      </Head>
-      <BulkCodes step={BulkCodeSteps.SELECT_PROJECT} />
+    <UserLayout skeleton={skeleton}>
+      {isContentReady ? (
+        <>
+          <Head>
+            <title>{t('bulkCodesTitleStep2')}</title>
+          </Head>
+          <BulkCodes step={BulkCodeSteps.SELECT_PROJECT} />
+        </>
+      ) : (
+        skeleton
+      )}
     </UserLayout>
   );
 }

--- a/pages/sites/[slug]/[locale]/profile/bulk-codes/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/bulk-codes/index.tsx
@@ -12,6 +12,7 @@ import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/
 import BulkCodes, {
   BulkCodeSteps,
 } from '../../../../../../src/features/user/BulkCodes';
+import BulkCodesSkeleton from '../../../../../../src/features/user/BulkCodes/BulkCodesSkeleton';
 import Head from 'next/head';
 import { useTranslations } from 'next-intl';
 import {
@@ -29,7 +30,9 @@ export default function BulkCodePage(): ReactElement {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout>
+    <UserLayout
+      skeleton={<BulkCodesSkeleton step={BulkCodeSteps.SELECT_METHOD} />}
+    >
       <Head>
         <title>{t('bulkCodesTitle')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/delete-account.tsx
+++ b/pages/sites/[slug]/[locale]/profile/delete-account.tsx
@@ -12,6 +12,7 @@ import Head from 'next/head';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import { useTranslations } from 'next-intl';
 import DeleteProfile from '../../../../../src/features/user/Settings/DeleteProfile';
+import SettingsFormSkeleton from '../../../../../src/features/user/Settings/SettingsFormSkeleton';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
@@ -29,7 +30,11 @@ function DeleteProfilePage(): ReactElement {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout>
+    <UserLayout
+      skeleton={
+        <SettingsFormSkeleton title={t('deleteProfile')} fieldsPerSection={1} />
+      }
+    >
       <Head>
         <title>{t('deleteProfile')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/donation-link.tsx
+++ b/pages/sites/[slug]/[locale]/profile/donation-link.tsx
@@ -10,6 +10,7 @@ import type { Tenant } from '@planet-sdk/common';
 
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import DonationLink from '../../../../../src/features/user/Widget/DonationLink';
+import SettingsFormSkeleton from '../../../../../src/features/user/Settings/SettingsFormSkeleton';
 import Head from 'next/head';
 import { useTranslations } from 'next-intl';
 import {
@@ -30,7 +31,15 @@ export default function DonationLinkPage(): ReactElement {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout>
+    <UserLayout
+      skeleton={
+        <SettingsFormSkeleton
+          title={t('donationLinkTitle')}
+          subtitleLines={2}
+          fieldsPerSection={1}
+        />
+      }
+    >
       <Head>
         <title>{t('donationLinkTitle')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/donation-receipt/donor-contact-management.tsx
+++ b/pages/sites/[slug]/[locale]/profile/donation-receipt/donor-contact-management.tsx
@@ -11,6 +11,7 @@ import Head from 'next/head';
 import { useTranslations } from 'next-intl';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import DonorContactManagement from '../../../../../../src/features/user/DonationReceipt/DonorContactManagement';
+import SettingsFormSkeleton from '../../../../../../src/features/user/Settings/SettingsFormSkeleton';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
@@ -27,7 +28,9 @@ export default function ModifyDonorData() {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout>
+    <UserLayout
+      skeleton={<SettingsFormSkeleton variant="section" fieldsPerSection={3} />}
+    >
       <Head>
         <title>{t('donorContactManagement')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/donation-receipt/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/donation-receipt/index.tsx
@@ -11,6 +11,7 @@ import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import DonationReceipts from '../../../../../../src/features/user/DonationReceipt/DonationReceipts';
+import DonationReceiptsSkeleton from '../../../../../../src/features/user/DonationReceipt/DonationReceiptsSkeleton';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
@@ -27,7 +28,7 @@ export default function DonationReceiptsPage() {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout>
+    <UserLayout skeleton={<DonationReceiptsSkeleton />}>
       <Head>
         <title>{t('receipts')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/edit.tsx
+++ b/pages/sites/[slug]/[locale]/profile/edit.tsx
@@ -12,6 +12,7 @@ import Head from 'next/head';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import { useTranslations } from 'next-intl';
 import EditProfile from '../../../../../src/features/user/Settings/EditProfile';
+import SettingsFormSkeleton from '../../../../../src/features/user/Settings/SettingsFormSkeleton';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
@@ -29,7 +30,16 @@ function EditProfilePage(): ReactElement {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout>
+    <UserLayout
+      skeleton={
+        <SettingsFormSkeleton
+          title={t('editProfile')}
+          subtitleLines={0}
+          sections={2}
+          fieldsPerSection={4}
+        />
+      }
+    >
       <Head>
         <title>{t('editProfile')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/giftfund/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/giftfund/index.tsx
@@ -9,6 +9,7 @@ import type { AbstractIntlMessages } from 'next-intl';
 import type { Tenant } from '@planet-sdk/common';
 
 import GiftFunds from '../../../../../../src/features/user/GiftFunds';
+import SettingsFormSkeleton from '../../../../../../src/features/user/Settings/SettingsFormSkeleton';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import { useTranslations } from 'next-intl';
@@ -28,7 +29,15 @@ export default function Register(): ReactElement {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout>
+    <UserLayout
+      skeleton={
+        <SettingsFormSkeleton
+          title={t('giftFund')}
+          subtitleLines={2}
+          fieldsPerSection={2}
+        />
+      }
+    >
       <Head>
         <title>{t('giftFund')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/impersonate-user.tsx
+++ b/pages/sites/[slug]/[locale]/profile/impersonate-user.tsx
@@ -13,6 +13,7 @@ import { useTranslations } from 'next-intl';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import ImpersonateUser from '../../../../../src/features/user/Settings/ImpersonateUser';
 import AccessDeniedLoader from '../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
+import SettingsFormSkeleton from '../../../../../src/features/user/Settings/SettingsFormSkeleton';
 import {
   constructPathsForTenantSlug,
   getTenantConfig,
@@ -35,7 +36,11 @@ const ImpersonateUserPage = (): ReactElement => {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout>
+    <UserLayout
+      skeleton={
+        <SettingsFormSkeleton title={t('switchUser')} fieldsPerSection={2} />
+      }
+    >
       <Head>
         <title>{t('switchUser')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/index.tsx
@@ -17,6 +17,7 @@ import UserLayout from '../../../../../src/features/common/Layout/UserLayout/Use
 import Head from 'next/head';
 import ProfileOuterContainer from '../../../../../src/features/user/Profile/ProfileOuterContainer';
 import ProfileLayout from '../../../../../src/features/user/Profile/ProfileLayout';
+import ProfileGridSkeleton from '../../../../../src/features/user/Profile/ProfileLayout/ProfileGridSkeleton';
 import { useTenantStore } from '../../../../../src/stores/tenantStore';
 import { defaultTenant } from '../../../../../tenant.config';
 
@@ -26,7 +27,13 @@ const MyForestPage = () => {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout>
+    <UserLayout
+      skeleton={
+        <ProfileOuterContainer>
+          <ProfileGridSkeleton />
+        </ProfileOuterContainer>
+      }
+    >
       <Head>
         <title>{t('profile')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/payouts/add-bank-details.tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/add-bank-details.tsx
@@ -13,6 +13,7 @@ import Head from 'next/head';
 import ManagePayouts, {
   ManagePayoutTabs,
 } from '../../../../../../src/features/user/ManagePayouts';
+import PayoutsSkeleton from '../../../../../../src/features/user/ManagePayouts/PayoutsSkeleton';
 import { useTranslations } from 'next-intl';
 import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import {
@@ -33,7 +34,7 @@ export default function AddBankDetailsPage(): ReactElement {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout>
+    <UserLayout skeleton={<PayoutsSkeleton />}>
       <Head>
         <title>{t('managePayouts.titleAddBankDetails')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/payouts/add-bank-details.tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/add-bank-details.tsx
@@ -34,7 +34,9 @@ export default function AddBankDetailsPage(): ReactElement {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout skeleton={<PayoutsSkeleton />}>
+    <UserLayout
+      skeleton={<PayoutsSkeleton step={ManagePayoutTabs.ADD_BANK_DETAILS} />}
+    >
       <Head>
         <title>{t('managePayouts.titleAddBankDetails')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/payouts/edit-bank-details/[id].tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/edit-bank-details/[id].tsx
@@ -13,6 +13,7 @@ import Head from 'next/head';
 import ManagePayouts, {
   ManagePayoutTabs,
 } from '../../../../../../../src/features/user/ManagePayouts';
+import PayoutsSkeleton from '../../../../../../../src/features/user/ManagePayouts/PayoutsSkeleton';
 import { useTranslations } from 'next-intl';
 import {
   constructPathsForTenantSlug,
@@ -31,7 +32,7 @@ export default function EditBankDetailsPage(): ReactElement {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout>
+    <UserLayout skeleton={<PayoutsSkeleton />}>
       <Head>
         <title>{t('managePayouts.titleEditBankDetails')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/payouts/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/index.tsx
@@ -15,6 +15,7 @@ import Head from 'next/head';
 import ManagePayouts, {
   ManagePayoutTabs,
 } from '../../../../../../src/features/user/ManagePayouts';
+import PayoutsSkeleton from '../../../../../../src/features/user/ManagePayouts/PayoutsSkeleton';
 import { useTranslations } from 'next-intl';
 import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import {
@@ -41,7 +42,7 @@ export default function OverviewPage(): ReactElement {
           <TopProgressBar progress={progress} />
         </div>
       )}
-      <UserLayout>
+      <UserLayout skeleton={<PayoutsSkeleton />}>
         <Head>
           <title>{t('managePayouts.titleOverview')}</title>
         </Head>

--- a/pages/sites/[slug]/[locale]/profile/payouts/schedule.tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/schedule.tsx
@@ -13,6 +13,7 @@ import Head from 'next/head';
 import ManagePayouts, {
   ManagePayoutTabs,
 } from '../../../../../../src/features/user/ManagePayouts';
+import PayoutsSkeleton from '../../../../../../src/features/user/ManagePayouts/PayoutsSkeleton';
 import { useTranslations } from 'next-intl';
 import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import {
@@ -32,7 +33,7 @@ export default function PayoutSchedulePage(): ReactElement {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout>
+    <UserLayout skeleton={<PayoutsSkeleton />}>
       <Head>
         <title>{t('managePayouts.titlePayoutSchedule')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/payouts/schedule.tsx
+++ b/pages/sites/[slug]/[locale]/profile/payouts/schedule.tsx
@@ -33,7 +33,9 @@ export default function PayoutSchedulePage(): ReactElement {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout skeleton={<PayoutsSkeleton />}>
+    <UserLayout
+      skeleton={<PayoutsSkeleton step={ManagePayoutTabs.PAYOUT_SCHEDULE} />}
+    >
       <Head>
         <title>{t('managePayouts.titlePayoutSchedule')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/projects/[id].tsx
+++ b/pages/sites/[slug]/[locale]/profile/projects/[id].tsx
@@ -11,8 +11,10 @@ import type {
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import ManageProjects from '../../../../../../src/features/user/ManageProjects';
-import GlobeContentLoader from '../../../../../../src/features/common/ContentLoaders/Projects/GlobeLoader';
+import ManageProjects, {
+  ProjectCreationTabs,
+} from '../../../../../../src/features/user/ManageProjects';
+import ManageProjectsSkeleton from '../../../../../../src/features/user/ManageProjects/ManageProjectsSkeleton';
 import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import Footer from '../../../../../../src/features/common/Layout/Footer';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
@@ -34,6 +36,18 @@ import {
 } from '../../../../../../src/stores';
 import useLocalizedPath from '../../../../../../src/hooks/useLocalizedPath';
 import { defaultTenant } from '../../../../../../tenant.config';
+
+// Mirrors the `type` query param ManageProjects' formRouteHandler sets when
+// navigating between steps, so the skeleton's active tab matches the step
+// being loaded instead of always defaulting to the first one.
+const TYPE_QUERY_TO_TAB: Record<string, ProjectCreationTabs> = {
+  'basic-details': ProjectCreationTabs.BASIC_DETAILS,
+  media: ProjectCreationTabs.PROJECT_MEDIA,
+  'detail-analysis': ProjectCreationTabs.DETAILED_ANALYSIS,
+  'project-sites': ProjectCreationTabs.PROJECT_SITES,
+  'project-spending': ProjectCreationTabs.PROJECT_SPENDING,
+  review: ProjectCreationTabs.REVIEW,
+};
 
 function ManageSingleProject(): ReactElement {
   const t = useTranslations('Common');
@@ -95,24 +109,29 @@ function ManageSingleProject(): ReactElement {
 
   // Showing error to other TPOs is left
 
+  // An existing project never shows the "project type" step, so this always
+  // resolves to a real step (basic details as the fallback, since that's
+  // the step ManageProjects lands on once the type query is missing).
+  const { type } = router.query;
+  const step =
+    (typeof type === 'string' && TYPE_QUERY_TO_TAB[type]) ||
+    ProjectCreationTabs.BASIC_DETAILS;
+  const skeleton = <ManageProjectsSkeleton variant="tabbed" step={step} />;
+
   return isInitialized ? (
     setupAccess ? (
       ready && token && !accessDenied && projectGUID && project ? (
-        <UserLayout>
+        <UserLayout skeleton={skeleton}>
           <Head>
             <title>{`${t('edit')} - ${project?.name}`}</title>
           </Head>
           <ManageProjects GUID={projectGUID} token={token} project={project} />
         </UserLayout>
       ) : (
-        <UserLayout>
-          <GlobeContentLoader />
-        </UserLayout>
+        <UserLayout skeleton={skeleton}>{skeleton}</UserLayout>
       )
     ) : (
-      <UserLayout>
-        <GlobeContentLoader />
-      </UserLayout>
+      <UserLayout skeleton={skeleton}>{skeleton}</UserLayout>
     )
   ) : (
     <></>

--- a/pages/sites/[slug]/[locale]/profile/projects/index.tsx
+++ b/pages/sites/[slug]/[locale]/profile/projects/index.tsx
@@ -9,6 +9,7 @@ import type {
 import type { Tenant } from '@planet-sdk/common';
 
 import ProjectsContainer from '../../../../../../src/features/user/ManageProjects/ProjectsContainer';
+import ManageProjectsSkeleton from '../../../../../../src/features/user/ManageProjects/ManageProjectsSkeleton';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import Head from 'next/head';
 import { useTranslations } from 'next-intl';
@@ -30,7 +31,7 @@ export default function Register(): ReactElement {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout>
+    <UserLayout skeleton={<ManageProjectsSkeleton variant="list" />}>
       <Head>
         <title>{t('projects')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/projects/new-project.tsx
+++ b/pages/sites/[slug]/[locale]/profile/projects/new-project.tsx
@@ -12,6 +12,7 @@ import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import UserLayout from '../../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import ManageProjects from '../../../../../../src/features/user/ManageProjects';
+import ManageProjectsSkeleton from '../../../../../../src/features/user/ManageProjects/ManageProjectsSkeleton';
 import AccessDeniedLoader from '../../../../../../src/features/common/ContentLoaders/Projects/AccessDeniedLoader';
 import Footer from '../../../../../../src/features/common/Layout/Footer';
 import Head from 'next/head';
@@ -74,7 +75,11 @@ export default function AddProjectType(): ReactElement {
   if (!isInitialized) return <></>;
 
   return (
-    <UserLayout>
+    <UserLayout
+      skeleton={
+        <ManageProjectsSkeleton variant="tabbed" title={t('addNewProject')} />
+      }
+    >
       <Head>
         <title>{t('addNewProject')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/profile/widgets.tsx
+++ b/pages/sites/[slug]/[locale]/profile/widgets.tsx
@@ -12,6 +12,7 @@ import { useState, useEffect } from 'react';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import EmbedModal from '../../../../../src/features/user/Widget/EmbedModal';
 import styles from '../../../../../src/features/common/Layout/UserLayout/UserLayout.module.scss';
+import SettingsFormSkeleton from '../../../../../src/features/user/Settings/SettingsFormSkeleton';
 import Head from 'next/head';
 import { useTranslations } from 'next-intl';
 import {
@@ -41,7 +42,7 @@ function ProfilePage(): ReactElement {
   if (!isInitialized) return <></>;
   // TO DO - change widget link
   return (
-    <UserLayout>
+    <UserLayout skeleton={<SettingsFormSkeleton variant="none" />}>
       <Head>
         <title>{t('widgets')}</title>
       </Head>

--- a/pages/sites/[slug]/[locale]/treemapper/index.tsx
+++ b/pages/sites/[slug]/[locale]/treemapper/index.tsx
@@ -13,7 +13,7 @@ import Head from 'next/head';
 import UserLayout from '../../../../../src/features/common/Layout/UserLayout/UserLayout';
 import TreemapperMigration from '../../../../../src/features/user/TreemapperMigration';
 import DashboardView from '../../../../../src/features/common/Layout/DashboardView';
-import { UserProfileLoader } from '../../../../../src/features/common/ContentLoaders/UserProfile/UserProfileLoader';
+import { UserLayoutLoader } from '../../../../../src/features/common/ContentLoaders/UserLayout/UserLayoutLoader';
 import { useTenantStore } from '../../../../../src/stores/tenantStore';
 import getMessagesForPage from '../../../../../src/utils/language/getMessagesForPage';
 import {
@@ -28,7 +28,7 @@ import { defaultTenant } from '../../../../../tenant.config';
 function TreemapperDashboardPage(): ReactElement {
   const t = useTranslations('Me');
   const isInitialized = useTenantStore((state) => state.isInitialized);
-  if (!isInitialized) return <UserProfileLoader />;
+  if (!isInitialized) return <UserLayoutLoader />;
 
   return (
     <UserLayout>

--- a/src/features/common/ContentLoaders/GenericPageSkeleton.module.scss
+++ b/src/features/common/ContentLoaders/GenericPageSkeleton.module.scss
@@ -1,0 +1,16 @@
+@import '../../../theme/theme';
+
+// Clears the fixed 80px header, same offset every profile page content area uses.
+.container {
+  margin-top: 80px;
+  padding: 20px 40px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 1060px;
+
+  @include xsPhoneView {
+    margin-top: 142px;
+    padding: 20px;
+  }
+}

--- a/src/features/common/ContentLoaders/GenericPageSkeleton.tsx
+++ b/src/features/common/ContentLoaders/GenericPageSkeleton.tsx
@@ -1,0 +1,18 @@
+import type { ReactElement } from 'react';
+
+import { SkeletonBlock } from './Skeleton';
+import styles from './GenericPageSkeleton.module.scss';
+
+/**
+ * Content-agnostic placeholder shown inside UserLayout when a route has not
+ * supplied its own `skeleton`. Only a title bar and one content block, so it
+ * never implies a shape that belongs to some other page.
+ */
+export default function GenericPageSkeleton(): ReactElement {
+  return (
+    <div className={styles.container} aria-hidden="true">
+      <SkeletonBlock height={32} width={240} />
+      <SkeletonBlock height={200} />
+    </div>
+  );
+}

--- a/src/features/common/ContentLoaders/Skeleton/index.tsx
+++ b/src/features/common/ContentLoaders/Skeleton/index.tsx
@@ -1,0 +1,48 @@
+import type { ReactElement } from 'react';
+
+import Skeleton from 'react-loading-skeleton';
+import 'react-loading-skeleton/dist/skeleton.css';
+
+interface SkeletonBlockProps {
+  width?: string | number;
+  height?: string | number;
+  borderRadius?: string | number;
+  className?: string;
+  count?: number;
+}
+
+/**
+ * Rectangular skeleton primitive. Every page skeleton should build from this
+ * (and SkeletonCircle) instead of importing react-loading-skeleton directly,
+ * so a future skeleton library swap only touches this file.
+ */
+export function SkeletonBlock({
+  width,
+  height,
+  borderRadius,
+  className,
+  count,
+}: SkeletonBlockProps): ReactElement {
+  return (
+    <Skeleton
+      width={width}
+      height={height}
+      borderRadius={borderRadius}
+      className={className}
+      count={count}
+    />
+  );
+}
+
+interface SkeletonCircleProps {
+  size: number;
+  className?: string;
+}
+
+/** Circular skeleton primitive, for avatars, icons, and round buttons. */
+export function SkeletonCircle({
+  size,
+  className,
+}: SkeletonCircleProps): ReactElement {
+  return <Skeleton circle width={size} height={size} className={className} />;
+}

--- a/src/features/common/ContentLoaders/UserLayout/UserLayoutLoader.module.scss
+++ b/src/features/common/ContentLoaders/UserLayout/UserLayoutLoader.module.scss
@@ -87,22 +87,11 @@
   }
 }
 
-// Mirrors UserLayout `.profilePageWrapper`.
+// Mirrors UserLayout `.profilePageWrapper`. Deliberately has no padding or
+// header offset of its own: those belong to whichever skeleton renders
+// inside, since that's how the real page content area behaves too.
 .wrapper {
   width: 100%;
   min-height: 100vh;
   max-width: 1400px;
-}
-
-// Mirrors ProfileOuterContainer `.mainContainer` (the header offset + padding
-// that sits between the wrapper and the profile grid).
-.outerContainer {
-  margin-top: 80px;
-  padding: 20px 40px 40px;
-
-  @include xsPhoneView {
-    // Extra top space accommodates the mobile burger button.
-    margin-top: 142px;
-    padding: 20px 0;
-  }
 }

--- a/src/features/common/ContentLoaders/UserLayout/UserLayoutLoader.tsx
+++ b/src/features/common/ContentLoaders/UserLayout/UserLayoutLoader.tsx
@@ -1,16 +1,27 @@
-import { useTranslations } from 'next-intl';
-import Skeleton from 'react-loading-skeleton';
-import 'react-loading-skeleton/dist/skeleton.css';
+import type { ReactNode } from 'react';
 
-import ProfileGridSkeleton from '../../../user/Profile/ProfileLayout/ProfileGridSkeleton';
-import styles from './UserProfileLoader.module.scss';
+import { useTranslations } from 'next-intl';
+
+import { SkeletonBlock, SkeletonCircle } from '../Skeleton';
+import GenericPageSkeleton from '../GenericPageSkeleton';
+import styles from './UserLayoutLoader.module.scss';
+
+interface UserLayoutLoaderProps {
+  /**
+   * The shape of the page being navigated to. Falls back to a minimal,
+   * content-agnostic placeholder when the route hasn't supplied one, rather
+   * than defaulting to any single page's shape.
+   */
+  skeleton?: ReactNode;
+}
 
 /**
  * Full-page loader displayed while the user context is loading. It replaces the
- * entire UserLayout, so it reproduces the sidebar, the content frame, and the
- * profile grid to minimize cumulative layout shift (CLS).
+ * entire UserLayout, so it reproduces the sidebar and the content frame to
+ * minimize cumulative layout shift (CLS). It owns only that shared chrome;
+ * the content area shows whatever skeleton the destination route supplies.
  */
-export const UserProfileLoader = () => {
+export const UserLayoutLoader = ({ skeleton }: UserLayoutLoaderProps) => {
   const t = useTranslations('Common');
 
   return (
@@ -23,7 +34,7 @@ export const UserProfileLoader = () => {
       {/* Mobile burger placeholder. Wrapped in aria-hidden to avoid exposing
     decorative loading UI to screen readers. */}
       <span aria-hidden="true">
-        <Skeleton className={styles.hamburgerSkeleton} borderRadius={10} />
+        <SkeletonBlock className={styles.hamburgerSkeleton} borderRadius={10} />
       </span>
 
       {/* Sidebar placeholder (matches UserLayout .sidebar) */}
@@ -32,7 +43,7 @@ export const UserProfileLoader = () => {
         <div className={styles.sidebarNavGroup}>
           {Array.from({ length: 6 }).map((_, index) => (
             <div key={index} className={styles.navRow}>
-              <Skeleton circle width={20} height={20} />
+              <SkeletonCircle size={20} />
             </div>
           ))}
         </div>
@@ -40,17 +51,16 @@ export const UserProfileLoader = () => {
         <div className={styles.sidebarBottomGroup}>
           {Array.from({ length: 4 }).map((_, index) => (
             <div key={index} className={styles.navRow}>
-              <Skeleton circle width={20} height={20} />
+              <SkeletonCircle size={20} />
             </div>
           ))}
         </div>
       </aside>
 
-      {/* Content frame (matches .profilePageWrapper + ProfileOuterContainer) */}
-      <div className={styles.wrapper} aria-hidden="true">
-        <div className={styles.outerContainer}>
-          <ProfileGridSkeleton />
-        </div>
+      {/* Content frame (matches .profilePageWrapper). The route-specific
+          skeleton renders inside, so this stays content-agnostic. */}
+      <div className={styles.wrapper}>
+        {skeleton ?? <GenericPageSkeleton />}
       </div>
     </div>
   );

--- a/src/features/common/ContentLoaders/UserLayout/UserLayoutLoader.tsx
+++ b/src/features/common/ContentLoaders/UserLayout/UserLayoutLoader.tsx
@@ -58,8 +58,11 @@ export const UserLayoutLoader = ({ skeleton }: UserLayoutLoaderProps) => {
       </aside>
 
       {/* Content frame (matches .profilePageWrapper). The route-specific
-          skeleton renders inside, so this stays content-agnostic. */}
-      <div className={styles.wrapper}>
+          skeleton renders inside, so this stays content-agnostic. aria-hidden
+          keeps the route skeleton's own landmarks (e.g. ProfileGridSkeleton's
+          article/section) out of the role="status" region above, which should
+          only announce the loading text. */}
+      <div className={styles.wrapper} aria-hidden="true">
         {skeleton ?? <GenericPageSkeleton />}
       </div>
     </div>

--- a/src/features/common/Layout/UserLayout/UserLayout.tsx
+++ b/src/features/common/Layout/UserLayout/UserLayout.tsx
@@ -13,7 +13,7 @@ import PlanetCashIcon from '../../../../../public/assets/images/icons/Sidebar/Pl
 import SettingsIcon from '../../../../../public/assets/images/icons/Sidebar/SettingsIcon';
 import UserIcon from '../../../../../public/assets/images/icons/Sidebar/UserIcon';
 import WidgetIcon from '../../../../../public/assets/images/icons/Sidebar/Widget';
-import { UserProfileLoader } from '../../ContentLoaders/UserProfile/UserProfileLoader';
+import { UserLayoutLoader } from '../../ContentLoaders/UserLayout/UserLayoutLoader';
 import styles from './UserLayout.module.scss';
 import TreeMapperIcon from '../../../../../public/assets/images/icons/Sidebar/TreeMapperIcon';
 import NotionLinkIcon from '../../../../../public/assets/images/icons/Sidebar/NotionLinkIcon';
@@ -27,7 +27,17 @@ import { clsx } from 'clsx';
 import { useAuthSession } from '../../../../hooks/useAuthSession';
 import { useAuthStore, useUserStore } from '../../../../stores';
 
-const UserLayout = ({ children }: { children: ReactNode }) => {
+interface UserLayoutProps {
+  children: ReactNode;
+  /**
+   * Loading shape for this route, shown while the user context is still
+   * resolving. Falls back to a minimal, content-agnostic placeholder when
+   * omitted; never to another route's shape.
+   */
+  skeleton?: ReactNode;
+}
+
+const UserLayout = ({ children, skeleton }: UserLayoutProps) => {
   const t = useTranslations('Me');
   const locale = useLocale();
   const router = useRouter();
@@ -280,7 +290,7 @@ const UserLayout = ({ children }: { children: ReactNode }) => {
 
   // While auth state is resolving
   if (!isAuthResolved) {
-    return <UserProfileLoader />;
+    return <UserLayoutLoader skeleton={skeleton} />;
   }
 
   //Auth resolved but no user (redirect in effect)

--- a/src/features/projectsV2/ProjectDetails/ProjectDetails.module.scss
+++ b/src/features/projectsV2/ProjectDetails/ProjectDetails.module.scss
@@ -24,7 +24,3 @@
     height: 100%;
   }
 }
-
-.projectDetailsSkeleton {
-  height: 100%;
-}

--- a/src/features/projectsV2/ProjectDetails/ProjectDetailsSkeleton.module.scss
+++ b/src/features/projectsV2/ProjectDetails/ProjectDetailsSkeleton.module.scss
@@ -1,0 +1,29 @@
+@import '../../../theme/theme';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.infoPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  padding: 15px;
+  background: $dsWhite;
+  border-radius: 16px;
+  box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.1);
+}
+
+.infoPanelMobile {
+  box-shadow: none;
+  padding: 15px 24px 0;
+}
+
+.aboutSection,
+.contactSection {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}

--- a/src/features/projectsV2/ProjectDetails/ProjectDetailsSkeleton.tsx
+++ b/src/features/projectsV2/ProjectDetails/ProjectDetailsSkeleton.tsx
@@ -1,0 +1,46 @@
+import type { ReactElement } from 'react';
+
+import { clsx } from 'clsx';
+import { SkeletonBlock } from '../../common/ContentLoaders/Skeleton';
+import ProjectSnippetSkeleton from '../ProjectSnippet/ProjectSnippetSkeleton';
+import styles from './ProjectDetailsSkeleton.module.scss';
+
+interface ProjectDetailsSkeletonProps {
+  isMobile?: boolean;
+}
+
+const CONTACT_ROW_COUNT = 4;
+
+/**
+ * Loading shape for the project-details route: the ProjectSnippet header
+ * card, then the info panel's always-present sections (about, image
+ * gallery, contact details). Other sections (reviews, key info, additional
+ * info, downloads) depend on project data we don't have yet, so they're
+ * left out rather than guessed at.
+ */
+export default function ProjectDetailsSkeleton({
+  isMobile = false,
+}: ProjectDetailsSkeletonProps): ReactElement {
+  return (
+    <div className={styles.container} aria-hidden="true">
+      <ProjectSnippetSkeleton isMobile={isMobile} />
+      <div
+        className={clsx(styles.infoPanel, {
+          [styles.infoPanelMobile]: isMobile,
+        })}
+      >
+        <div className={styles.aboutSection}>
+          <SkeletonBlock width={140} height={20} />
+          <SkeletonBlock height={14} count={3} />
+        </div>
+        <SkeletonBlock height={192} borderRadius={12} />
+        <div className={styles.contactSection}>
+          <SkeletonBlock width={160} height={20} />
+          {Array.from({ length: CONTACT_ROW_COUNT }, (_, index) => (
+            <SkeletonBlock key={index} height={41} borderRadius={8} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/projectsV2/ProjectDetails/index.tsx
+++ b/src/features/projectsV2/ProjectDetails/index.tsx
@@ -8,8 +8,7 @@ import { useRouter } from 'next/router';
 import ProjectSnippet from '../ProjectSnippet';
 import ProjectInfo from './components/ProjectInfo';
 import styles from './ProjectDetails.module.scss';
-import Skeleton from 'react-loading-skeleton';
-import 'react-loading-skeleton/dist/skeleton.css';
+import ProjectDetailsSkeleton from './ProjectDetailsSkeleton';
 import MultiTreeInfo from './components/MultiTreeInfo';
 import SingleTreeInfo from './components/SingleTreeInfo';
 import { getActiveSingleTree } from '../../../utils/projectV2';
@@ -85,7 +84,7 @@ const ProjectDetails = ({ isMobile }: { isMobile: boolean }) => {
   );
 
   if (singleProject === null) {
-    return <Skeleton className={styles.projectDetailsSkeleton} />;
+    return <ProjectDetailsSkeleton isMobile={isMobile} />;
   }
 
   return (

--- a/src/features/projectsV2/ProjectSnippet/ProjectSnippetSkeleton.module.scss
+++ b/src/features/projectsV2/ProjectSnippet/ProjectSnippetSkeleton.module.scss
@@ -1,0 +1,26 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  max-width: 356px;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 4px 8px 16px 0px rgba(0, 0, 0, 0.1);
+}
+
+.cardMobile {
+  max-width: 100%;
+  box-shadow: none;
+}
+
+.cardInfo {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+}
+
+.cardInfoText {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}

--- a/src/features/projectsV2/ProjectSnippet/ProjectSnippetSkeleton.tsx
+++ b/src/features/projectsV2/ProjectSnippet/ProjectSnippetSkeleton.tsx
@@ -1,0 +1,30 @@
+import type { ReactElement } from 'react';
+
+import { clsx } from 'clsx';
+import { SkeletonBlock } from '../../common/ContentLoaders/Skeleton';
+import styles from './ProjectSnippetSkeleton.module.scss';
+
+interface ProjectSnippetSkeletonProps {
+  /** Matches ProjectSnippet's own `.singleProject` phone-view override: full width, no shadow. */
+  isMobile?: boolean;
+}
+
+/** Mirrors a single ProjectSnippet card: image, progress bar, info row, TPO footer. */
+export default function ProjectSnippetSkeleton({
+  isMobile = false,
+}: ProjectSnippetSkeletonProps): ReactElement {
+  return (
+    <div className={clsx(styles.card, { [styles.cardMobile]: isMobile })}>
+      <SkeletonBlock height={160} />
+      <SkeletonBlock height={4} />
+      <div className={styles.cardInfo}>
+        <div className={styles.cardInfoText}>
+          <SkeletonBlock width={140} height={16} />
+          <SkeletonBlock width={90} height={12} />
+        </div>
+        <SkeletonBlock width={50} height={16} />
+      </div>
+      <SkeletonBlock height={30} />
+    </div>
+  );
+}

--- a/src/features/projectsV2/ProjectsSection.module.scss
+++ b/src/features/projectsV2/ProjectsSection.module.scss
@@ -29,10 +29,6 @@ $bottomFooterSpace: 49px;
   }
 }
 
-.projectSectionSkeleton {
-  height: 100%;
-}
-
 .noProjectFoundContainer {
   height: 100%;
   display: flex;

--- a/src/features/projectsV2/ProjectsSection.tsx
+++ b/src/features/projectsV2/ProjectsSection.tsx
@@ -1,10 +1,8 @@
-import Skeleton from 'react-loading-skeleton';
 import { useEffect, useState } from 'react';
-import 'react-loading-skeleton/dist/skeleton.css';
-import styles from './ProjectsSection.module.scss';
 import ProjectListControls, { type ProjectTabs } from './ProjectListControls';
 import ProjectListControlForMobile from './ProjectListControls/ProjectListControlForMobile';
 import ProjectList from './ProjectList';
+import ProjectsSectionSkeleton from './ProjectsSectionSkeleton';
 import ProjectsListMeta from '../../utils/getMetaTags/ProjectsListMeta';
 import {
   useProjectMapStore,
@@ -59,7 +57,12 @@ const ProjectsSection = ({ isMobile }: ProjectsSectionProps) => {
   const shouldHideProjectTabs = tenantConfig.topProjectsOnly === true;
 
   if ((isProjectsFetching || isProjectsError) && !hasFilteredProjects) {
-    return <Skeleton className={styles.projectSectionSkeleton} />;
+    return (
+      <ProjectsSectionSkeleton
+        isMobile={isMobile}
+        shouldHideProjectTabs={shouldHideProjectTabs}
+      />
+    );
   }
 
   const projectListControlCommonProps = {

--- a/src/features/projectsV2/ProjectsSectionSkeleton.module.scss
+++ b/src/features/projectsV2/ProjectsSectionSkeleton.module.scss
@@ -1,0 +1,39 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  overflow: hidden;
+}
+
+.controls,
+.controlsMobile {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.controls {
+  height: 47px;
+  max-width: 355px;
+}
+
+.controlsMobile {
+  gap: 10px;
+  padding: 0 10px;
+}
+
+.iconsMobile {
+  display: flex;
+  gap: 10px;
+}
+
+.cardList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.cardListMobile {
+  padding: 0 9px;
+}

--- a/src/features/projectsV2/ProjectsSectionSkeleton.tsx
+++ b/src/features/projectsV2/ProjectsSectionSkeleton.tsx
@@ -1,0 +1,56 @@
+import type { ReactElement } from 'react';
+
+import { clsx } from 'clsx';
+import { SkeletonBlock } from '../common/ContentLoaders/Skeleton';
+import ProjectSnippetSkeleton from './ProjectSnippet/ProjectSnippetSkeleton';
+import styles from './ProjectsSectionSkeleton.module.scss';
+
+interface ProjectsSectionSkeletonProps {
+  isMobile: boolean;
+  /** Real, already-known tenant flag: when true the tabs row is replaced by a single header line, matching ProjectListControls. */
+  shouldHideProjectTabs: boolean;
+}
+
+const DESKTOP_CARD_COUNT = 4;
+const MOBILE_CARD_COUNT = 3;
+
+/** Loading shape for the root project-list page: mirrors ProjectListControls (tabs + search/filter) above a column of ProjectSnippet cards. */
+export default function ProjectsSectionSkeleton({
+  isMobile,
+  shouldHideProjectTabs,
+}: ProjectsSectionSkeletonProps): ReactElement {
+  const cardCount = isMobile ? MOBILE_CARD_COUNT : DESKTOP_CARD_COUNT;
+
+  return (
+    <div className={styles.container} aria-hidden="true">
+      {isMobile ? (
+        <div className={styles.controlsMobile}>
+          {!shouldHideProjectTabs && (
+            <SkeletonBlock width={130} height={28} borderRadius={5} />
+          )}
+          <div className={styles.iconsMobile}>
+            <SkeletonBlock width={28} height={28} borderRadius={8} />
+            <SkeletonBlock width={28} height={28} borderRadius={8} />
+          </div>
+          <SkeletonBlock width={90} height={28} borderRadius={5} />
+        </div>
+      ) : (
+        <div className={styles.controls}>
+          {shouldHideProjectTabs ? (
+            <SkeletonBlock width={220} height={16} />
+          ) : (
+            <SkeletonBlock width={200} height={24} borderRadius={12} />
+          )}
+          <SkeletonBlock width={40} height={24} borderRadius={12} />
+        </div>
+      )}
+      <div
+        className={clsx(styles.cardList, { [styles.cardListMobile]: isMobile })}
+      >
+        {Array.from({ length: cardCount }, (_, index) => (
+          <ProjectSnippetSkeleton key={index} isMobile={isMobile} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/user/BulkCodes/BulkCodesSkeleton.module.scss
+++ b/src/features/user/BulkCodes/BulkCodesSkeleton.module.scss
@@ -1,0 +1,6 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+}

--- a/src/features/user/BulkCodes/BulkCodesSkeleton.tsx
+++ b/src/features/user/BulkCodes/BulkCodesSkeleton.tsx
@@ -1,0 +1,88 @@
+import type { ReactElement } from 'react';
+import type { TabItem } from '../../common/Layout/TabbedView/TabbedViewTypes';
+
+import { useTranslations } from 'next-intl';
+import DashboardView from '../../common/Layout/DashboardView';
+import TabbedView from '../../common/Layout/TabbedView';
+import { SkeletonBlock } from '../../common/ContentLoaders/Skeleton';
+import { BulkCodeSteps } from './index';
+import styles from './BulkCodesSkeleton.module.scss';
+
+interface BulkCodesSkeletonProps {
+  step?: BulkCodeSteps;
+}
+
+/**
+ * Loading shape for all three bulk-codes steps (select method, select
+ * project, issue codes). The DashboardView + TabbedView shell is identical
+ * across steps, so it's reused as-is with its real, already-loaded title and
+ * tab labels; only the step content, which differs, is a placeholder.
+ *
+ * `step` must match the step of the page rendering this skeleton, so the
+ * active tab and disabled state reflect the route the user is actually on
+ * (e.g. a refresh on the select-project step shouldn't show the
+ * select-method tab state).
+ */
+export default function BulkCodesSkeleton({
+  step = BulkCodeSteps.SELECT_METHOD,
+}: BulkCodesSkeletonProps): ReactElement {
+  const t = useTranslations('BulkCodes');
+
+  const tabItems: TabItem[] = [
+    {
+      label: t('tabCreationMethod'),
+      link: '',
+      step: BulkCodeSteps.SELECT_METHOD,
+    },
+    {
+      label: t('tabSelectProject'),
+      link: '',
+      step: BulkCodeSteps.SELECT_PROJECT,
+      disabled: step === BulkCodeSteps.SELECT_METHOD,
+    },
+    {
+      label: t('tabIssueCodes'),
+      link: '',
+      step: BulkCodeSteps.ISSUE_CODES,
+      disabled: step !== BulkCodeSteps.ISSUE_CODES,
+    },
+  ];
+
+  // Each step's real form has a different number of top-level sections
+  // (select method: two side-by-side option cards; select project: one
+  // selector; issue codes: one form), so the placeholder count must follow
+  // the step too, not just the active tab.
+  const renderContent = () => {
+    switch (step) {
+      case BulkCodeSteps.SELECT_PROJECT:
+        return <SkeletonBlock height={56} borderRadius={9} />;
+      case BulkCodeSteps.ISSUE_CODES:
+        return <SkeletonBlock height={400} borderRadius={9} />;
+      case BulkCodeSteps.SELECT_METHOD:
+      default:
+        return (
+          <>
+            <SkeletonBlock height={130} borderRadius={9} />
+            <SkeletonBlock height={130} borderRadius={9} />
+          </>
+        );
+    }
+  };
+
+  return (
+    <DashboardView
+      title={t('bulkCodesTitle')}
+      subtitle={
+        <span aria-hidden="true">
+          <SkeletonBlock width={280} height={16} />
+        </span>
+      }
+    >
+      <TabbedView step={step} tabItems={tabItems}>
+        <div className={styles.content} aria-hidden="true">
+          {renderContent()}
+        </div>
+      </TabbedView>
+    </DashboardView>
+  );
+}

--- a/src/features/user/DonationReceipt/DonationReceipts.tsx
+++ b/src/features/user/DonationReceipt/DonationReceipts.tsx
@@ -18,8 +18,7 @@ import {
   transformProfileToPrimaryAddressView,
 } from './transformers';
 import { useApi } from '../../../hooks/useApi';
-import Skeleton from 'react-loading-skeleton';
-import 'react-loading-skeleton/dist/skeleton.css';
+import DonationReceiptsSkeleton from './DonationReceiptsSkeleton';
 import NoDataFound from '../../../../public/assets/images/icons/projectV2/NoDataFound';
 import useLocalizedPath from '../../../hooks/useLocalizedPath';
 import { useRouter } from 'next/router';
@@ -165,12 +164,7 @@ const DonationReceipts = () => {
   const hasNoReceipts =
     !donationReceipts?.issued.length && !donationReceipts?.unissued.length;
 
-  if (!donationReceipts)
-    return (
-      <section className={styles.donorContactManagementLayout}>
-        <Skeleton height={600} width={524} />
-      </section>
-    );
+  if (!donationReceipts) return <DonationReceiptsSkeleton />;
 
   if (hasNoReceipts)
     return (

--- a/src/features/user/DonationReceipt/DonationReceiptsSkeleton.tsx
+++ b/src/features/user/DonationReceipt/DonationReceiptsSkeleton.tsx
@@ -1,0 +1,70 @@
+import type { ReactElement } from 'react';
+
+import {
+  SkeletonBlock,
+  SkeletonCircle,
+} from '../../common/ContentLoaders/Skeleton';
+import styles from './DonationReceipt.module.scss';
+
+const ReceiptCardSkeleton = (): ReactElement => (
+  <div className={styles.donationReceiptCard} aria-hidden="true">
+    <div className={styles.donationInfo}>
+      <SkeletonBlock width={130} height={28} />
+      <SkeletonBlock width={190} height={16} />
+    </div>
+    <SkeletonBlock
+      width={159}
+      height={40}
+      borderRadius={8}
+      className={styles.receiptCardButton}
+    />
+  </div>
+);
+
+const YearGroupSkeleton = ({
+  cardCount,
+}: {
+  cardCount: number;
+}): ReactElement => (
+  <div className={styles.yearlyReceiptGroup} aria-hidden="true">
+    <div className={styles.yearHeader}>
+      <SkeletonBlock width={90} height={34} />
+      <SkeletonBlock width={187} height={44} borderRadius={12} />
+    </div>
+    <div className={styles.yearReceiptCards}>
+      {Array.from({ length: cardCount }).map((_, index) => (
+        <ReceiptCardSkeleton key={index} />
+      ))}
+    </div>
+  </div>
+);
+
+/**
+ * Loading shape for the donation receipt list (this feature's own CSS
+ * classes are reused directly, in place of a shared shell component like
+ * DashboardView, since the real page doesn't use one either).
+ */
+export default function DonationReceiptsSkeleton(): ReactElement {
+  return (
+    <section className={styles.donorContactManagementLayout} aria-hidden="true">
+      <SkeletonBlock
+        width={220}
+        height={28}
+        className={styles.receiptListHeader}
+      />
+      <section className={styles.donationReceipts}>
+        <YearGroupSkeleton cardCount={2} />
+        <YearGroupSkeleton cardCount={2} />
+      </section>
+      <footer className={styles.receiptListFooter} aria-hidden="true">
+        <div className={styles.contactInfo}>
+          <SkeletonCircle size={24} />
+          <div>
+            <SkeletonBlock width={280} height={16} />
+            <SkeletonBlock width={220} height={16} />
+          </div>
+        </div>
+      </footer>
+    </section>
+  );
+}

--- a/src/features/user/ManagePayouts/PayoutsSkeleton.module.scss
+++ b/src/features/user/ManagePayouts/PayoutsSkeleton.module.scss
@@ -1,0 +1,6 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+}

--- a/src/features/user/ManagePayouts/PayoutsSkeleton.tsx
+++ b/src/features/user/ManagePayouts/PayoutsSkeleton.tsx
@@ -15,7 +15,13 @@ import styles from './PayoutsSkeleton.module.scss';
  * Only the per-tab content (a bank account list or a form), which differs,
  * is a placeholder.
  */
-export default function PayoutsSkeleton(): ReactElement {
+interface PayoutsSkeletonProps {
+  step?: ManagePayoutTabs;
+}
+
+export default function PayoutsSkeleton({
+  step = ManagePayoutTabs.OVERVIEW,
+}: PayoutsSkeletonProps): ReactElement {
   const t = useTranslations('ManagePayouts');
 
   const tabItems: TabItem[] = [
@@ -41,7 +47,7 @@ export default function PayoutsSkeleton(): ReactElement {
         </span>
       }
     >
-      <TabbedView step={ManagePayoutTabs.OVERVIEW} tabItems={tabItems}>
+      <TabbedView step={step} tabItems={tabItems}>
         <div className={styles.content} aria-hidden="true">
           <SkeletonBlock height={120} borderRadius={9} />
           <SkeletonBlock height={120} borderRadius={9} />

--- a/src/features/user/ManagePayouts/PayoutsSkeleton.tsx
+++ b/src/features/user/ManagePayouts/PayoutsSkeleton.tsx
@@ -1,0 +1,52 @@
+import type { ReactElement } from 'react';
+import type { TabItem } from '../../common/Layout/TabbedView/TabbedViewTypes';
+
+import { useTranslations } from 'next-intl';
+import DashboardView from '../../common/Layout/DashboardView';
+import TabbedView from '../../common/Layout/TabbedView';
+import { SkeletonBlock } from '../../common/ContentLoaders/Skeleton';
+import { ManagePayoutTabs } from './index';
+import styles from './PayoutsSkeleton.module.scss';
+
+/**
+ * Loading shape shared by the overview, add-bank-details, edit-bank-details,
+ * and payout-schedule routes: they all render the same DashboardView +
+ * TabbedView shell, reused here as-is with its real title and tab labels.
+ * Only the per-tab content (a bank account list or a form), which differs,
+ * is a placeholder.
+ */
+export default function PayoutsSkeleton(): ReactElement {
+  const t = useTranslations('ManagePayouts');
+
+  const tabItems: TabItem[] = [
+    { label: t('tabOverview'), link: '', step: ManagePayoutTabs.OVERVIEW },
+    {
+      label: t('tabPayoutSchedule'),
+      link: '',
+      step: ManagePayoutTabs.PAYOUT_SCHEDULE,
+    },
+    {
+      label: t('tabAddBankDetails'),
+      link: '',
+      step: ManagePayoutTabs.ADD_BANK_DETAILS,
+    },
+  ];
+
+  return (
+    <DashboardView
+      title={t('title')}
+      subtitle={
+        <span aria-hidden="true">
+          <SkeletonBlock width={280} height={16} />
+        </span>
+      }
+    >
+      <TabbedView step={ManagePayoutTabs.OVERVIEW} tabItems={tabItems}>
+        <div className={styles.content} aria-hidden="true">
+          <SkeletonBlock height={120} borderRadius={9} />
+          <SkeletonBlock height={120} borderRadius={9} />
+        </div>
+      </TabbedView>
+    </DashboardView>
+  );
+}

--- a/src/features/user/ManageProjects/ManageProjectsSkeleton.module.scss
+++ b/src/features/user/ManageProjects/ManageProjectsSkeleton.module.scss
@@ -1,0 +1,18 @@
+.ctaRow {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.cardGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.tabContent {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+}

--- a/src/features/user/ManageProjects/ManageProjectsSkeleton.tsx
+++ b/src/features/user/ManageProjects/ManageProjectsSkeleton.tsx
@@ -1,0 +1,131 @@
+import type { ReactElement } from 'react';
+import type { TabItem } from '../../common/Layout/TabbedView/TabbedViewTypes';
+
+import { useTranslations } from 'next-intl';
+import DashboardView from '../../common/Layout/DashboardView';
+import SingleColumnView from '../../common/Layout/SingleColumnView';
+import TabbedView from '../../common/Layout/TabbedView';
+import { SkeletonBlock } from '../../common/ContentLoaders/Skeleton';
+import { ProjectCreationTabs } from './index';
+import styles from './ManageProjectsSkeleton.module.scss';
+
+interface ManageProjectsSkeletonProps {
+  /**
+   * `list` mirrors the project list route (a CTA row and a card grid).
+   * `tabbed` mirrors the create/edit-project routes, which share a
+   * DashboardView + TabbedView shell across all of their steps.
+   */
+  variant?: 'list' | 'tabbed';
+  /** Real, already-translated title, when known ahead of any fetch (e.g. "add new project"). Left blank for the edit route, whose title is the fetched project's name. */
+  title?: string;
+  /**
+   * `tabbed` variant only. Must match the step of the page rendering this
+   * skeleton: the "project type" step only ever shows on its own (a project
+   * hasn't been created yet, so there's nothing else to navigate to), while
+   * every later step shows the full basic-details-through-review menu, never
+   * "project type" (an existing project can't change its type). Defaults to
+   * `PROJECT_TYPE` for the create-project route, which starts there.
+   */
+  step?: ProjectCreationTabs;
+}
+
+/** Loading shape for the manage-projects routes: the project list, and the multi-step project create/edit flow. */
+export default function ManageProjectsSkeleton({
+  variant = 'list',
+  title,
+  step = ProjectCreationTabs.PROJECT_TYPE,
+}: ManageProjectsSkeletonProps): ReactElement {
+  const t = useTranslations('ManageProjects');
+
+  if (variant === 'tabbed') {
+    const isProjectTypeStep = step === ProjectCreationTabs.PROJECT_TYPE;
+
+    const tabItems: TabItem[] = isProjectTypeStep
+      ? [
+          {
+            label: t('projectType'),
+            link: '',
+            step: ProjectCreationTabs.PROJECT_TYPE,
+          },
+        ]
+      : [
+          {
+            label: t('basicDetails'),
+            link: '',
+            step: ProjectCreationTabs.BASIC_DETAILS,
+          },
+          {
+            label: t('projectMedia'),
+            link: '',
+            step: ProjectCreationTabs.PROJECT_MEDIA,
+          },
+          {
+            label: t('detailedAnalysis'),
+            link: '',
+            step: ProjectCreationTabs.DETAILED_ANALYSIS,
+          },
+          {
+            label: t('projectSites'),
+            link: '',
+            step: ProjectCreationTabs.PROJECT_SITES,
+          },
+          {
+            label: t('projectSpending'),
+            link: '',
+            step: ProjectCreationTabs.PROJECT_SPENDING,
+          },
+          {
+            label: t('review'),
+            link: '',
+            step: ProjectCreationTabs.REVIEW,
+          },
+        ];
+
+    return (
+      <DashboardView
+        title={title ?? ''}
+        subtitle={
+          <span aria-hidden="true">
+            <SkeletonBlock width={280} height={16} />
+          </span>
+        }
+      >
+        <TabbedView step={step} tabItems={tabItems}>
+          <div className={styles.tabContent} aria-hidden="true">
+            {isProjectTypeStep ? (
+              <>
+                <SkeletonBlock height={130} borderRadius={9} />
+                <SkeletonBlock height={130} borderRadius={9} />
+              </>
+            ) : (
+              <SkeletonBlock height={400} borderRadius={9} />
+            )}
+          </div>
+        </TabbedView>
+      </DashboardView>
+    );
+  }
+
+  return (
+    <DashboardView
+      title={t('manageProject')}
+      subtitle={
+        <span aria-hidden="true">
+          <SkeletonBlock width={'80%'} height={16} count={2} />
+        </span>
+      }
+    >
+      <SingleColumnView>
+        <div className={styles.ctaRow} aria-hidden="true">
+          <SkeletonBlock width={140} height={40} borderRadius={8} />
+          <SkeletonBlock width={160} height={40} borderRadius={8} />
+        </div>
+        <div className={styles.cardGrid} aria-hidden="true">
+          <SkeletonBlock height={100} borderRadius={9} />
+          <SkeletonBlock height={100} borderRadius={9} />
+          <SkeletonBlock height={100} borderRadius={9} />
+        </div>
+      </SingleColumnView>
+    </DashboardView>
+  );
+}

--- a/src/features/user/Profile/ProfileLayout/ProfileGridSkeleton.tsx
+++ b/src/features/user/Profile/ProfileLayout/ProfileGridSkeleton.tsx
@@ -15,9 +15,10 @@ export const PROFILE_SECTION_HEIGHTS = {
 } as const;
 
 /**
- * Full profile grid in its loading state. Rendered both by ProfileLayout while
- * the my-forest data loads and by UserProfileLoader while the user context
- * loads, so the two phases share identical geometry and avoid layout shift.
+ * Full profile grid in its loading state. Rendered by ProfileLayout while the
+ * my-forest data loads, and passed to UserLayout as the `skeleton` for
+ * `/profile` while the user context loads, so both phases share identical
+ * geometry and avoid layout shift.
  */
 const ProfileGridSkeleton = () => {
   return (

--- a/src/features/user/Settings/SettingsFormSkeleton.module.scss
+++ b/src/features/user/Settings/SettingsFormSkeleton.module.scss
@@ -1,0 +1,35 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 100%;
+
+  & + & {
+    margin-top: 24px;
+  }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.subtitle {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.plainContent {
+  margin-top: 80px;
+  padding: 20px 40px 40px;
+}

--- a/src/features/user/Settings/SettingsFormSkeleton.tsx
+++ b/src/features/user/Settings/SettingsFormSkeleton.tsx
@@ -1,0 +1,98 @@
+import type { ReactElement, ReactNode } from 'react';
+
+import DashboardView from '../../common/Layout/DashboardView';
+import SingleColumnView from '../../common/Layout/SingleColumnView';
+import CenteredContainer from '../../common/Layout/CenteredContainer';
+import { SkeletonBlock } from '../../common/ContentLoaders/Skeleton';
+import styles from './SettingsFormSkeleton.module.scss';
+
+interface SettingsFormSkeletonProps {
+  /** Real, already-translated page title, shown via the real DashboardView header. */
+  title?: string;
+  /**
+   * How the page frames its content: `dashboard` (DashboardView header, the
+   * shape most of these routes use), `section` (a back-button + heading,
+   * e.g. donor contact management), or `none` (no header at all, e.g. the
+   * widgets route, which is just an embed).
+   */
+  variant?: 'dashboard' | 'section' | 'none';
+  /** Number of placeholder lines under the title, `dashboard` variant only. */
+  subtitleLines?: number;
+  /** Number of stacked field groups the form has (e.g. edit profile also has a separate address section). */
+  sections?: number;
+  /** Number of label+input rows per field group. */
+  fieldsPerSection?: number;
+}
+
+const FieldGroup = ({ fieldCount }: { fieldCount: number }): ReactElement => (
+  <div className={styles.section} aria-hidden="true">
+    {Array.from({ length: fieldCount }).map((_, index) => (
+      <div key={index} className={styles.field}>
+        <SkeletonBlock height={14} width={120} />
+        <SkeletonBlock height={40} />
+      </div>
+    ))}
+    <SkeletonBlock height={40} width={140} borderRadius={8} />
+  </div>
+);
+
+/**
+ * Shared loading shape for the settings/single-form routes: api key, edit
+ * profile, delete account, donation link, gift funds, impersonate user,
+ * widgets, and donor contact management. Their forms share the same basic
+ * shape (a header, one or more stacked field groups), so one component
+ * covers all of them via props rather than duplicating a near-identical
+ * skeleton per route.
+ */
+export default function SettingsFormSkeleton({
+  title,
+  variant = 'dashboard',
+  subtitleLines = 1,
+  sections = 1,
+  fieldsPerSection = 3,
+}: SettingsFormSkeletonProps): ReactElement {
+  const content: ReactNode = (
+    <>
+      {Array.from({ length: sections }).map((_, index) => (
+        <FieldGroup key={index} fieldCount={fieldsPerSection} />
+      ))}
+    </>
+  );
+
+  if (variant === 'none') {
+    return (
+      <div className={styles.plainContent} aria-hidden="true">
+        <SkeletonBlock height={500} />
+      </div>
+    );
+  }
+
+  if (variant === 'section') {
+    return (
+      <div className={styles.plainContent} aria-hidden="true">
+        <div className={styles.sectionHeader}>
+          <SkeletonBlock width={24} height={24} borderRadius={6} />
+          <SkeletonBlock width={220} height={24} />
+        </div>
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <DashboardView
+      title={title ?? ''}
+      subtitle={
+        subtitleLines > 0 ? (
+          <div className={styles.subtitle} aria-hidden="true">
+            <SkeletonBlock count={subtitleLines} width={'80%'} height={16} />
+          </div>
+        ) : undefined
+      }
+    >
+      <SingleColumnView>
+        <CenteredContainer>{content}</CenteredContainer>
+      </SingleColumnView>
+    </DashboardView>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a generic `SkeletonBlock` primitive and per-route skeleton loading shapes, replacing the generic `react-loading-skeleton` placeholder used across the app.
- Cover UserLayout, bulk-codes, manage-payouts, manage-projects, settings/single-form pages, and the project list and project details pages under projectsV2.
- Each skeleton mirrors the shape of the real content it precedes (cards, sections, form rows) so layout doesn't shift once data loads, and mobile variants match their real component's responsive styles.

## Test plan
- [ ] Verify each route's skeleton renders correctly on both desktop and mobile viewports: user layout shell, bulk-codes, manage payouts, manage projects, settings/single-form pages, project list, and project details.
- [ ] Confirm the skeleton-to-content transition doesn't cause layout shift on slow network throttling.
- [ ] Run `npm run lint` and `npm run build`.