### PR TITLE
refactor(auth): shared is-the-user-ready selectors

### DIFF
--- a/src/features/common/Layout/CookiePolicy/index.tsx
+++ b/src/features/common/Layout/CookiePolicy/index.tsx
@@ -4,22 +4,20 @@ import IconButton from '../../IconButton';
 import styles from './CookiePolicy.module.scss';
 import { useLocale, useTranslations } from 'next-intl';
 import themeProperties from '../../../../theme/themeProperties';
-import { useAuthStore, useUserStore } from '../../../../stores';
+import { useIsProfileReady } from '../../../../hooks/useAuthReadiness';
 
 export default function CookiePolicy() {
   const [showCookieNotice, setShowCookieNotice] = useState(false);
   const t = useTranslations('Common');
   const locale = useLocale();
 
-  //store: state
-  const userProfile = useUserStore((state) => state.userProfile);
-  const isAuthResolved = useAuthStore((state) => state.isAuthResolved);
+  const isProfileReady = useIsProfileReady();
 
   useEffect(() => {
-    if (isAuthResolved && userProfile) {
+    if (isProfileReady) {
       setShowCookieNotice(false);
     }
-  }, [isAuthResolved, userProfile]);
+  }, [isProfileReady]);
 
   const isMountedRef = useRef(false);
 

--- a/src/features/user/BulkCodes/components/ProjectSelector.tsx
+++ b/src/features/user/BulkCodes/components/ProjectSelector.tsx
@@ -6,11 +6,8 @@ import ProjectSelectAutocomplete from '../../../common/ProjectSelectAutocomplete
 import UnitCostDisplay from './UnitCostDisplay';
 import { handleError } from '@planet-sdk/common';
 import { useApi } from '../../../../hooks/useApi';
-import {
-  useAuthStore,
-  useUserStore,
-  useErrorHandlingStore,
-} from '../../../../stores';
+import { useIsAuthReady } from '../../../../hooks/useAuthReadiness';
+import { useUserStore, useErrorHandlingStore } from '../../../../stores';
 import { useBulkCodeStore } from '../../../../stores/bulkCodeStore';
 import { useTranslations } from 'next-intl';
 
@@ -26,10 +23,8 @@ const ProjectSelector = ({
 }: ProjectSelectorProps): ReactElement | null => {
   const tBulkCodes = useTranslations('BulkCodes');
   const { getApiAuthenticated } = useApi();
+  const isAuthReady = useIsAuthReady();
   //store: state
-  const isAuthReady = useAuthStore(
-    (state) => state.token !== null && state.isAuthResolved
-  );
   const userProfile = useUserStore((state) => state.userProfile);
   const projectList = useBulkCodeStore((state) => state.projectList);
   const planetCashAccount = useBulkCodeStore(

--- a/src/features/user/CompleteSignup/index.tsx
+++ b/src/features/user/CompleteSignup/index.tsx
@@ -18,6 +18,7 @@ import { getStoredConfig } from '../../../utils/storeConfig';
 import { useTranslations } from 'next-intl';
 import { handleError } from '@planet-sdk/common';
 import { useApi } from '../../../hooks/useApi';
+import { useIsAuthReady } from '../../../hooks/useAuthReadiness';
 import useLocalizedPath from '../../../hooks/useLocalizedPath';
 import { useRouter } from 'next/router';
 import SignupToggles from './components/SignupToggles';
@@ -65,6 +66,7 @@ export default function CompleteSignup(): ReactElement | null {
   const t = useTranslations('EditProfile');
   const { postApi } = useApi();
   const { auth0User } = useAuthSession();
+  const isAuthReady = useIsAuthReady();
 
   // local state
   const [isProcessing, setIsProcessing] = useState(false);
@@ -143,7 +145,8 @@ export default function CompleteSignup(): ReactElement | null {
   };
   const handleCreateAccount = async (data: SignupFormData) => {
     setFormSubmitted(true);
-    if (!agreedToTerms || !country || !isAuthResolved || !token) return;
+    // token is re-checked here (isAuthReady already implies it) so TS can narrow it for oAuthAccessToken below.
+    if (!agreedToTerms || !country || !isAuthReady || !token) return;
 
     const { isPublic, ...otherData } = data;
     const submitData = {

--- a/src/features/user/DonationReceipt/DonationReceipts.tsx
+++ b/src/features/user/DonationReceipt/DonationReceipts.tsx
@@ -29,11 +29,11 @@ import {
   getOverviewEligibilityForAllYears,
 } from './receiptGroupingUtils';
 import {
-  useAuthStore,
   useUserStore,
   useErrorHandlingStore,
   useDonationReceiptStore,
 } from '../../../stores';
+import { useIsProfileReady } from '../../../hooks/useAuthReadiness';
 
 const DonationReceipts = () => {
   const { getApiAuthenticated } = useApi();
@@ -56,13 +56,13 @@ const DonationReceipts = () => {
   );
   // store: state
   const userProfile = useUserStore((state) => state.userProfile);
-  const isAuthResolved = useAuthStore((state) => state.isAuthResolved);
+  const isProfileReady = useIsProfileReady();
   // store: action
   const setErrors = useErrorHandlingStore((state) => state.setErrors);
 
   useEffect(() => {
     (async () => {
-      if (!userProfile || !isAuthResolved) return;
+      if (!isProfileReady) return;
       try {
         const response = await getApiAuthenticated<DonationReceiptsStatus>(
           '/app/donationReceiptsStatus'

--- a/src/features/user/ManagePayouts/index.tsx
+++ b/src/features/user/ManagePayouts/index.tsx
@@ -14,9 +14,9 @@ import AddBankAccount from './screens/AddBankAccount';
 import { useRouter } from 'next/router';
 import { handleError } from '@planet-sdk/common';
 import { useApi } from '../../../hooks/useApi';
+import { useIsAuthReady } from '../../../hooks/useAuthReadiness';
 import useLocalizedPath from '../../../hooks/useLocalizedPath';
 import {
-  useAuthStore,
   useUserStore,
   useErrorHandlingStore,
   useManagePayoutStore,
@@ -45,13 +45,11 @@ export default function ManagePayouts({
   const router = useRouter();
   const { localizedPath } = useLocalizedPath();
   const { getApi, getApiAuthenticated } = useApi();
+  const isAuthReady = useIsAuthReady();
   // local state
   const [tabConfig, setTabConfig] = useState<TabItem[]>([]);
   const [isDataLoading, setIsDataLoading] = useState(false);
   // store: state
-  const isAuthReady = useAuthStore(
-    (state) => state.token !== null && state.isAuthResolved
-  );
   const { userId, isTpo } = useUserStore(
     useShallow((state) => ({
       userId: state.userProfile?.id,

--- a/src/features/user/ManageProjects/ProjectsContainer.tsx
+++ b/src/features/user/ManageProjects/ProjectsContainer.tsx
@@ -22,12 +22,9 @@ import SingleColumnView from '../../common/Layout/SingleColumnView';
 import { useRouter } from 'next/router';
 import { generateProjectLink } from '../../../utils/projectV2';
 import { useApi } from '../../../hooks/useApi';
+import { useIsAuthReady } from '../../../hooks/useAuthReadiness';
 import useLocalizedPath from '../../../hooks/useLocalizedPath';
-import {
-  useAuthStore,
-  useUserStore,
-  useErrorHandlingStore,
-} from '../../../stores';
+import { useUserStore, useErrorHandlingStore } from '../../../stores';
 
 type ProjectProperties =
   | ProfileProjectPropertiesFund
@@ -128,13 +125,11 @@ export default function ProjectsContainer() {
   const tManageProjects = useTranslations('ManageProjects');
   const { getApiAuthenticated } = useApi();
   const { localizedPath } = useLocalizedPath();
+  const isAuthReady = useIsAuthReady();
   // local state
   const [projects, setProjects] = useState<ProfileProjectFeature[]>([]);
   const [loader, setLoader] = useState(true);
   // store: state
-  const isAuthReady = useAuthStore(
-    (state) => state.token !== null && state.isAuthResolved
-  );
   const userProfile = useUserStore((state) => state.userProfile);
   // store: action
   const setErrors = useErrorHandlingStore((state) => state.setErrors);

--- a/src/features/user/PlanetCash/index.tsx
+++ b/src/features/user/PlanetCash/index.tsx
@@ -12,13 +12,10 @@ import Accounts from './screens/Accounts';
 import Transactions from './screens/Transactions';
 import { handleError } from '@planet-sdk/common';
 import { useApi } from '../../../hooks/useApi';
+import { useIsAuthReady } from '../../../hooks/useAuthReadiness';
 import useLocalizedPath from '../../../hooks/useLocalizedPath';
 import { useRouter } from 'next/router';
-import {
-  useAuthStore,
-  useErrorHandlingStore,
-  usePlanetCashStore,
-} from '../../../stores';
+import { useErrorHandlingStore, usePlanetCashStore } from '../../../stores';
 
 export enum PlanetCashTabs {
   ACCOUNTS = 'accounts',
@@ -40,15 +37,13 @@ export default function PlanetCash({
   const router = useRouter();
   const { localizedPath } = useLocalizedPath();
   const locale = useLocale();
+  const isAuthReady = useIsAuthReady();
   // local state
   const [tabConfig, setTabConfig] = useState<TabItem[]>([]);
   const [isDataLoading, setIsDataLoading] = useState(false);
   // store: state
   const planetCashAccounts = usePlanetCashStore(
     (state) => state.planetCashAccounts
-  );
-  const isAuthReady = useAuthStore(
-    (state) => state.token !== null && state.isAuthResolved
   );
   // store: action
   const setPlanetCashAccounts = usePlanetCashStore(

--- a/src/features/user/PlanetCash/screens/Transactions.tsx
+++ b/src/features/user/PlanetCash/screens/Transactions.tsx
@@ -10,11 +10,8 @@ import { Button, CircularProgress } from '@mui/material';
 import NoTransactionsFound from '../components/NoTransactionsFound';
 import { handleError } from '@planet-sdk/common';
 import { useApi } from '../../../../hooks/useApi';
-import {
-  useAuthStore,
-  useErrorHandlingStore,
-  usePlanetCashStore,
-} from '../../../../stores';
+import { useIsAuthReady } from '../../../../hooks/useAuthReadiness';
+import { useErrorHandlingStore, usePlanetCashStore } from '../../../../stores';
 import { useRouter } from 'next/router';
 import useLocalizedPath from '../../../../hooks/useLocalizedPath';
 
@@ -29,6 +26,7 @@ const Transactions = ({
   const router = useRouter();
   const { localizedPath } = useLocalizedPath();
   const { getApiAuthenticated } = useApi();
+  const isAuthReady = useIsAuthReady();
   // local state
   const [transactionHistory, setTransactionHistory] =
     useState<PaymentHistory | null>(null);
@@ -39,9 +37,6 @@ const Transactions = ({
   const hasPlanetCashAccount = usePlanetCashStore(
     (state) =>
       state.planetCashAccounts !== null && state.planetCashAccounts.length > 0
-  );
-  const isAuthReady = useAuthStore(
-    (state) => state.token !== null && state.isAuthResolved
   );
   // store: action
   const setErrors = useErrorHandlingStore((state) => state.setErrors);

--- a/src/features/user/Profile/ForestProgress/TargetsModal.tsx
+++ b/src/features/user/Profile/ForestProgress/TargetsModal.tsx
@@ -11,8 +11,8 @@ import IconButton from '../../../common/IconButton';
 import TargetFormInput from './TargetFormInput';
 import { useState } from 'react';
 import { useApi } from '../../../../hooks/useApi';
+import { useIsAuthReady } from '../../../../hooks/useAuthReadiness';
 import {
-  useAuthStore,
   useMyForestStore,
   useUserStore,
   useErrorHandlingStore,
@@ -43,6 +43,7 @@ const TargetsModal = ({
   conservationTarget,
 }: TargetsModalProps) => {
   const { putApiAuthenticated } = useApi();
+  const isAuthReady = useIsAuthReady();
   const tProfile = useTranslations('Profile.progressBar');
   const tCommon = useTranslations('Common');
   // states to manage modal
@@ -58,15 +59,9 @@ const TargetsModal = ({
   );
   const [isConservedAreaTargetActive, setIsConservedAreaTargetActive] =
     useState(conservationTarget > 0);
-  //store: state
-  const isAuthReady = useAuthStore(
-    (state) => state.token !== null && state.isAuthResolved
-  );
   //store: action
   const setUserInfo = useMyForestStore((state) => state.setUserInfo);
-  const refetchUserProfile = useUserStore(
-    (state) => state.refetchUserProfile
-  );
+  const refetchUserProfile = useUserStore((state) => state.refetchUserProfile);
   const setErrors = useErrorHandlingStore((state) => state.setErrors);
 
   const handleClose = () => {

--- a/src/features/user/Profile/ProfileCard/RedeemModal/index.tsx
+++ b/src/features/user/Profile/ProfileCard/RedeemModal/index.tsx
@@ -14,12 +14,12 @@ import {
   EnterRedeemCode,
 } from '../../../../common/RedeemCode';
 import {
-  useAuthStore,
   useMyForestStore,
   useUserStore,
   useErrorHandlingStore,
 } from '../../../../../stores';
 import { useApi } from '../../../../../hooks/useApi';
+import { useIsProfileReady } from '../../../../../hooks/useAuthReadiness';
 
 interface RedeemModal {
   redeemModalOpen: boolean;
@@ -43,7 +43,7 @@ export default function RedeemModal({
   const [isLoading, setIsLoading] = useState<boolean>(false);
   // store: state
   const userProfile = useUserStore((state) => state.userProfile);
-  const isAuthResolved = useAuthStore((state) => state.isAuthResolved);
+  const isProfileReady = useIsProfileReady();
   const errors = useErrorHandlingStore((state) => state.errors);
   // store: action
   const setUserProfile = useUserStore((state) => state.setUserProfile);
@@ -58,7 +58,8 @@ export default function RedeemModal({
     const payload = {
       code: data,
     };
-    if (isAuthResolved && userProfile) {
+    // userProfile is re-checked here (isProfileReady already implies it) so TS can narrow it for the spread below.
+    if (isProfileReady && userProfile) {
       try {
         const res = await postApiAuthenticated<
           RedeemedCodeData,

--- a/src/features/user/Profile/ProfileLayout/index.tsx
+++ b/src/features/user/Profile/ProfileLayout/index.tsx
@@ -5,13 +5,10 @@ import ProfileCard from '../ProfileCard';
 import { ProfileLoader } from '../../../common/ContentLoaders/ProfileV2';
 import ForestProgress from '../ForestProgress';
 import CommunityContributions from '../CommunityContributions';
-import {
-  useAuthStore,
-  useMyForestStore,
-  useUserStore,
-} from '../../../../stores';
+import { useMyForestStore, useUserStore } from '../../../../stores';
 import MyContributions from '../MyContributions';
 import { useApi } from '../../../../hooks/useApi';
+import { useIsProfileReady } from '../../../../hooks/useAuthReadiness';
 import { clsx } from 'clsx';
 import { transformProfileToForestUserInfo } from '../../../../utils/myForestUtils';
 import { PROFILE_SECTION_HEIGHTS } from './ProfileGridSkeleton';
@@ -26,7 +23,7 @@ const ProfileLayout = () => {
   );
   const userSlug = useMyForestStore((state) => state.userInfo?.slug);
   const userProfile = useUserStore((state) => state.userProfile);
-  const isAuthResolved = useAuthStore((state) => state.isAuthResolved);
+  const isProfileReady = useIsProfileReady();
   // store: action
   const setUserInfo = useMyForestStore((state) => state.setUserInfo);
   const fetchMyForest = useMyForestStore((state) => state.fetchMyForest);
@@ -38,11 +35,12 @@ const ProfileLayout = () => {
   );
 
   useEffect(() => {
-    if (!isAuthResolved || !userProfile) return;
+    // userProfile is re-checked here (isProfileReady already implies it) so TS can narrow it for the transform call below.
+    if (!isProfileReady || !userProfile) return;
 
     setIsPublicProfile(false);
     setUserInfo(transformProfileToForestUserInfo(userProfile));
-  }, [isAuthResolved, userProfile]);
+  }, [isProfileReady, userProfile]);
 
   useEffect(() => {
     if (userSlug) fetchMyForest(getApi, getApiAuthenticated);

--- a/src/features/user/Settings/ApiKey/ApiKeyForm.tsx
+++ b/src/features/user/Settings/ApiKey/ApiKeyForm.tsx
@@ -12,7 +12,8 @@ import { Button, InputAdornment, TextField } from '@mui/material';
 import { handleError } from '@planet-sdk/common';
 import InlineFormDisplayGroup from '../../../common/Layout/Forms/InlineFormDisplayGroup';
 import { useApi } from '../../../../hooks/useApi';
-import { useAuthStore, useErrorHandlingStore } from '../../../../stores';
+import { useIsAuthReady } from '../../../../hooks/useAuthReadiness';
+import { useErrorHandlingStore } from '../../../../stores';
 
 interface EyeButtonParams {
   isVisible: boolean;
@@ -40,14 +41,11 @@ const EyeButton = ({ isVisible, onClick }: EyeButtonParams) => {
 export default function ApiKey() {
   const t = useTranslations('Me');
   const { getApiAuthenticated, putApiAuthenticated } = useApi();
+  const isAuthReady = useIsAuthReady();
   // local state
   const [isUploadingData, setIsUploadingData] = useState(false);
   const [apiKey, setApiKey] = useState('');
   const [isApiKeyVisible, setIsApiKeyVisible] = useState(false);
-  // store: state
-  const isAuthReady = useAuthStore(
-    (state) => state.token !== null && state.isAuthResolved
-  );
   // store: action
   const setErrors = useErrorHandlingStore((state) => state.setErrors);
 

--- a/src/features/user/Settings/EditProfile/AddressManagement/useAddressOperations.tsx
+++ b/src/features/user/Settings/EditProfile/AddressManagement/useAddressOperations.tsx
@@ -4,6 +4,7 @@ import type { AddressType, Address, APIError } from '@planet-sdk/common';
 
 import { useEffect, useRef, useState } from 'react';
 import { useApi } from '../../../../../hooks/useApi';
+import { useIsAuthReady } from '../../../../../hooks/useAuthReadiness';
 import { handleError } from '@planet-sdk/common';
 import {
   updateAddressesAfterAdd,
@@ -11,11 +12,7 @@ import {
   updateAddressesAfterEdit,
   updateAddressesAfterTypeChange,
 } from './utils';
-import {
-  useAuthStore,
-  useUserStore,
-  useErrorHandlingStore,
-} from '../../../../../stores';
+import { useUserStore, useErrorHandlingStore } from '../../../../../stores';
 
 export type UnsetBillingAddressApiPayload = {
   type: 'other';
@@ -38,13 +35,11 @@ type AddressTypeApiPayload = {
 export const useAddressOperations = () => {
   const { postApiAuthenticated, putApiAuthenticated, deleteApiAuthenticated } =
     useApi();
+  const isAuthReady = useIsAuthReady();
   const isMountedRef = useRef(true);
   // local state
   const [isLoading, setIsLoading] = useState(false);
   // store: state
-  const isAuthReady = useAuthStore(
-    (state) => state.token !== null && state.isAuthResolved
-  );
   const userProfile = useUserStore((state) => state.userProfile);
   // store: action
   const setErrors = useErrorHandlingStore((state) => state.setErrors);

--- a/src/features/user/Settings/EditProfile/EditProfileForm.tsx
+++ b/src/features/user/Settings/EditProfile/EditProfileForm.tsx
@@ -28,13 +28,10 @@ import DefaultProfileImageIcon from '../../../../../public/assets/images/icons/h
 import themeProperties from '../../../../theme/themeProperties';
 import NewInfoIcon from '../../../../../public/assets/images/icons/projectV2/NewInfoIcon';
 import { useApi } from '../../../../hooks/useApi';
+import { useIsAuthReady } from '../../../../hooks/useAuthReadiness';
 import useLocalizedPath from '../../../../hooks/useLocalizedPath';
 import { useRouter } from 'next/router';
-import {
-  useAuthStore,
-  useUserStore,
-  useErrorHandlingStore,
-} from '../../../../stores';
+import { useUserStore, useErrorHandlingStore } from '../../../../stores';
 
 type ProfileFormData = {
   address: string;
@@ -83,8 +80,7 @@ export default function EditProfileForm() {
     value: 'individual',
   });
   // store: state
-  const token = useAuthStore((state) => state.token);
-  const isAuthResolved = useAuthStore((state) => state.isAuthResolved);
+  const isAuthReady = useIsAuthReady();
   const userProfile = useUserStore((state) => state.userProfile);
   // store: action
   const setUserProfile = useUserStore((state) => state.setUserProfile);
@@ -205,7 +201,7 @@ export default function EditProfileForm() {
         reader.onabort = () => console.log('file reading was aborted');
         reader.onerror = () => console.log('file reading has failed');
         reader.onload = async (event) => {
-          if (isAuthResolved && token) {
+          if (isAuthReady) {
             const profileImagePayload = {
               imageFile: event.target?.result,
             };
@@ -217,7 +213,7 @@ export default function EditProfileForm() {
         };
       });
     },
-    [token]
+    [isAuthReady]
   );
 
   const deleteProfilePicture = (event: MouseEvent<HTMLButtonElement>) => {
@@ -245,7 +241,7 @@ export default function EditProfileForm() {
       ...(type !== 'tpo' ? { type: type } : {}),
     };
 
-    if (isAuthResolved && token) {
+    if (isAuthReady) {
       try {
         const res = await putApiAuthenticated<User, UpdateProfileApiPayload>(
           `/app/profile`,

--- a/src/features/user/Widget/EmbedModal.tsx
+++ b/src/features/user/Widget/EmbedModal.tsx
@@ -10,11 +10,8 @@ import { useRouter } from 'next/router';
 import { ThemeContext } from '../../../theme/themeContext';
 import { handleError } from '@planet-sdk/common';
 import { useApi } from '../../../hooks/useApi';
-import {
-  useAuthStore,
-  useUserStore,
-  useErrorHandlingStore,
-} from '../../../stores';
+import { useIsAuthReady } from '../../../hooks/useAuthReadiness';
+import { useUserStore, useErrorHandlingStore } from '../../../stores';
 interface Props {
   embedModalOpen: boolean;
   setEmbedModalOpen: Function;
@@ -30,13 +27,10 @@ export default function EmbedModal({
   const t = useTranslations('EditProfile');
   const router = useRouter();
   const { putApiAuthenticated } = useApi();
+  const isAuthReady = useIsAuthReady();
   // local state
   const [isUploadingData, setIsUploadingData] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
-  //store: state
-  const isAuthReady = useAuthStore(
-    (state) => state.token !== null && state.isAuthResolved
-  );
   //store: action
   const setUserProfile = useUserStore((state) => state.setUserProfile);
   const setErrors = useErrorHandlingStore((state) => state.setErrors);

--- a/src/hooks/useAuthReadiness.ts
+++ b/src/hooks/useAuthReadiness.ts
@@ -1,0 +1,15 @@
+import { useAuthStore } from '../stores/authStore';
+import { useUserStore } from '../stores/userStore';
+
+// Auth is ready for an API call: a token exists and the initial auth check has resolved.
+// Distinct from useIsProfileReady - a token can exist before the profile has loaded.
+export const useIsAuthReady = (): boolean =>
+  useAuthStore((state) => state.token !== null && state.isAuthResolved);
+
+// The profile is ready to read: auth has resolved and the profile has loaded.
+// Distinct from useIsAuthReady - do not swap the two, a token alone does not mean the profile is present.
+export const useIsProfileReady = (): boolean => {
+  const isAuthResolved = useAuthStore((state) => state.isAuthResolved);
+  const userProfile = useUserStore((state) => state.userProfile);
+  return isAuthResolved && userProfile !== null;
+};


### PR DESCRIPTION
## Summary
Closes #3043.

- Adds `useIsAuthReady()` and `useIsProfileReady()` in `src/hooks/useAuthReadiness.ts`.
- Migrates the 9 group 1 call sites (`token !== null && isAuthResolved`) to `useIsAuthReady()`.
- Migrates the 4 group 2 call sites (`isAuthResolved && userProfile`) to `useIsProfileReady()`. `RedeemPopup` from the issue was already removed from the codebase, so its site no longer exists.
- Hand-converts the two extra sites written in near-variant wording (`EditProfileForm.tsx`, `CompleteSignup/index.tsx` line 146) to `useIsAuthReady()`.
- Leaves the standalone `isAuthResolved` checks (`BulkCodes/index.tsx`, `CompleteSignup/index.tsx` line 92, `UserLayout.tsx` line 282) and the login-redirect gates (`UserLayout.tsx` line 271, `CompleteSignup/index.tsx` line 169) untouched, per the issue's explicit warning against folding those into either selector.

## Test plan
- [x] `tsc --noEmit` shows no new errors introduced by this change (compared the same run against `develop`).
- [ ] Manually verify in the browser: profile page load, address management, API key screen, PlanetCash, payouts, bulk codes, targets modal, cookie notice, redeem modal, donation receipts, complete-signup flow, and the login-redirect behavior for a signed-in vs signed-out user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)