### PR TITLE
fix: date labels update immediately after a locale switch

### DIFF
--- a/pages/sites/[slug]/[locale]/claim/[type]/[code].tsx
+++ b/pages/sites/[slug]/[locale]/claim/[type]/[code].tsx
@@ -142,6 +142,7 @@ function ClaimDonation(): ReactElement {
         localStorage.setItem('redirectLink', router.asPath);
         loginWithRedirect({
           redirectUri: `${window.location.origin}/login`,
+          // Legacy compatibility read, kept until Auth0 redirects are migrated off localStorage.language (see issue #3020).
           ui_locales: localStorage.getItem('language') || 'en',
         });
       }

--- a/pages/sites/[slug]/[locale]/login.tsx
+++ b/pages/sites/[slug]/[locale]/login.tsx
@@ -75,6 +75,7 @@ export default function Login(): ReactElement {
     // Not authenticated → login
     loginWithRedirect({
       redirectUri: `${window.location.origin}/login`,
+      // Legacy compatibility read, kept until Auth0 redirects are migrated off localStorage.language (see issue #3020).
       ui_locales: localStorage.getItem('language') || 'en',
     });
   }, [userProfile, isAuthResolved, isInitialized]);

--- a/pages/sites/[slug]/[locale]/profile/projects/new-project.tsx
+++ b/pages/sites/[slug]/[locale]/profile/projects/new-project.tsx
@@ -51,6 +51,7 @@ export default function AddProjectType(): ReactElement {
 
       loginWithRedirect({
         redirectUri: `${window.location.origin}/login`,
+        // Legacy compatibility read, kept until Auth0 redirects are migrated off localStorage.language (see issue #3020).
         ui_locales: localStorage.getItem('language') || 'en',
       });
       return;

--- a/src/features/common/Layout/Navbar/microComponents/SignInButton.tsx
+++ b/src/features/common/Layout/Navbar/microComponents/SignInButton.tsx
@@ -41,6 +41,7 @@ export const SignInButton = () => {
     } else {
       loginWithRedirect({
         redirectUri: `${window.location.origin}/login`,
+        // Legacy compatibility read, kept until Auth0 redirects are migrated off localStorage.language (see issue #3020).
         ui_locales: localStorage.getItem('language') || 'en',
       });
     }

--- a/src/features/common/VerifyEmail/VerifyEmail.tsx
+++ b/src/features/common/VerifyEmail/VerifyEmail.tsx
@@ -39,6 +39,7 @@ function VerifyEmailComponent(): ReactElement {
         onClick={() =>
           loginWithRedirect({
             redirectUri: `${window.location.origin}/login`,
+            // Legacy compatibility read, kept until Auth0 redirects are migrated off localStorage.language (see issue #3020).
             ui_locales: localStorage.getItem('language') || 'en',
           })
         }

--- a/src/features/projectsV2/ProjectDetails/components/KeyInfo.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/KeyInfo.tsx
@@ -51,7 +51,9 @@ const KeyInfo = ({
     activitySeasons !== null && activitySeasons.length > 0;
   const showPlantingSeasons =
     plantingSeasons !== null && plantingSeasons.length > 0;
-  const restorationDate = firstTreePlanted ? formatDate(firstTreePlanted) : '';
+  const restorationDate = firstTreePlanted
+    ? formatDate(firstTreePlanted, locale)
+    : '';
   const showProjectArea =
     projectAreaInHectares !== null && projectAreaInHectares > 0;
 

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/OtherInterventionInfoHeader.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/OtherInterventionInfoHeader.tsx
@@ -3,7 +3,7 @@ import type { INTERVENTION_TYPE } from '../../../../../utils/constants/intervent
 import styles from '../../styles/InterventionInfo.module.scss';
 import { formatHid } from '../../../../../utils/projectV2';
 import formatDate from '../../../../../utils/countryCurrency/getFormattedDate';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { clsx } from 'clsx';
 
 interface Props {
@@ -19,6 +19,7 @@ const OtherInterventionInfoHeader = ({
 }: Props) => {
   const tProjectDetails = useTranslations('ProjectDetails');
   const tIntervention = useTranslations('ProjectDetails.intervention');
+  const locale = useLocale();
 
   return (
     <>
@@ -40,7 +41,7 @@ const OtherInterventionInfoHeader = ({
           {tProjectDetails('intervention.interventionDate')}
         </h2>
         <p className={styles.data}>
-          {plantDate ? formatDate(plantDate) : null}
+          {plantDate ? formatDate(plantDate, locale) : null}
         </p>
       </div>
     </>

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/PlantInfoCard.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/PlantInfoCard.tsx
@@ -1,7 +1,7 @@
 import type { Measurements } from '@planet-sdk/common';
 
 import styles from '../../styles/InterventionInfo.module.scss';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import formatDate from '../../../../../utils/countryCurrency/getFormattedDate';
 import { clsx } from 'clsx';
 import { useInterventionStore } from '../../../../../stores';
@@ -22,13 +22,14 @@ const PlantInfoCard = ({
   type,
 }: Props) => {
   const tProjectDetails = useTranslations('ProjectDetails');
+  const locale = useLocale();
   const setSelectedSampleIntervention = useInterventionStore(
     (state) => state.setSelectedSampleIntervention
   );
   const sampleTreeConfig = [
     {
       label: tProjectDetails('plantingDate'),
-      data: plantDate ? formatDate(plantDate) : null,
+      data: plantDate ? formatDate(plantDate, locale) : null,
       shouldRender: Boolean(plantDate),
     },
     {

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/PlantingDetails.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/PlantingDetails.tsx
@@ -15,7 +15,7 @@ const PlantingDetails = ({ plantingDensity, plantDate }: Props) => {
   const plantingDetails = [
     {
       label: tProjectDetails('plantingDate'),
-      data: plantDate ? formatDate(plantDate) : null,
+      data: plantDate ? formatDate(plantDate, locale) : null,
       shouldRender: plantDate !== null,
     },
     {

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/SingleReview.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/SingleReview.tsx
@@ -1,6 +1,6 @@
 import type { Review } from '@planet-sdk/common';
 
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import styles from '../../styles/ProjectReviews.module.scss';
 import DownloadReportIcon from '../../../../../../public/assets/images/icons/projectV2/DownloadReportIcon';
 import VerifiedIcon from '@mui/icons-material/Verified';
@@ -17,12 +17,13 @@ interface Props {
 const SingleReview = ({ singleReview }: Props) => {
   const tCommon = useTranslations('Common');
   const tProjectDetails = useTranslations('ProjectDetails');
+  const locale = useLocale();
 
   const { colors } = themeProperties.designSystem;
 
   const displayDate = (date: string) => {
     return format(parse(date, 'MM-yyyy', new Date()), 'LLLL yyyy', {
-      locale: localeMapForDate[localStorage.getItem('language') || 'en'],
+      locale: localeMapForDate[locale] || localeMapForDate['en'],
     });
   };
 

--- a/src/features/projectsV2/ProjectSnippet/microComponents/TopProjectReports.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/TopProjectReports.tsx
@@ -6,7 +6,7 @@ import { getPDFFile } from '../../../../utils/getImageURL';
 import parse from 'date-fns/parse';
 import format from 'date-fns/format';
 import { localeMapForDate } from '../../../../utils/language/getLanguageName';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import themeProperties from '../../../../theme/themeProperties';
 
 interface Props {
@@ -15,9 +15,10 @@ interface Props {
 
 export default function TopProjectReports({ projectReviews }: Props) {
   const t = useTranslations('Common');
+  const locale = useLocale();
   const displayDate = (date: string) => {
     return format(parse(date, 'MM-yyyy', new Date()), 'LLLL yyyy', {
-      locale: localeMapForDate[localStorage.getItem('language') || 'en'],
+      locale: localeMapForDate[locale] || localeMapForDate['en'],
     });
   };
   return (

--- a/src/features/user/Account/EditModal.tsx
+++ b/src/features/user/Account/EditModal.tsx
@@ -65,17 +65,10 @@ export const EditModal = ({
     mode: 'all',
   });
   //local state
-  const [userLang, setUserLang] = useState('en');
   const [disabled, setDisabled] = useState(false);
   //store
   const setErrors = useErrorHandlingStore((state) => state.setErrors);
 
-  useEffect(() => {
-    if (localStorage.getItem('language')) {
-      const userLang = localStorage.getItem('language');
-      if (userLang) setUserLang(userLang);
-    }
-  }, []);
   useEffect(() => {
     setDisabled(false);
   }, [editModalOpen]);
@@ -247,9 +240,7 @@ export const EditModal = ({
                   <LocalizationProvider
                     dateAdapter={AdapterDateFns}
                     adapterLocale={
-                      localeMapForDate[userLang]
-                        ? localeMapForDate[userLang]
-                        : localeMapForDate['en']
+                      localeMapForDate[locale] || localeMapForDate['en']
                     }
                   >
                     <Controller

--- a/src/features/user/Account/components/AccountRecord.tsx
+++ b/src/features/user/Account/components/AccountRecord.tsx
@@ -85,7 +85,7 @@ export function RecordHeader({
     <>
       <div className={styles.left}>
         {getRecordTitle()}
-        <p>{formatDate(record.created)}</p>
+        <p>{formatDate(record.created, locale)}</p>
       </div>
       <div className={styles.right}>
         <p className={clsx(styles.top, styles[netAmountStatus])}>
@@ -135,19 +135,19 @@ export function DetailsComponent({ record }: DetailProps): ReactElement {
       {record.created && (
         <div className={styles.singleDetail}>
           <p className={styles.title}>{tMe('created')}</p>
-          <p>{formatDate(record.created)}</p>
+          <p>{formatDate(record.created, locale)}</p>
         </div>
       )}
       {record.lastUpdate && (
         <div className={styles.singleDetail}>
           <p className={styles.title}>{tMe('lastUpdate')}</p>
-          <p>{formatDate(record.lastUpdate)}</p>
+          <p>{formatDate(record.lastUpdate, locale)}</p>
         </div>
       )}
       {record.details?.paymentDate && (
         <div className={styles.singleDetail}>
           <p className={styles.title}>{tMe('paymentDate')}</p>
-          <p>{formatDate(record.details?.paymentDate)}</p>
+          <p>{formatDate(record.details?.paymentDate, locale)}</p>
         </div>
       )}
       {record.details?.paidAmount && (
@@ -357,6 +357,7 @@ interface BankDetailsProps {
 
 export function BankDetails({ recipientBank }: BankDetailsProps): ReactElement {
   const t = useTranslations('Me');
+  const locale = useLocale();
   return (
     <>
       {recipientBank?.bankName && (
@@ -404,13 +405,13 @@ export function BankDetails({ recipientBank }: BankDetailsProps): ReactElement {
       {recipientBank?.created && (
         <div className={styles.singleDetail}>
           <p className={styles.title}>{t('created')}</p>
-          <p>{formatDate(recipientBank.created)}</p>
+          <p>{formatDate(recipientBank.created, locale)}</p>
         </div>
       )}
       {recipientBank?.updated && (
         <div className={styles.singleDetail}>
           <p className={styles.title}>{t('updated')}</p>
-          <p>{formatDate(recipientBank.updated)}</p>
+          <p>{formatDate(recipientBank.updated, locale)}</p>
         </div>
       )}
     </>

--- a/src/features/user/Account/components/RecurrencyRecord.tsx
+++ b/src/features/user/Account/components/RecurrencyRecord.tsx
@@ -91,7 +91,8 @@ export function RecordHeader({
      */
     const formatDateWithOffset = (dateString: string) =>
       formatDate(
-        new Date(new Date(dateString).valueOf() + 1000 * 3600).toISOString()
+        new Date(new Date(dateString).valueOf() + 1000 * 3600).toISOString(),
+        locale
       );
 
     // Active or Trialing - check for scheduled cancellation
@@ -104,9 +105,10 @@ export function RecordHeader({
           )} • ${t(record.frequency)}`;
         }
       }
-      return `${t('nextOn')} ${formatDate(record.currentPeriodEnd)} • ${t(
-        record.frequency
-      )}`;
+      return `${t('nextOn')} ${formatDate(
+        record.currentPeriodEnd,
+        locale
+      )} • ${t(record.frequency)}`;
     }
 
     // Paused
@@ -129,9 +131,10 @@ export function RecordHeader({
 
     // Past Due
     if (record.status === 'past_due') {
-      return `${t('lastDueOn')} ${formatDate(record.currentPeriodEnd)} • ${t(
-        record.frequency
-      )}`;
+      return `${t('lastDueOn')} ${formatDate(
+        record.currentPeriodEnd,
+        locale
+      )} • ${t(record.frequency)}`;
     }
 
     // Canceled
@@ -152,7 +155,7 @@ export function RecordHeader({
 
     // Fallback for any other status
     return null;
-  }, [record, t]);
+  }, [record, t, locale]);
 
   const headerContent = (
     <>
@@ -261,7 +264,7 @@ export function DetailsComponent({ record }: DetailProps): ReactElement {
       {record.firstDonation?.created && (
         <div className={styles.singleDetail}>
           <p className={styles.title}>{t('firstDonation')}</p>
-          <p>{formatDate(record.firstDonation.created)}</p>
+          <p>{formatDate(record.firstDonation.created, locale)}</p>
         </div>
       )}
       {record?.destination?.type === 'planet-cash' && (

--- a/src/features/user/DonationReceipt/microComponents/DonationInfoPopover.tsx
+++ b/src/features/user/DonationReceipt/microComponents/DonationInfoPopover.tsx
@@ -4,7 +4,7 @@ import type {
 } from '../donationReceiptTypes';
 
 import { Popover } from '@mui/material';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import CrossIcon from '../../../../../public/assets/images/icons/projectV2/CrossIcon';
 import IconButton from '../../../common/IconButton';
 import formatDate from '../../../../utils/countryCurrency/getFormattedDate';
@@ -28,6 +28,7 @@ const DonationInfoPopover = ({
 }: Props) => {
   const tReceipt = useTranslations('DonationReceipt');
   const tCommon = useTranslations('Common');
+  const locale = useLocale();
   const open = Boolean(popoverAnchor);
   const id = open ? 'donation-info-popOver' : undefined;
   return (
@@ -64,7 +65,7 @@ const DonationInfoPopover = ({
           {donations.map((item) => (
             <tr key={getDonationReference(item)}>
               <td>{getDonationReference(item)}</td>
-              <td>{formatDate(item.paymentDate)}</td>
+              <td>{formatDate(item.paymentDate, locale)}</td>
             </tr>
           ))}
         </tbody>

--- a/src/features/user/DonationReceipt/microComponents/DonationsTable.tsx
+++ b/src/features/user/DonationReceipt/microComponents/DonationsTable.tsx
@@ -1,6 +1,6 @@
 import type { Donation } from '../donationReceiptTypes';
 
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import styles from '../DonationReceipt.module.scss';
 import formatDate from '../../../../utils/countryCurrency/getFormattedDate';
 
@@ -12,6 +12,7 @@ type Props = {
 
 const DonationsTable = ({ donations, amount, currency }: Props) => {
   const tReceipt = useTranslations('DonationReceipt');
+  const locale = useLocale();
   return (
     <table
       className={styles.donationsTable}
@@ -42,7 +43,9 @@ const DonationsTable = ({ donations, amount, currency }: Props) => {
                 })}
               </td>
               <td className={styles.date}>
-                <time dateTime={paymentDate}>{formatDate(paymentDate)}</time>
+                <time dateTime={paymentDate}>
+                  {formatDate(paymentDate, locale)}
+                </time>
               </td>
             </tr>
           );

--- a/src/features/user/DonationReceipt/microComponents/IssuedReceiptCard.tsx
+++ b/src/features/user/DonationReceipt/microComponents/IssuedReceiptCard.tsx
@@ -1,6 +1,6 @@
 import type { IssuedReceiptDataApi } from '../donationReceiptTypes';
 
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import WebappButton from '../../../common/WebappButton';
 import styles from '../DonationReceipt.module.scss';
 import formatDate from '../../../../utils/countryCurrency/getFormattedDate';
@@ -20,6 +20,7 @@ const IssuedReceiptCard = ({
   isProcessing,
 }: Prop) => {
   const tReceipt = useTranslations('DonationReceipt');
+  const locale = useLocale();
   const {
     amount,
     currency,
@@ -43,7 +44,7 @@ const IssuedReceiptCard = ({
         count={donationCount}
         reference={reference}
         template={template}
-        date={formatDate(paymentDate)}
+        date={formatDate(paymentDate, locale)}
         donations={donations}
       />
       {isReceiptVerified ? (

--- a/src/features/user/DonationReceipt/microComponents/UnissuedReceiptCard.tsx
+++ b/src/features/user/DonationReceipt/microComponents/UnissuedReceiptCard.tsx
@@ -4,7 +4,7 @@ import styles from '../DonationReceipt.module.scss';
 import DonationInfo from './DonationInfo';
 import formatDate from '../../../../utils/countryCurrency/getFormattedDate';
 import WebappButton from '../../../common/WebappButton';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { UNISSUED_RECEIPT_TYPE } from '../donationReceiptTypes';
 
 type Prop = {
@@ -19,6 +19,7 @@ const UnissuedReceiptCard = ({
   isProcessing,
 }: Prop) => {
   const tReceipt = useTranslations('DonationReceipt');
+  const locale = useLocale();
   const {
     amount,
     currency,
@@ -38,7 +39,7 @@ const UnissuedReceiptCard = ({
         amount={amount}
         count={donationCount}
         currency={currency}
-        date={formatDate(paymentDate)}
+        date={formatDate(paymentDate, locale)}
         reference={reference}
         template={template}
         donations={donations}

--- a/src/features/user/ManageProjects/index.tsx
+++ b/src/features/user/ManageProjects/index.tsx
@@ -160,14 +160,6 @@ export default function ManageProjects({
       fetchProjectDetails();
     }
   }, [GUID, projectGUID]);
-  const [userLang, setUserLang] = useState('en');
-  useEffect(() => {
-    if (localStorage.getItem('language')) {
-      const userLang = localStorage.getItem('language');
-      if (userLang) setUserLang(userLang);
-    }
-  }, []);
-
   useEffect(() => {
     if (router.query.purpose) {
       setTabSelected(1);
@@ -293,7 +285,7 @@ export default function ManageProjects({
       case ProjectCreationTabs.DETAILED_ANALYSIS:
         return (
           <DetailedAnalysis
-            userLang={userLang}
+            userLang={locale}
             handleNext={handleNext}
             token={token}
             handleBack={handleBack}
@@ -317,7 +309,7 @@ export default function ManageProjects({
       case ProjectCreationTabs.PROJECT_SPENDING:
         return (
           <ProjectSpending
-            userLang={userLang}
+            userLang={locale}
             handleNext={handleNext}
             token={token}
             handleBack={handleBack}

--- a/src/features/user/Profile/ContributionsMap/Popup/RegisteredTreesPopup.tsx
+++ b/src/features/user/Profile/ContributionsMap/Popup/RegisteredTreesPopup.tsx
@@ -5,7 +5,7 @@ import type {
 } from '../../../../common/types/myForest';
 import type { SetState } from '../../../../common/types/common';
 
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { Popup } from 'react-map-gl-v7/maplibre';
 import RegisteredTreePopupIcon from '../../../../../../public/assets/images/icons/myForestMapIcons/RegisteredTreePopupIcon';
 import styles from '../ContributionsMap.module.scss';
@@ -16,6 +16,7 @@ type RegisteredTreesInfoProps = {
 };
 const RegisteredTreesInfo = ({ registrations }: RegisteredTreesInfoProps) => {
   const tProfile = useTranslations('Profile.myForestMap');
+  const locale = useLocale();
   return (
     <>
       {registrations.map((singleRegistration) => {
@@ -32,7 +33,7 @@ const RegisteredTreesInfo = ({ registrations }: RegisteredTreesInfoProps) => {
               {tProfile('registered')}
             </div>
             <div className={styles.registeredTreeDate}>
-              {formatDate(plantDate)}
+              {formatDate(plantDate, locale)}
             </div>
           </>
         );

--- a/src/features/user/Profile/MyContributions/ContributionSummary.tsx
+++ b/src/features/user/Profile/MyContributions/ContributionSummary.tsx
@@ -1,6 +1,6 @@
 import type { MySingleContribution } from '../../../common/types/myForest';
 
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import GiftIcon from '../../../../../public/assets/images/icons/Gift';
 import styles from './MyContributions.module.scss';
 import format from 'date-fns/format';
@@ -16,6 +16,7 @@ interface Props {
 const UnwrappedContributionSummary = forwardRef<HTMLDivElement, Props>(
   ({ contribution, purpose }: Props, ref) => {
     const t = useTranslations('Profile');
+    const locale = useLocale();
 
     const showGiftIcon =
       contribution.dataType === 'receivedGift' || contribution.isGifted;
@@ -31,7 +32,7 @@ const UnwrappedContributionSummary = forwardRef<HTMLDivElement, Props>(
           });
 
     const contributionDate = format(new Date(contribution.plantDate), 'PP', {
-      locale: localeMapForDate[localStorage.getItem('language') || 'en'],
+      locale: localeMapForDate[locale] || localeMapForDate['en'],
     });
 
     return (

--- a/src/features/user/Profile/MyContributions/RegistrationSummary.tsx
+++ b/src/features/user/Profile/MyContributions/RegistrationSummary.tsx
@@ -2,7 +2,7 @@ import type { CountryCode } from '@planet-sdk/common';
 import type { DateString } from '../../../common/types/common';
 
 import styles from './MyContributions.module.scss';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { localeMapForDate } from '../../../../utils/language/getLanguageName';
 import format from 'date-fns/format';
 
@@ -19,10 +19,11 @@ const RegistrationSummary = ({
 }: Props) => {
   const t = useTranslations('Profile');
   const tCountry = useTranslations('Country');
+  const locale = useLocale();
 
   const formattedRegDate = registrationDate
     ? format(new Date(registrationDate), 'PP', {
-        locale: localeMapForDate[localStorage.getItem('language') || 'en'],
+        locale: localeMapForDate[locale] || localeMapForDate['en'],
       })
     : '';
 

--- a/src/hooks/useInitializeAuth.ts
+++ b/src/hooks/useInitializeAuth.ts
@@ -30,6 +30,7 @@ export const useInitializeAuth = () => {
 
     loginWithRedirect({
       redirectUri: `${window.location.origin}/login`,
+      // Legacy compatibility read, kept until Auth0 redirects are migrated off localStorage.language (see issue #3020).
       ui_locales: localStorage.getItem('language') || 'en',
     });
   }, [loginWithRedirect, setIsAuthResolved, setHasAuthFailed]);

--- a/src/hooks/useProfileErrorHandler.ts
+++ b/src/hooks/useProfileErrorHandler.ts
@@ -55,6 +55,7 @@ const useProfileErrorHandler = () => {
 
           loginWithRedirect({
             redirectUri: `${window.location.origin}/login`,
+            // Legacy compatibility read, kept until Auth0 redirects are migrated off localStorage.language (see issue #3020).
             ui_locales: localStorage.getItem('language') || 'en',
           });
           break;

--- a/src/utils/countryCurrency/getFormattedDate.ts
+++ b/src/utils/countryCurrency/getFormattedDate.ts
@@ -2,7 +2,10 @@ import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
 import { localeMapForDate } from '../language/getLanguageName';
 
-export default function formatDate(date: number | Date | string) {
+export default function formatDate(
+  date: number | Date | string,
+  locale: string
+) {
   if (!date) {
     return '';
   }
@@ -31,11 +34,11 @@ export default function formatDate(date: number | Date | string) {
         '0'
       )}`;
       return format(parseISO(isoDateString), 'LLLL d, yyyy', {
-        locale: localeMapForDate[localStorage.getItem('language') || 'en'],
+        locale: localeMapForDate[locale] || localeMapForDate['en'],
       });
     } else {
       return format(date, 'LLLL d, yyyy', {
-        locale: localeMapForDate[localStorage.getItem('language') || 'en'],
+        locale: localeMapForDate[locale] || localeMapForDate['en'],
       });
     }
   } catch (error) {

--- a/src/utils/getDonationUrl.ts
+++ b/src/utils/getDonationUrl.ts
@@ -9,6 +9,7 @@ export const getDonationUrl = (
   utmCampaign?: string
 ): string => {
   const country = localStorage.getItem('countryCode') || 'DE';
+  // Legacy compatibility read, kept until the donation widget URL is migrated off localStorage.language (see issue #3020).
   const language = localStorage.getItem('language') || 'en';
 
   const storedDirectGift = localStorage.getItem('directGift');


### PR DESCRIPTION
## Summary

Follow-up to #3018 / #3015, addresses #3020.

Date-formatting paths still read `localStorage.language` directly instead of using the route's current locale, so payment history, recurring donation, and project date labels stayed in the old language after a locale switch (they only picked up the new language on a full page reload once `localStorage` caught up).

- `formatDate()` (`getFormattedDate.ts`) now takes `locale` as an explicit parameter instead of reading `localStorage` internally, matching the pattern already used by `getFormattedCurrency()`. All 11 call sites now pass `locale` from `useLocale()`.
- Four components that built `date-fns` locale objects directly from `localeMapForDate[localStorage.getItem('language')]` (project reviews, reports, contribution/registration summaries) now use `useLocale()` instead.
- `EditModal.tsx` (recurring donation edit) and `ManageProjects/index.tsx` each held a `userLang` state populated once from `localStorage` on mount, even though `locale` from `useLocale()` was already available in the same component. Removed the dead state/effect in favor of the existing reactive value.
- The remaining `localStorage.language` reads (Auth0 `ui_locales` login/signup redirects, donation widget URL) are out of scope here since they redirect to external services rather than render in-app UI. They're now marked with a compatibility comment per the issue's acceptance criteria, instead of being silently left as-is.

## Why this approach

The codebase already has an established pattern for this: `getFormattedCurrency(locale, ...)` takes locale explicitly and callers pass `useLocale()`. Matching that for dates keeps the fix small and idiomatic, and makes the locale dependency explicit at each call site rather than hiding a `localStorage` read (and its staleness) inside the formatter.

## Test plan

- [x] `tsc --noEmit` shows the same pre-existing error count before and after (no new type errors)
- [x] `eslint` clean on all changed files
- [ ] Manually switch locale on Payment History / Recurring Donations screens and confirm dates update immediately without a page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)