### PR TITLE
fix: return profile fetch errors to the caller instead of store state

### DIFF
--- a/src/features/user/Settings/ImpersonateUser/ImpersonateUserForm.tsx
+++ b/src/features/user/Settings/ImpersonateUser/ImpersonateUserForm.tsx
@@ -11,6 +11,7 @@ import styles from './ImpersonateUser.module.scss';
 import { isEmailValid } from '../../../../utils/isEmailValid';
 import { APIError } from '@planet-sdk/common';
 import useLocalizedPath from '../../../../hooks/useLocalizedPath';
+import useProfileErrorHandler from '../../../../hooks/useProfileErrorHandler';
 import { useAuthStore, useTenantStore, useUserStore } from '../../../../stores';
 
 const ImpersonateUserForm = (): ReactElement => {
@@ -18,6 +19,7 @@ const ImpersonateUserForm = (): ReactElement => {
   const { localizedPath } = useLocalizedPath();
   const t = useTranslations('Me');
   const locale = useLocale();
+  const { handleProfileError } = useProfileErrorHandler();
   // store: state
   const token = useAuthStore((state) => state.token);
   const tenantId = useTenantStore((state) => state.tenantConfig.id);
@@ -99,8 +101,13 @@ const ImpersonateUserForm = (): ReactElement => {
         router.push(localizedPath('/profile'));
       } catch (err) {
         if (err instanceof APIError) {
-          console.error('API error:', err.message);
-          if (err.statusCode === 403) setIsInvalidEmail(true);
+          // A 403 here means the target email/support pin pair was rejected -
+          // handle it locally instead of through the global error handler.
+          if (err.statusCode === 403) {
+            setIsInvalidEmail(true);
+          } else {
+            handleProfileError(err);
+          }
         } else {
           console.error('Unexpected error:', err);
         }

--- a/src/features/user/Settings/ImpersonateUser/ImpersonationActivated.tsx
+++ b/src/features/user/Settings/ImpersonateUser/ImpersonationActivated.tsx
@@ -1,15 +1,19 @@
+import type { APIError } from '@planet-sdk/common';
+
 import { useLocale, useTranslations } from 'next-intl';
 import LogoutIcon from '../../../../../public/assets/images/icons/Sidebar/LogoutIcon';
 import styles from './ImpersonateUser.module.scss';
 import useLocalizedPath from '../../../../hooks/useLocalizedPath';
 import { useRouter } from 'next/router';
 import { useAuthStore, useTenantStore, useUserStore } from '../../../../stores';
+import useProfileErrorHandler from '../../../../hooks/useProfileErrorHandler';
 
 const ImpersonationActivated = () => {
   const t = useTranslations('Me');
   const locale = useLocale();
   const router = useRouter();
   const { localizedPath } = useLocalizedPath();
+  const { handleProfileError } = useProfileErrorHandler();
   // store: state
   const token = useAuthStore((state) => state.token);
   const isImpersonationModeOn = useUserStore(
@@ -34,13 +38,7 @@ const ImpersonationActivated = () => {
         token,
         tenantId,
         locale,
-      }).catch((error) => {
-        // Errors are surfaced through the global `profileApiError` flow.
-        console.error(
-          '[Profile API] Failed to restore the real user profile:',
-          error
-        );
-      });
+      }).catch((error: APIError) => handleProfileError(error));
     }
   };
 

--- a/src/hooks/useInitializeUser.ts
+++ b/src/hooks/useInitializeUser.ts
@@ -1,6 +1,7 @@
+import type { APIError } from '@planet-sdk/common';
+
 import { useEffect, useRef } from 'react';
 import { useAuthStore, useTenantStore, useUserStore } from '../stores';
-
 import { useLocale } from 'next-intl';
 import useProfileErrorHandler from './useProfileErrorHandler';
 import { useAuthSession } from './useAuthSession';
@@ -13,7 +14,6 @@ export const useInitializeUser = () => {
     useAuthSession();
   const { handleProfileError } = useProfileErrorHandler();
   // store: state
-  const profileApiError = useUserStore((state) => state.profileApiError);
   const token = useAuthStore((state) => state.token);
   const profileRefetchNonce = useUserStore(
     (state) => state.profileRefetchNonce
@@ -25,9 +25,6 @@ export const useInitializeUser = () => {
     (state) => state.setIsImpersonationModeOn
   );
   const exitImpersonation = useUserStore((state) => state.exitImpersonation);
-  const clearProfileApiError = useUserStore(
-    (state) => state.clearProfileApiError
-  );
   const setIsAuthResolved = useAuthStore((state) => state.setIsAuthResolved);
 
   // `isAuthResolved` means the first auth check and profile fetch are finished.
@@ -55,10 +52,8 @@ export const useInitializeUser = () => {
         // unrelated login or profile errors.
         clearRedirectCount();
       })
-      .catch((err) => {
-        // API errors are surfaced through `profileApiError` below.
-        // Catching here only prevents an unhandled promise rejection.
-        console.error('[Profile API] Failed to fetch user profile:', err);
+      .catch((err: APIError) => {
+        handleProfileError(err);
       })
       .finally(() => {
         if (!hasResolvedInitialAuth.current) {
@@ -66,14 +61,13 @@ export const useInitializeUser = () => {
           setIsAuthResolved(true);
         }
       });
-  }, [token, profileRefetchNonce, fetchUserProfile, setIsAuthResolved]);
-
-  useEffect(() => {
-    if (!profileApiError) return;
-    handleProfileError(profileApiError);
-    // Clear the error after handling it so it does not run again later.
-    clearProfileApiError();
-  }, [profileApiError, handleProfileError, clearProfileApiError]);
+  }, [
+    token,
+    profileRefetchNonce,
+    fetchUserProfile,
+    setIsAuthResolved,
+    handleProfileError,
+  ]);
 
   useEffect(() => {
     if (

--- a/src/hooks/useProfileErrorHandler.ts
+++ b/src/hooks/useProfileErrorHandler.ts
@@ -69,15 +69,11 @@ const useProfileErrorHandler = () => {
             exitImpersonation();
             // Restore the real user's profile.
             if (token) {
-              fetchUserProfile({ token, tenantId, locale })
-                // The refetch runs without impersonation data, so a further
-                // failure is recorded in `profileApiError` and handled here again.
-                .catch((error) =>
-                  console.error(
-                    '[Profile API] Failed to restore the real user profile:',
-                    error
-                  )
-                );
+              // The refetch runs without impersonation data, so a further
+              // failure goes through this same handler again.
+              fetchUserProfile({ token, tenantId, locale }).catch(
+                (error: APIError) => handleProfileError(error)
+              );
             }
           }
           break;

--- a/src/stores/userStore.test.ts
+++ b/src/stores/userStore.test.ts
@@ -1,0 +1,103 @@
+import type { User } from '@planet-sdk/common';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { APIError } from '@planet-sdk/common';
+import { useUserStore } from './userStore';
+
+// Only the fields each test reads/asserts on are needed - not a full User.
+const asUser = (profile: Record<string, unknown>) => profile as unknown as User;
+
+// fetchUserProfile only reads `ok`, `status`, and `json()` off the response,
+// so the mock only needs to cover that shape.
+const fetchResponse = (status: number, body: unknown) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response);
+
+const BASE_PARAMS = { token: 'test-token', tenantId: 'tenant-1', locale: 'en' };
+
+describe('userStore.fetchUserProfile', () => {
+  beforeEach(() => {
+    process.env.API_ENDPOINT = 'https://api.example.test';
+    useUserStore.setState({ userProfile: null });
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('commits the profile to the store and resolves with it on success', async () => {
+    const profile = { id: 'user-1', email: 'user@example.com' };
+    vi.mocked(fetch).mockResolvedValue(fetchResponse(200, profile));
+
+    const result = await useUserStore.getState().fetchUserProfile(BASE_PARAMS);
+
+    expect(result).toEqual(profile);
+    expect(useUserStore.getState().userProfile).toEqual(profile);
+  });
+
+  it('rejects with a matching APIError but keeps the existing profile on a 500', async () => {
+    const existingProfile = asUser({ id: 'user-1', email: 'user@example.com' });
+    useUserStore.setState({ userProfile: existingProfile });
+    vi.mocked(fetch).mockResolvedValue(fetchResponse(500, {}));
+
+    await expect(
+      useUserStore.getState().fetchUserProfile(BASE_PARAMS)
+    ).rejects.toMatchObject({ statusCode: 500 });
+    expect(useUserStore.getState().userProfile).toEqual(existingProfile);
+  });
+
+  it('clears the profile on a 401, since the session is no longer valid', async () => {
+    useUserStore.setState({ userProfile: asUser({ id: 'user-1' }) });
+    vi.mocked(fetch).mockResolvedValue(fetchResponse(401, {}));
+
+    await expect(
+      useUserStore.getState().fetchUserProfile(BASE_PARAMS)
+    ).rejects.toMatchObject({ statusCode: 401 });
+    expect(useUserStore.getState().userProfile).toBeNull();
+  });
+
+  it('clears the profile on a 303, since signup is not finished', async () => {
+    useUserStore.setState({ userProfile: asUser({ id: 'user-1' }) });
+    vi.mocked(fetch).mockResolvedValue(fetchResponse(303, {}));
+
+    await expect(
+      useUserStore.getState().fetchUserProfile(BASE_PARAMS)
+    ).rejects.toMatchObject({ statusCode: 303 });
+    expect(useUserStore.getState().userProfile).toBeNull();
+  });
+
+  // Regression: the caller now owns error handling and reads `statusCode` off
+  // the rejection, so a plain network failure must also arrive as an APIError
+  // rather than the raw fetch error.
+  it('normalizes a network failure into an APIError instead of rejecting with the raw error', async () => {
+    const networkError = new TypeError('Failed to fetch');
+    vi.mocked(fetch).mockRejectedValue(networkError);
+
+    const rejection: APIError = await useUserStore
+      .getState()
+      .fetchUserProfile(BASE_PARAMS)
+      .catch((error) => error);
+
+    expect(rejection).toBeInstanceOf(APIError);
+    expect(rejection.statusCode).toBe(0);
+    expect(rejection.cause).toBe(networkError);
+  });
+
+  it('rejects with the original 403 and leaves the profile untouched when starting an impersonation attempt', async () => {
+    const existingProfile = asUser({ id: 'agent-1' });
+    useUserStore.setState({ userProfile: existingProfile });
+    vi.mocked(fetch).mockResolvedValue(fetchResponse(403, {}));
+
+    await expect(
+      useUserStore.getState().fetchUserProfile({
+        ...BASE_PARAMS,
+        impersonationData: { targetEmail: 'x@y.com', supportPin: '1234' },
+      })
+    ).rejects.toMatchObject({ statusCode: 403 });
+    expect(useUserStore.getState().userProfile).toEqual(existingProfile);
+  });
+});

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -36,15 +36,15 @@ interface UserStore {
   // Incremented on each refetch request so the fetch effect runs every time.
   profileRefetchNonce: number;
   isImpersonationModeOn: boolean;
-  profileApiError: APIError | null;
 
   setUserProfile: (profile: User | null) => void;
   setIsImpersonationModeOn: (isEnabled: boolean) => void;
   enterImpersonation: (impersonationData: ImpersonationData) => void;
   exitImpersonation: () => void;
   refetchUserProfile: () => void;
+  // Failures are returned to the caller (rejected promise), not written to
+  // store state - see #3045.
   fetchUserProfile: (params: FetchUserProfileParams) => Promise<User>;
-  clearProfileApiError: () => void;
 }
 
 export const useUserStore = create<UserStore>()(
@@ -54,7 +54,6 @@ export const useUserStore = create<UserStore>()(
       userProfile: null,
       profileRefetchNonce: 0,
       isImpersonationModeOn: false,
-      profileApiError: null,
 
       //actions
       setUserProfile: (profile) =>
@@ -151,16 +150,13 @@ export const useUserStore = create<UserStore>()(
             });
           }
           set(
-            {
-              userProfile: result,
-              profileApiError: null,
-            },
+            { userProfile: result },
             undefined,
             'userStore/fetch_user_profile_success'
           );
           return result;
         } catch (error) {
-          // Impersonation-specific 403: Handle ONLY in component
+          // Impersonation-specific 403: Handle ONLY in the caller (ImpersonateUserForm).
 
           // This runs only when `impersonationData` is passed to this function.
           // Currently, only ImpersonateUserForm passes it when starting impersonation,
@@ -169,28 +165,17 @@ export const useUserStore = create<UserStore>()(
           // If another caller passes `impersonationData`, its 403 will also be handled locally.
           // If ImpersonateUserForm stops passing it, the impersonation header will be missing
           // and the API may return the support agent's profile instead of showing an error.
-
           if (
             error instanceof APIError &&
             error.statusCode === 403 &&
             impersonationData
           ) {
-            if (!isStale()) {
-              set(
-                {
-                  profileApiError: null, // do NOT trigger global handler
-                },
-                undefined,
-                'userStore/fetch_user_profile_impersonation_error'
-              );
-            }
-
-            throw error; // handled by component
+            throw error; // handled by the caller, not the global handler
           }
-          // All other errors → global handling
 
-          // Convert non-API errors into APIError so the global error handler can handle them.
-          // Keep the original error details for debugging.
+          // Convert non-API errors into APIError so every caller can rely on
+          // a consistent shape (e.g. read `statusCode`). Keep the original
+          // error details for debugging.
           let apiError: APIError;
           if (error instanceof APIError) {
             apiError = error;
@@ -207,28 +192,21 @@ export const useUserStore = create<UserStore>()(
           // or the session is no longer valid (401).
           // For temporary errors like 500 or network failures,
           // keep the existing profile so the user is not sent to /login.
-          const patch: Partial<UserStore> = { profileApiError: apiError };
-          if (apiError.statusCode === 303 || apiError.statusCode === 401) {
-            patch.userProfile = null;
+          if (
+            !isStale() &&
+            (apiError.statusCode === 303 || apiError.statusCode === 401)
+          ) {
+            set(
+              { userProfile: null },
+              undefined,
+              'userStore/fetch_user_profile_error'
+            );
           }
 
-          if (!isStale()) {
-            set(patch, undefined, 'userStore/fetch_user_profile_error');
-          }
-
-          // Rethrow so the promise never resolves with `undefined`.
-          // The global flow still runs via the `profileApiError` state above;
-          // callers that only rely on that state can ignore this rejection.
-          throw error;
+          // Reject with the normalized error so the caller decides how to handle it.
+          throw apiError;
         }
       },
-
-      clearProfileApiError: () =>
-        set(
-          { profileApiError: null },
-          undefined,
-          'userStore/clear_profile_api_error'
-        ),
     }),
     {
       name: 'UserStore',


### PR DESCRIPTION
## Summary
- `fetchUserProfile` used to write failures to a `profileApiError` field in the store, which `useInitializeUser` picked up in a separate effect to call `handleProfileError`. That added an extra render cycle between the failure happening and it being handled, and split the error-handling logic across two files.
- `fetchUserProfile` now rejects with a normalized `APIError` instead. Callers (`useInitializeUser`, `ImpersonateUserForm`, `ImpersonationActivated`, and `useProfileErrorHandler`'s own impersonation-restore retry) catch the rejection and call `handleProfileError` directly, except for the impersonation-start 403 case, which `ImpersonateUserForm` still handles locally as before.
- Removed `profileApiError` and `clearProfileApiError` from `userStore`, since nothing reads or clears that state anymore.
- Added `src/stores/userStore.test.ts` covering `fetchUserProfile`: success, 500 (profile kept), 401/303 (profile cleared), a raw network failure normalized into an `APIError`, and the impersonation 403 path (profile untouched, rejects for the caller to handle).

## Test plan
- [x] `src/stores/userStore.test.ts` added and passing
- [ ] Manually verify profile fetch failure still surfaces the global error handling (e.g. session expiry redirect) in the browser
- [ ] Manually verify starting impersonation with an invalid email/support pin still shows the inline error instead of the global handler