### PR TITLE
fix: surface the real profile fetch error message instead of a generic one

### DIFF
--- a/src/hooks/useProfileErrorHandler.ts
+++ b/src/hooks/useProfileErrorHandler.ts
@@ -11,6 +11,15 @@ import {
   registerRedirectAttempt,
 } from '../utils/authRedirectGuard';
 
+// APIError.message is always the string "Something went wrong" - the real
+// text lives in `.errors`, which fetchUserProfile always shapes as
+// { code, message }. Fall back to err.message for errors from elsewhere
+// that don't follow that shape.
+const getProfileErrorMessage = (err: APIError): string =>
+  'message' in err.errors && typeof err.errors.message === 'string'
+    ? err.errors.message
+    : err.message;
+
 const useProfileErrorHandler = () => {
   const router = useRouter();
   const locale = useLocale();
@@ -80,12 +89,15 @@ const useProfileErrorHandler = () => {
         }
         // 500: server error, nothing the client can do, just log it
         case 500:
-          console.error('[Profile API] Internal Server Error:', err.message);
+          console.error(
+            '[Profile API] Internal Server Error:',
+            getProfileErrorMessage(err)
+          );
           break;
 
         // Any other status, log it for debugging
         default:
-          console.error('[Profile API] Error:', err.message);
+          console.error('[Profile API] Error:', getProfileErrorMessage(err));
           break;
       }
     },

--- a/src/stores/userStore.test.ts
+++ b/src/stores/userStore.test.ts
@@ -44,9 +44,18 @@ describe('userStore.fetchUserProfile', () => {
     useUserStore.setState({ userProfile: existingProfile });
     vi.mocked(fetch).mockResolvedValue(fetchResponse(500, {}));
 
-    await expect(
-      useUserStore.getState().fetchUserProfile(BASE_PARAMS)
-    ).rejects.toMatchObject({ statusCode: 500 });
+    const rejection: APIError = await useUserStore
+      .getState()
+      .fetchUserProfile(BASE_PARAMS)
+      .catch((error) => error);
+
+    expect(rejection.statusCode).toBe(500);
+    // APIError.message is always "Something went wrong" - callers read the
+    // real cause off `.errors` instead (see I7).
+    expect(rejection.errors).toMatchObject({
+      code: 500,
+      message: 'Failed to fetch user profile',
+    });
     expect(useUserStore.getState().userProfile).toEqual(existingProfile);
   });
 
@@ -85,6 +94,10 @@ describe('userStore.fetchUserProfile', () => {
     expect(rejection).toBeInstanceOf(APIError);
     expect(rejection.statusCode).toBe(0);
     expect(rejection.cause).toBe(networkError);
+    expect(rejection.errors).toMatchObject({
+      code: 0,
+      message: 'Failed to fetch',
+    });
   });
 
   it('rejects with the original 403 and leaves the profile untouched when starting an impersonation attempt', async () => {

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -132,20 +132,24 @@ export const useUserStore = create<UserStore>()(
           );
 
           if (!response.ok) {
-            throw new APIError(response.status, 'Failed to fetch user profile');
+            throw new APIError(response.status, {
+              code: response.status,
+              message: 'Failed to fetch user profile',
+            });
           }
 
           const result = await response.json();
           if (!result) {
-            throw new APIError(
-              response.status,
-              'User profile response was empty'
-            );
+            throw new APIError(response.status, {
+              code: response.status,
+              message: 'User profile response was empty',
+            });
           }
 
           // Superseded by a newer fetch: do not commit to store, and do not return a stale identity back to the caller (e.g. ImpersonateUserForm enters impersonation from this return value).
           if (isStale()) {
             throw new APIError(NON_HTTP_ERROR_STATUS_CODE, {
+              code: NON_HTTP_ERROR_STATUS_CODE,
               message: 'Profile fetch superseded by a newer request',
             });
           }
@@ -183,6 +187,7 @@ export const useUserStore = create<UserStore>()(
             const originalMessage =
               error instanceof Error ? error.message : String(error);
             apiError = new APIError(NON_HTTP_ERROR_STATUS_CODE, {
+              code: NON_HTTP_ERROR_STATUS_CODE,
               message: originalMessage,
             });
             apiError.cause = error;


### PR DESCRIPTION

## Changes in this pull request:

- `fetchUserProfile` used to write errors to `profileApiError` in the store, and a separate effect in `useInitializeUser` picked that up to call `handleProfileError`. That added an indirection and a render cycle between the failure and its handling. Callers now catch the rejected promise and call `handleProfileError` directly, so `profileApiError` and `clearProfileApiError` are gone.
- `APIError.message` is always the generic string `"Something went wrong"` - the real cause lives in `.errors`. `useProfileErrorHandler` now reads the message off `err.errors.message` via a `getProfileErrorMessage` helper, falling back to `err.message` for errors that don't follow the `{ code, message }` shape. `userStore` now sets `errors.code` on every thrown `APIError` so that shape holds consistently.
- Added test coverage for `userStore.fetchUserProfile`: success, 401/303/500 handling, network failure normalized into an `APIError`, and the 403 impersonation path.