### PR TITLE
fix: correct project site step after deleting a site's polygon

### DIFF
--- a/src/features/user/ManageProjects/components/ProjectSites.tsx
+++ b/src/features/user/ManageProjects/components/ProjectSites.tsx
@@ -171,7 +171,12 @@ export default function ProjectSites({
     try {
       setIsUploadingData(true);
       await deleteApiAuthenticated(`/app/projects/${projectGUID}/sites/${id}`);
-      setSiteList((prev) => prev.filter((item) => item.id !== id));
+      setSiteList((prev) => {
+        const updatedList = prev.filter((item) => item.id !== id);
+        // No sites left, so show the form instead of an empty list.
+        if (updatedList.length === 0) setShowForm(true);
+        return updatedList;
+      });
     } catch (err) {
       setErrors(handleError(err as APIError));
     } finally {
@@ -181,6 +186,12 @@ export default function ProjectSites({
   };
 
   const uploadProjectSiteNext = async (data: ProjectSitesFormData) => {
+    // No new site is being drafted.
+    if (!geoJson || geoJson.features.length === 0) {
+      handleNext(ProjectCreationTabs.PROJECT_SPENDING);
+      return;
+    }
+
     const success = await uploadProjectSite(data);
     if (success) handleNext(ProjectCreationTabs.PROJECT_SPENDING);
   };


### PR DESCRIPTION
## Summary
- Show the form again when the last site is deleted, instead of leaving an empty list with no way to add a new site.
- Skip site upload and validation on "next" when no new site is being drafted, so a project with existing sites can continue without being blocked by validation for a site that isn't there.

## Test plan
- [ ] Add a site to a project, then delete it. Confirm the form reappears so a new site can be drawn.
- [ ] With existing sites and no new site drafted, click continue and confirm it proceeds to the spending step without a validation error.
- [ ] With a new site drafted, click continue and confirm it still saves the site before proceeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)