### PR TITLE
refactor: replace inline getApi types with ApiRequestFn

### DIFF
--- a/src/stores/currencyStore.ts
+++ b/src/stores/currencyStore.ts
@@ -1,10 +1,11 @@
-import type { ApiConfigBase } from '../hooks/useApi';
 import type { CurrencyCode, APIError } from '@planet-sdk/common';
+import type { ApiRequestFn } from '../hooks/useApi';
 
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { useErrorHandlingStore } from './errorHandlingStore';
 import { handleError } from '@planet-sdk/common';
+
 
 type CurrencyList = {
   [key in CurrencyCode]?: string;
@@ -26,8 +27,8 @@ interface CurrencyStore {
   isFetching: boolean;
 
   fetchSupportedCurrencies: (
-    getApi: <T>(url: string, config?: ApiConfigBase) => Promise<T>
-  ) => void;
+    getApi: ApiRequestFn
+  ) => Promise<void>;
   setCurrencyCode: (code: CurrencyCode) => void;
   initializeCurrencyCode: () => void;
 }

--- a/src/stores/interventionStore.ts
+++ b/src/stores/interventionStore.ts
@@ -1,13 +1,14 @@
 import type { Intervention, SampleTreeRegistration } from '@planet-sdk/common';
-import type { ApiConfigBase } from '../hooks/useApi';
 import type { INTERVENTION_TYPE } from '../utils/constants/intervention';
 import type { NextRouter } from 'next/router';
 import type { TreemapperApiResponse } from '../features/common/types/map';
+import type { ApiRequestFn } from '../hooks/useApi';
 
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { buildProjectDetailsQuery } from '../utils/projectV2';
 import { useSingleProjectStore } from './singleProjectStore';
+
 
 interface InterventionStore {
   interventions: Intervention[] | null;
@@ -24,7 +25,7 @@ interface InterventionStore {
    * Uses extended scope to include sample interventions.
    */
   fetchInterventions: (
-    getApi: <T>(url: string, config?: ApiConfigBase) => Promise<T>,
+    getApi: ApiRequestFn,
     projectId: string
   ) => Promise<void>;
 

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -1,6 +1,7 @@
 import type { MapProject } from '../features/common/types/projectv2';
 import type { ApiConfigBase } from '../hooks/useApi';
 import type { APIError, TreeProjectClassification } from '@planet-sdk/common';
+import type { ApiRequestFn } from '../hooks/useApi';
 
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
@@ -8,6 +9,7 @@ import { useErrorHandlingStore } from './errorHandlingStore';
 import { handleError } from '@planet-sdk/common';
 import { getTopProjects } from '../utils/projectV2';
 import { isSameFetchKey } from '../utils/fetchKey';
+
 
 /**
  * Conditions a fetched project list depends on. No slug, unlike the single
@@ -39,7 +41,7 @@ interface ProjectStore {
   debouncedSearchValue: string;
 
   fetchProjects: (
-    getApi: <T>(url: string, config?: ApiConfigBase) => Promise<T>,
+    getApi: ApiRequestFn,
     config: ApiConfigBase
   ) => Promise<void>;
   setShowDonatableProjects: (show: boolean) => void;
@@ -72,7 +74,7 @@ export const useProjectStore = create<ProjectStore>()(
       isSearching: false,
       debouncedSearchValue: '',
 
-      fetchProjects: async (getApi, config) => {
+      fetchProjects: async (getApi , config) => {
         const { lastFetch, pendingFetch, projects: cached } = get();
         const requested: ProjectsFetchKey = {
           locale: String(config.queryParams?.locale ?? ''),

--- a/src/stores/singleProjectStore.ts
+++ b/src/stores/singleProjectStore.ts
@@ -2,6 +2,7 @@ import type { APIError } from '@planet-sdk/common';
 import type { ExtendedProject } from '../features/common/types/projectv2';
 import type { ApiConfigBase } from '../hooks/useApi';
 import type { NextRouter } from 'next/router';
+import type { ApiRequestFn } from '../hooks/useApi';
 
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
@@ -15,6 +16,7 @@ import {
   getSiteIdFromIndex,
 } from '../utils/projectV2';
 import { isSameFetchKey } from '../utils/fetchKey';
+
 
 /**
  * Conditions a fetched project depends on. Includes the slug, since a session
@@ -54,7 +56,7 @@ interface SingleProjectStore {
    * - Forwards errors to the global error store
    */
   fetchProject: (
-    getApi: <T>(url: string, config?: ApiConfigBase) => Promise<T>,
+    getApi: ApiRequestFn,
     config: ApiConfigBase,
     projectSlug: string
   ) => Promise<void>;


### PR DESCRIPTION
Fixes #3092

## Changes in this pull request:

* Replaced the inline `getApi` function signature in `currencyStore`, `projectStore`, `singleProjectStore`, and `interventionStore` with the shared `ApiRequestFn` type.
* Kept the existing function parameters and behavior unchanged.
* No localization, validation, or error-handling changes were required.

## Verification

* Ran `npx tsc --noEmit`.
* TypeScript currently reports 126 pre-existing errors across 51 files.
* None of the reported errors are in the four modified store files.
