### PR TITLE
Derive current page synchronously

### DIFF
--- a/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
+++ b/src/features/common/Layout/ProjectsLayout/MobileProjectsLayout.tsx
@@ -10,6 +10,7 @@ import {
   useUserStore,
   useViewStore,
 } from '../../../../stores';
+import { useCurrentPage } from '../../../../hooks/useCurrentPage';
 
 export type ViewMode = 'list' | 'map';
 interface ProjectsLayoutProps {
@@ -28,7 +29,7 @@ const MobileProjectsLayout = ({ children, isMobile }: ProjectsLayoutProps) => {
   const isImpersonationModeOn = useUserStore(
     (state) => state.isImpersonationModeOn
   );
-  const currentPage = useViewStore((state) => state.page);
+  const currentPage = useCurrentPage();
   const isMapMode = useViewStore((state) => state.selectedMode === 'map');
 
   // store: action

--- a/src/features/common/Layout/ProjectsLayout/index.tsx
+++ b/src/features/common/Layout/ProjectsLayout/index.tsx
@@ -9,8 +9,8 @@ import {
   useProjectMapStore,
   useQueryParamStore,
   useUserStore,
-  useViewStore,
 } from '../../../../stores';
+import { useCurrentPage } from '../../../../hooks/useCurrentPage';
 
 interface ProjectsLayoutProps {
   children: ReactNode;
@@ -27,7 +27,7 @@ const ProjectsLayoutContent = ({ children }: ProjectsLayoutProps) => {
   const isImpersonationModeOn = useUserStore(
     (state) => state.isImpersonationModeOn
   );
-  const currentPage = useViewStore((state) => state.page);
+  const currentPage = useCurrentPage();
   // store: action
   const updateMapOption = useProjectMapStore((state) => state.updateMapOption);
 

--- a/src/features/common/Layout/index.tsx
+++ b/src/features/common/Layout/index.tsx
@@ -12,9 +12,9 @@ import {
   useAuthStore,
   useQueryParamStore,
   useTenantStore,
-  useViewStore,
 } from '../../../stores';
 import { isEmbeddablePage } from '../../../stores/viewStore';
+import { useCurrentPage } from '../../../hooks/useCurrentPage';
 
 const Layout = ({ children }: { children: ReactNode }) => {
   const { theme: themeType } = useTheme();
@@ -25,7 +25,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
   );
 
   const embed = useQueryParamStore((state) => state.embed);
-  const embeddablePage = useViewStore((state) => state.page);
+  const embeddablePage = useCurrentPage();
   const isEmbedMode = embed === 'true' && isEmbeddablePage(embeddablePage);
 
   // The profile fetch runs globally, so a sign-in can fail on any page. Swapping the content here reaches the user wherever they are, with no redirect.

--- a/src/features/projectsV2/ProjectListControls/ProjectListControlForMobile.tsx
+++ b/src/features/projectsV2/ProjectListControls/ProjectListControlForMobile.tsx
@@ -19,6 +19,7 @@ import {
   useQueryParamStore,
 } from '../../../stores';
 import { useFilteredProjects } from '../../../hooks/useFilteredProjects';
+import { useCurrentPage } from '../../../hooks/useCurrentPage';
 
 interface ProjectListControlForMobileProps {
   tabSelected?: ProjectTabs;
@@ -48,7 +49,7 @@ const ProjectListControlForMobile = ({
   const isEmbedMode = useQueryParamStore((state) => state.embed === 'true');
   const showProjectList = useQueryParamStore((state) => state.showProjectList);
   const selectedMode = useViewStore((state) => state.selectedMode);
-  const currentPage = useViewStore((state) => state.page);
+  const currentPage = useCurrentPage();
   const isFilterApplied = useProjectStore(
     (state) =>
       state.selectedClassification.length > 0 || state.showDonatableProjects

--- a/src/features/projectsV2/ProjectSnippet/index.tsx
+++ b/src/features/projectsV2/ProjectSnippet/index.tsx
@@ -23,8 +23,9 @@ import {
 } from '../../../utils/projectV2';
 import TpoName from './microComponents/TpoName';
 import useLocalizedPath from '../../../hooks/useLocalizedPath';
+import { useCurrentPage } from '../../../hooks/useCurrentPage';
 import { clsx } from 'clsx';
-import { useViewStore, useQueryParamStore } from '../../../stores';
+import { useQueryParamStore } from '../../../stores';
 
 interface Props {
   project:
@@ -160,7 +161,7 @@ export default function ProjectSnippet({
 
   const embed = useQueryParamStore((state) => state.embed);
   const callbackUrl = useQueryParamStore((state) => state.callbackUrl);
-  const currentPage = useViewStore((state) => state.page);
+  const currentPage = useCurrentPage();
 
   const isTopProject = project.purpose === 'trees' && project.isTopProject;
   const isApproved = project.purpose === 'trees' && project.isApproved;

--- a/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/ImageSection.tsx
@@ -15,8 +15,9 @@ import styles from '../styles/ProjectSnippet.module.scss';
 import BackButton from '../../../../../public/assets/images/icons/BackButton';
 import IconButton from '../../../common/IconButton';
 import useLocalizedPath from '../../../../hooks/useLocalizedPath';
+import { useCurrentPage } from '../../../../hooks/useCurrentPage';
 import { clsx } from 'clsx';
-import { useViewStore, useQueryParamStore } from '../../../../stores';
+import { useQueryParamStore } from '../../../../stores';
 
 const MAX_NAME_LENGTH = 32;
 
@@ -46,7 +47,7 @@ const ImageSection = (props: ImageSectionProps) => {
   const isEmbedMode = useQueryParamStore((state) => state.embed === 'true');
   const callbackUrl = useQueryParamStore((state) => state.callbackUrl);
   const showBackIcon = useQueryParamStore((state) => state.showBackIcon);
-  const currentPage = useViewStore((state) => state.page);
+  const currentPage = useCurrentPage();
 
   useEffect(() => {
     setMounted(true);

--- a/src/features/projectsV2/ProjectSnippet/microComponents/ProjectBadge.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/ProjectBadge.tsx
@@ -9,7 +9,8 @@ import NewInfoIcon from '../../../../../public/assets/images/icons/projectV2/New
 import styles from '../styles/Badge.module.scss';
 import CustomTooltip from '../../../common/Layout/CustomTooltip';
 import { clsx } from 'clsx';
-import { useViewStore, useTenantStore } from '../../../../stores';
+import { useTenantStore } from '../../../../stores';
+import { useCurrentPage } from '../../../../hooks/useCurrentPage';
 
 interface Props {
   isApproved: boolean;
@@ -54,7 +55,7 @@ const ProjectBadge = ({
 }: Props) => {
   const tCommon = useTranslations('Common');
   const tProjectDetails = useTranslations('ProjectDetails');
-  const currentPage = useViewStore((state) => state.page);
+  const currentPage = useCurrentPage();
   const tenantSlug = useTenantStore((state) => state.tenantConfig.config.slug);
 
   const badgeConfigurations: TitleAndIconReturnType | undefined =

--- a/src/features/projectsV2/ProjectSnippet/microComponents/TpoName.tsx
+++ b/src/features/projectsV2/ProjectSnippet/microComponents/TpoName.tsx
@@ -5,8 +5,8 @@ import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import styles from '../styles/ProjectSnippet.module.scss';
 import useLocalizedPath from '../../../../hooks/useLocalizedPath';
+import { useCurrentPage } from '../../../../hooks/useCurrentPage';
 import { clsx } from 'clsx';
-import { useViewStore } from '../../../../stores';
 
 interface TpoNameProps {
   projectTpoName: string;
@@ -27,7 +27,7 @@ const TpoName = ({
 }: TpoNameProps) => {
   const tCommon = useTranslations('Common');
   const { localizedPath } = useLocalizedPath();
-  const currentPage = useViewStore((state) => state.page);
+  const currentPage = useCurrentPage();
 
   const tpoNameBackgroundClass = useMemo(() => {
     if (!allowDonations) return `${styles.noDonation}`;

--- a/src/features/projectsV2/ProjectsMap/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/index.tsx
@@ -42,11 +42,11 @@ import {
   useInterventionStore,
   useProjectStore,
   useSingleProjectStore,
-  useViewStore,
   useQueryParamStore,
   useProjectMapStore,
 } from '../../../stores';
 import { useFilteredProjects } from '../../../hooks/useFilteredProjects';
+import { useCurrentPage } from '../../../hooks/useCurrentPage';
 import { useLocale } from 'next-intl';
 import { useRouter } from 'next/router';
 
@@ -70,7 +70,7 @@ function ProjectsMap(props: ProjectsMapProps) {
   const lastHoveredIdRef = useRef<string | null>(null);
   const { filteredProjects } = useFilteredProjects();
   // store: state
-  const currentPage = useViewStore((state) => state.page);
+  const currentPage = useCurrentPage();
   const isEmbedded = useQueryParamStore((state) => state.embed === 'true');
   const isQueryParamsLoaded = useQueryParamStore(
     (state) => state.isContextLoaded

--- a/src/hooks/useCurrentPage.ts
+++ b/src/hooks/useCurrentPage.ts
@@ -1,0 +1,17 @@
+import type { Page } from '../stores/viewStore';
+
+import { useRouter } from 'next/router';
+
+/**
+ * Derives the current page from `router.pathname`, which is known
+ * synchronously on both server and client. Unlike `router.query`, this needs
+ * no `router.isReady` wait, so there is no `null` window during which a
+ * page-gated render can permanently miss its mount (see issue #3010).
+ */
+export const useCurrentPage = (): Page => {
+  const { pathname } = useRouter();
+
+  if (pathname === '/sites/[slug]/[locale]') return 'project-list';
+  if (pathname === '/sites/[slug]/[locale]/[p]') return 'project-details';
+  return null;
+};

--- a/src/hooks/useInitializeIntervention.ts
+++ b/src/hooks/useInitializeIntervention.ts
@@ -1,14 +1,11 @@
 import type { Intervention } from '@planet-sdk/common';
 
 import { useEffect } from 'react';
-import {
-  useInterventionStore,
-  useSingleProjectStore,
-  useViewStore,
-} from '../stores';
+import { useInterventionStore, useSingleProjectStore } from '../stores';
 import { useRouter } from 'next/router';
 import { useLocale } from 'next-intl';
 import { FIRST_SITE_INDEX, hasNoSites, isString } from '../utils/projectV2';
+import { useCurrentPage } from './useCurrentPage';
 
 const getInterventionByHid = (
   interventions: Intervention[] | null,
@@ -25,7 +22,7 @@ export const useInitializeIntervention = () => {
     requestedSite && requestedIntervention
   );
   // store: state
-  const currentPage = useViewStore((state) => state.page);
+  const currentPage = useCurrentPage();
   const singleProject = useSingleProjectStore((state) => state.singleProject);
   const selectedIntervention = useInterventionStore(
     (state) => state.selectedIntervention

--- a/src/hooks/useInitializeProject.ts
+++ b/src/hooks/useInitializeProject.ts
@@ -1,10 +1,11 @@
 import { useLocale } from 'next-intl';
 import { useEffect } from 'react';
-import { useProjectStore, useViewStore } from '../stores';
+import { useProjectStore } from '../stores';
 import { useApi } from './useApi';
 import { useCurrencyStore, useTenantStore } from '../stores';
 import { useRouter } from 'next/router';
 import { isValidClassification } from '../utils/projectV2';
+import { useCurrentPage } from './useCurrentPage';
 
 export const useInitializeProject = () => {
   const locale = useLocale();
@@ -16,7 +17,7 @@ export const useInitializeProject = () => {
   const isCurrencyResolved = useCurrencyStore(
     (state) => state.isCurrencyResolved
   );
-  const currentPage = useViewStore((state) => state.page);
+  const currentPage = useCurrentPage();
   // store: action
   const fetchProjects = useProjectStore((state) => state.fetchProjects);
   const setSelectedClassification = useProjectStore(
@@ -66,7 +67,6 @@ export const useInitializeProject = () => {
         setShowDonatableProjects(true);
       }
     }
-    // `currentPage` starts as `null` and is resolved by `useInitializeView` once the router is ready; include it so the URL filters initialize when the page becomes 'project-list' (not only on the initial `router.isReady`).
   }, [router.isReady, currentPage]);
 
   useEffect(() => {

--- a/src/hooks/useInitializeSingleProject.ts
+++ b/src/hooks/useInitializeSingleProject.ts
@@ -7,12 +7,12 @@ import {
   useInterventionStore,
   useSingleProjectStore,
   useTenantStore,
-  useViewStore,
 } from '../stores';
 import { useLocale } from 'next-intl';
 import { FIRST_SITE_INDEX, hasNoSites, isString } from '../utils/projectV2';
 import { useApi } from './useApi';
 import useLocalizedPath from './useLocalizedPath';
+import { useCurrentPage } from './useCurrentPage';
 
 const getSiteIndexById = (
   sites: ProjectSiteFeature[],
@@ -37,7 +37,7 @@ export const useInitializeSingleProject = () => {
     !requestedSite && requestedIntervention
   );
   // store: state
-  const currentPage = useViewStore((state) => state.page);
+  const currentPage = useCurrentPage();
   const currencyCode = useCurrencyStore((state) => state.currencyCode);
   const isCurrencyResolved = useCurrencyStore(
     (state) => state.isCurrencyResolved

--- a/src/hooks/useInitializeView.ts
+++ b/src/hooks/useInitializeView.ts
@@ -1,31 +1,11 @@
 import { useEffect } from 'react';
 import { useViewStore } from '../stores/viewStore';
-import { useRouter } from 'next/router';
+import { useCurrentPage } from './useCurrentPage';
 
 export const useInitializeView = (isMobile: boolean) => {
-  const router = useRouter();
-  // store: state
-  const currentPage = useViewStore((state) => state.page);
+  const currentPage = useCurrentPage();
   // store: action
-  const setPage = useViewStore((state) => state.setPage);
   const setSelectedMode = useViewStore((state) => state.setSelectedMode);
-
-  useEffect(() => {
-    if (!router.isReady) return;
-
-    const { query, pathname } = router;
-    const page =
-      pathname === '/sites/[slug]/[locale]'
-        ? 'project-list'
-        : query.p !== undefined
-        ? 'project-details'
-        : null;
-
-    // Only update if the page actually changed
-    if (page !== currentPage) {
-      setPage(page);
-    }
-  }, [router.isReady, router.pathname, router.query, currentPage, setPage]);
 
   useEffect(() => {
     if (!isMobile) return;

--- a/src/stores/singleProjectStore.ts
+++ b/src/stores/singleProjectStore.ts
@@ -230,17 +230,22 @@ export const useSingleProjectStore = create<SingleProjectStore>()(
         queryParams = {},
         router
       ) => {
-        const pathname = `/${locale}/${projectSlug}`;
+        const displayPathname = `/${locale}/${projectSlug}`;
         // Extract only the visible query params for the URL
         const { locale: _, slug: __, p: ___, ...visibleParams } = queryParams;
 
         router?.push(
           {
-            pathname,
+            // Keep the actual route pattern here, not the tenant-facing
+            // display path. Passing the display path instead corrupts
+            // `router.pathname` after this shallow push (it no longer
+            // matches '/sites/[slug]/[locale]/[p]'), which broke page
+            // detection that relies on `router.pathname` (see useCurrentPage).
+            pathname: router.pathname,
             query: queryParams,
           },
           // Only show necessary params in the URL
-          `${pathname}${
+          `${displayPathname}${
             Object.keys(visibleParams).length
               ? '?' + new URLSearchParams(visibleParams).toString()
               : ''

--- a/src/stores/viewStore.ts
+++ b/src/stores/viewStore.ts
@@ -10,39 +10,27 @@ export type ViewMode = 'list' | 'map';
 export const EMBEDDABLE_PAGES = ['project-list', 'project-details'] as const;
 export type EmbeddablePage = (typeof EMBEDDABLE_PAGES)[number];
 
-/**
- * `null` means the current view hasn't been determined yet, or the route is
- * not a project page. The value is set by `useInitializeView` once the router
- * is ready.
- */
+/** `null` means the current route is not a project page. */
 export type Page = EmbeddablePage | null;
 
 /** Whether the given page is one that supports embed mode. */
 export const isEmbeddablePage = (page: Page): page is EmbeddablePage =>
   page !== null && (EMBEDDABLE_PAGES as readonly string[]).includes(page);
 interface ViewStore {
-  page: Page;
   /**
    * View mode is primarily used for mobile layouts
    * (e.g. map ↔ list toggle on project details, project list page).
    */
   selectedMode: ViewMode;
 
-  setPage: (currentPage: Page) => void;
   setSelectedMode: (viewMode: ViewMode) => void;
 }
 
 export const useViewStore = create<ViewStore>()(
   devtools(
     (set) => ({
-      // Start unresolved. `useInitializeView` sets the page when the router is
-      // ready. A concrete default can incorrectly trigger route-specific effects
-      // before the current route is determined.
-      page: null,
       selectedMode: 'list',
 
-      setPage: (currentPage) =>
-        set({ page: currentPage }, undefined, 'viewStore/set_current_page'),
       setSelectedMode: (viewMode) =>
         set({ selectedMode: viewMode }, undefined, 'viewStore/set_view_mode'),
     }),


### PR DESCRIPTION
## Summary

`viewStore`'s `page` field was only set once the Next.js router became ready, via an effect in `useInitializeView`. This left a `null` window on first render during which any page-gated logic could permanently miss its mount (issue #3010).

`useCurrentPage` derives the page directly from `router.pathname`, which is known synchronously on both server and client, so there is no ready-wait and no `null` window.

- `useCurrentPage.ts` (new) replaces `viewStore`'s `page` state and `setPage` action
- All consumers (`Layout`, `ProjectsLayout`, `MobileProjectsLayout`, the `useInitialize*` hooks, `ProjectsMap`, `ProjectListControlForMobile`, `ProjectSnippet` and its microComponents) switch from `useViewStore((state) => state.page)` to `useCurrentPage()`
- Fixes a related bug in `singleProjectStore.updateSingleProjectUrl`: it was pushing the tenant-facing display path as the router `pathname`, which corrupted `router.pathname` after the shallow push (no longer matching `/sites/[slug]/[locale]/[p]`), breaking page detection

## Test plan

### First render / hard reload (the main bug this PR fixes)

- [x] Hard reload (full browser refresh, not a client-side link) directly on a project list page (`/sites/<slug>/<locale>`) and confirm list-specific UI (filters, list/map toggle, embed handling) is correct from the very first paint, with no flash of the wrong state
- [x] Hard reload directly on a project details page (`/sites/<slug>/<locale>/<p>`) and confirm details-specific UI (project snippet, badge, TPO name, back button) is correct from the very first paint
- [x] Hard reload directly on a project details URL that also has `site` and `intervention` query params, and confirm the correct site/intervention render immediately, not just after a delay

### Embed mode edge cases

- [x] Load a project list page with `?embed=true` and confirm embed mode activates immediately (no flash of the non-embed layout)
- [x] Load a project details page with `?embed=true` and confirm the same
- [x] Load a non-embeddable page (e.g. a profile or claim page under `/sites/<slug>/<locale>/...`) with `?embed=true` and confirm embed mode does NOT activate, since `useCurrentPage` returns `null` there

### Mobile layout

- [x] On a mobile viewport, load the project list page directly and confirm the list/map view mode initializes correctly
- [x] On a mobile viewport, load the project details page directly and confirm the same
- [x] Toggle between list/map mode on mobile and confirm it still works after navigating between list and details

### Client-side navigation

- [x] From the project list, click into a project (client-side transition, not a hard reload) and confirm the page switches to details correctly
- [x] Navigate back from project details to the list and confirm the page switches back correctly
- [x] Navigate to a page outside the project routes (e.g. home) and confirm project-page-gated UI (embed mode, map, filters) fully turns off

### `updateSingleProjectUrl` regression check (the `singleProjectStore` fix)

- [x] On a project details page, select a different site and confirm the URL updates to show the site, the map/snippet reflect the new site, and the page is still detected as `project-details` afterward (no layout reset or flicker)
- [x] Do the same for selecting an intervention
- [x] After selecting a site/intervention, hard reload the resulting URL and confirm it still resolves to the project details page correctly (this is the scenario the old code silently corrupted `router.pathname` on)

### Project snippet components

- [x] Confirm `ImageSection`'s back button only shows in the contexts it should (embed vs non-embed, list vs details)
- [x] Confirm `ProjectBadge` renders the correct badge/tooltip on both list and details
- [x] Confirm `TpoName` links/styling are correct on both list and details

🤖 Generated with [Claude Code](https://claude.com/claude-code)