### PR TITLE
Refactor getDonationUrl to take a single options object

### DIFF
--- a/src/features/projectsV2/ProjectSnippet/microComponents/ProjectInfoSection.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/ProjectInfoSection.tsx
@@ -40,15 +40,14 @@ const ProjectInfoSection = (props: ProjectInfoProps) => {
   const callbackUrl = useQueryParamStore((state) => state.callbackUrl);
   const token = useAuthStore((state) => state.token);
 
-  const donateLink = getDonationUrl(
-    tenantId,
-    slug,
+  const donateLink = getDonationUrl({
+    tenant: tenantId,
+    target: slug,
     token,
-    embed || undefined,
-    callbackUrl || undefined,
-    undefined,
-    utmCampaign || undefined
-  );
+    embed: embed || undefined,
+    callbackUrl: callbackUrl || undefined,
+    utmCampaign: utmCampaign || undefined,
+  });
   const donationLabel = useMemo(() => {
     if (unitCount === undefined) {
       return;

--- a/src/features/user/BulkCodes/components/BulkCodesError.tsx
+++ b/src/features/user/BulkCodes/components/BulkCodesError.tsx
@@ -34,7 +34,11 @@ const BulkCodesError = (): ReactElement | null => {
     }
 
     if (planetCash.balance + planetCash.creditLimit <= 0) {
-      const donationUrl = getDonationUrl(tenantId, 'planetcash', token);
+      const donationUrl = getDonationUrl({
+        tenant: tenantId,
+        target: 'planetcash',
+        token,
+      });
 
       return (
         <div>

--- a/src/features/user/PlanetCash/components/AccountDetails.tsx
+++ b/src/features/user/PlanetCash/components/AccountDetails.tsx
@@ -73,7 +73,11 @@ const AccountDetails = ({ account }: AccountDetailsProps): ReactElement => {
   const token = useAuthStore((state) => state.token);
   const tenantId = useTenantStore((state) => state.tenantConfig.id);
 
-  const addBalanceLink = getDonationUrl(tenantId, 'planetcash', token);
+  const addBalanceLink = getDonationUrl({
+    tenant: tenantId,
+    target: 'planetcash',
+    token,
+  });
 
   return (
     <Grid

--- a/src/features/user/Profile/MyContributions/DonateButton.tsx
+++ b/src/features/user/Profile/MyContributions/DonateButton.tsx
@@ -43,14 +43,13 @@ const DonateButton = (props: DonateButtonProps) => {
   });
 
   // Construct donate link
-  const donateLink = getDonationUrl(
-    tenantId,
-    projectSlug,
+  const donateLink = getDonationUrl({
+    tenant: tenantId,
+    target: projectSlug,
     token,
-    undefined,
-    undefined,
-    type === 'supported' ? props.supportedTreecounter : undefined
-  );
+    recipientSlug:
+      type === 'supported' ? props.supportedTreecounter : undefined,
+  });
 
   return (
     <WebappButton

--- a/src/utils/getDonationUrl.test.ts
+++ b/src/utils/getDonationUrl.test.ts
@@ -31,7 +31,9 @@ describe('getDonationUrl', () => {
 
   describe('country and locale', () => {
     it('falls back to DE and en when localStorage is empty', () => {
-      const query = queryOf(getDonationUrl(undefined, 'project-1', null));
+      const query = queryOf(
+        getDonationUrl({ target: 'project-1', token: null })
+      );
 
       expect(query.get('country')).toBe('DE');
       expect(query.get('locale')).toBe('en');
@@ -41,7 +43,9 @@ describe('getDonationUrl', () => {
       localStorage.setItem('countryCode', 'IN');
       localStorage.setItem('language', 'de');
 
-      const query = queryOf(getDonationUrl(undefined, 'project-1', null));
+      const query = queryOf(
+        getDonationUrl({ target: 'project-1', token: null })
+      );
 
       expect(query.get('country')).toBe('IN');
       expect(query.get('locale')).toBe('de');
@@ -53,7 +57,12 @@ describe('getDonationUrl', () => {
       const callbackUrl = 'https://host.example/page?ref=abc&utm_source=news';
 
       const query = queryOf(
-        getDonationUrl(undefined, 'project-1', null, 'true', callbackUrl)
+        getDonationUrl({
+          target: 'project-1',
+          token: null,
+          embed: 'true',
+          callbackUrl,
+        })
       );
 
       expect(query.get('callback_url')).toBe(callbackUrl);
@@ -64,13 +73,13 @@ describe('getDonationUrl', () => {
 
     it('does not let a callback url override another param', () => {
       const query = queryOf(
-        getDonationUrl(
-          'real-tenant',
-          'project-1',
-          null,
-          'true',
-          'https://host.example/page?tenant=spoofed&token=spoofed'
-        )
+        getDonationUrl({
+          tenant: 'real-tenant',
+          target: 'project-1',
+          token: null,
+          embed: 'true',
+          callbackUrl: 'https://host.example/page?tenant=spoofed&token=spoofed',
+        })
       );
 
       expect(query.get('tenant')).toBe('real-tenant');
@@ -82,13 +91,12 @@ describe('getDonationUrl', () => {
       setCurrentUrl('/current-page');
 
       const query = queryOf(
-        getDonationUrl(
-          undefined,
-          'project-1',
-          null,
-          'true',
-          'https://host.example/embedded'
-        )
+        getDonationUrl({
+          target: 'project-1',
+          token: null,
+          embed: 'true',
+          callbackUrl: 'https://host.example/embedded',
+        })
       );
 
       expect(query.get('callback_url')).toBe('https://host.example/embedded');
@@ -98,13 +106,11 @@ describe('getDonationUrl', () => {
       setCurrentUrl('/current-page');
 
       const query = queryOf(
-        getDonationUrl(
-          undefined,
-          'project-1',
-          null,
-          undefined,
-          'https://host.example/embedded'
-        )
+        getDonationUrl({
+          target: 'project-1',
+          token: null,
+          callbackUrl: 'https://host.example/embedded',
+        })
       );
 
       expect(query.get('callback_url')).toBe(window.location.href);
@@ -113,7 +119,12 @@ describe('getDonationUrl', () => {
 
     it('omits the param in embed mode when no callback url is given', () => {
       const query = queryOf(
-        getDonationUrl(undefined, 'project-1', null, 'true', undefined)
+        getDonationUrl({
+          target: 'project-1',
+          token: null,
+          embed: 'true',
+          callbackUrl: undefined,
+        })
       );
 
       expect(query.has('callback_url')).toBe(false);
@@ -125,14 +136,11 @@ describe('getDonationUrl', () => {
       storeDirectGift({ id: 'gift-1' });
 
       const query = queryOf(
-        getDonationUrl(
-          undefined,
-          'project-1',
-          null,
-          undefined,
-          undefined,
-          'slug-1'
-        )
+        getDonationUrl({
+          target: 'project-1',
+          token: null,
+          recipientSlug: 'slug-1',
+        })
       );
 
       expect(query.get('s')).toBe('gift-1');
@@ -142,14 +150,11 @@ describe('getDonationUrl', () => {
       storeDirectGift({ recipientName: 'Someone' });
 
       const query = queryOf(
-        getDonationUrl(
-          undefined,
-          'project-1',
-          null,
-          undefined,
-          undefined,
-          'slug-1'
-        )
+        getDonationUrl({
+          target: 'project-1',
+          token: null,
+          recipientSlug: 'slug-1',
+        })
       );
 
       expect(query.get('s')).toBe('slug-1');
@@ -157,21 +162,20 @@ describe('getDonationUrl', () => {
 
     it('uses the slug when there is no stored direct gift', () => {
       const query = queryOf(
-        getDonationUrl(
-          undefined,
-          'project-1',
-          null,
-          undefined,
-          undefined,
-          'slug-1'
-        )
+        getDonationUrl({
+          target: 'project-1',
+          token: null,
+          recipientSlug: 'slug-1',
+        })
       );
 
       expect(query.get('s')).toBe('slug-1');
     });
 
     it('omits the param when there is neither a direct gift nor a slug', () => {
-      const query = queryOf(getDonationUrl(undefined, 'project-1', null));
+      const query = queryOf(
+        getDonationUrl({ target: 'project-1', token: null })
+      );
 
       expect(query.has('s')).toBe(false);
     });
@@ -180,25 +184,19 @@ describe('getDonationUrl', () => {
       storeDirectGift('not json');
 
       expect(() =>
-        getDonationUrl(
-          undefined,
-          'project-1',
-          null,
-          undefined,
-          undefined,
-          'slug-1'
-        )
+        getDonationUrl({
+          target: 'project-1',
+          token: null,
+          recipientSlug: 'slug-1',
+        })
       ).not.toThrow();
       expect(
         queryOf(
-          getDonationUrl(
-            undefined,
-            'project-1',
-            null,
-            undefined,
-            undefined,
-            'slug-1'
-          )
+          getDonationUrl({
+            target: 'project-1',
+            token: null,
+            recipientSlug: 'slug-1',
+          })
         ).get('s')
       ).toBe('slug-1');
     });
@@ -206,7 +204,9 @@ describe('getDonationUrl', () => {
 
   describe('optional params', () => {
     it('omits token, tenant and utm_campaign when they are absent', () => {
-      const query = queryOf(getDonationUrl(undefined, 'project-1', null));
+      const query = queryOf(
+        getDonationUrl({ target: 'project-1', token: null })
+      );
 
       expect(query.has('token')).toBe(false);
       expect(query.has('tenant')).toBe(false);
@@ -215,15 +215,12 @@ describe('getDonationUrl', () => {
 
     it('includes token, tenant and utm_campaign when they are given', () => {
       const query = queryOf(
-        getDonationUrl(
-          'ten-1',
-          'project-1',
-          'tok-1',
-          undefined,
-          undefined,
-          undefined,
-          'camp-1'
-        )
+        getDonationUrl({
+          tenant: 'ten-1',
+          target: 'project-1',
+          token: 'tok-1',
+          utmCampaign: 'camp-1',
+        })
       );
 
       expect(query.get('token')).toBe('tok-1');
@@ -233,7 +230,12 @@ describe('getDonationUrl', () => {
 
     it('encodes reserved characters in a value', () => {
       const query = queryOf(
-        getDonationUrl('ten&1', 'project 1', null, undefined, undefined, 'a=b')
+        getDonationUrl({
+          tenant: 'ten&1',
+          target: 'project 1',
+          token: null,
+          recipientSlug: 'a=b',
+        })
       );
 
       expect(query.get('to')).toBe('project 1');
@@ -248,15 +250,15 @@ describe('getDonationUrl', () => {
     localStorage.setItem('language', 'de');
 
     expect(
-      getDonationUrl(
-        'ten-1',
-        'project-1',
-        'tok-1',
-        'true',
-        'https://host.example/page',
-        'slug-1',
-        'camp-1'
-      )
+      getDonationUrl({
+        tenant: 'ten-1',
+        target: 'project-1',
+        token: 'tok-1',
+        embed: 'true',
+        callbackUrl: 'https://host.example/page',
+        recipientSlug: 'slug-1',
+        utmCampaign: 'camp-1',
+      })
     ).toBe(
       `${DONATION_URL}/?to=project-1&callback_url=https%3A%2F%2Fhost.example%2Fpage&country=IN&locale=de&token=tok-1&tenant=ten-1&s=slug-1&utm_campaign=camp-1`
     );

--- a/src/utils/getDonationUrl.ts
+++ b/src/utils/getDonationUrl.ts
@@ -1,13 +1,27 @@
+type DonationUrlOptions = {
+  tenant?: string;
+  /** Project slug, or 'planetcash' to top up a PlanetCash balance. */
+  target: string;
+  token?: string | null;
+  embed?: string;
+  callbackUrl?: string;
+  /** Direct-gift recipient slug, used for the `s` param. */
+  recipientSlug?: string;
+  utmCampaign?: string;
+};
+
 // calling this function before window is loaded may cause an error
-export const getDonationUrl = (
-  tenant: string | undefined,
-  id: string,
-  token: string | null,
-  embed?: string,
-  callbackUrl?: string,
-  slug?: string,
-  utmCampaign?: string
-): string => {
+export const getDonationUrl = (options: DonationUrlOptions): string => {
+  const {
+    tenant,
+    target,
+    token,
+    embed,
+    callbackUrl,
+    recipientSlug,
+    utmCampaign,
+  } = options;
+
   const country = localStorage.getItem('countryCode') || 'DE';
   const language = localStorage.getItem('language') || 'en';
 
@@ -24,12 +38,12 @@ export const getDonationUrl = (
   const callbackUrlValue =
     embed === 'true' ? callbackUrl : window.location.href;
 
-  // directGift.id, when present, takes precedence over slug for the 's' param
+  // directGift.id, when present, takes precedence over recipientSlug for the 's' param
   const giftSlug =
-    directGift && directGift.id !== undefined ? directGift.id : slug;
+    directGift && directGift.id !== undefined ? directGift.id : recipientSlug;
 
   const queryParams = [
-    `to=${encodeURIComponent(id)}`,
+    `to=${encodeURIComponent(target)}`,
     callbackUrlValue !== undefined
       ? `callback_url=${encodeURIComponent(callbackUrlValue)}`
       : undefined,


### PR DESCRIPTION
## Summary
- Converts `getDonationUrl` from seven positional parameters to a single `DonationUrlOptions` object, so callers no longer need to pad earlier params with `undefined` to reach a later one.
- Renames `id` to `target` (it's a project slug or the literal `'planetcash'`) and `slug` to `recipientSlug` (the direct-gift recipient slug used for the `s` param) to remove the ambiguity flagged in the issue.
- Updates the four call sites (`DonateButton.tsx`, `AccountDetails.tsx`, `BulkCodesError.tsx`, `ProjectInfoSection.tsx`) to pass named fields.
- Internal query-param array and `join('&')` composition are untouched, as scoped by the issue.

Closes #3079

## Test plan
- [x] `getDonationUrl.test.ts` updated to the new call signature; the characterization test's asserted output URL is unchanged, proving the refactor is behavior-preserving
- [x] `npx vitest run` — all 45 tests pass
- [x] `npx tsc --noEmit` — no new errors introduced by this change
- [x] `npx eslint` and `npx prettier --check` clean on all changed files