### PR TITLE
fix: coerce null/undefined translation values for next-intl v4

### DIFF
--- a/src/features/projectsV2/ProjectDetails/components/MultiTreeInfo.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/MultiTreeInfo.tsx
@@ -42,7 +42,7 @@ const MultiTreeInfo = ({ activeMultiTree, isMobile }: Props) => {
       return {
         id: item.coordinates[0].id,
         image: item.coordinates[0].image ?? '',
-        description: tProjectDetails('sampleTreeTag', { tag: item.tag }),
+        description: tProjectDetails('sampleTreeTag', { tag: item.tag ?? '' }),
       };
     });
     return result;

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/MultiTreeInfoHeader.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/MultiTreeInfoHeader.tsx
@@ -32,7 +32,8 @@ const MultiTreeInfoHeader = ({
             Number(totalTreesCount),
             1
           ),
-          area: hectaresCovered > 0 ? hectaresCovered.toFixed(3) : undefined,
+          // The message's ICU select matches the literal string 'undefined' to hide the area chunk
+          area: hectaresCovered > 0 ? hectaresCovered.toFixed(3) : 'undefined',
           areaContainer: (chunks) => <span>{chunks}</span>,
         })}
       </div>

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/PlantInfoCard.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/PlantInfoCard.tsx
@@ -34,7 +34,7 @@ const PlantInfoCard = ({
     {
       label: tProjectDetails('treeTag'),
       data: tProjectDetails('tag', {
-        number: tag,
+        number: tag ?? '',
       }),
       shouldRender: Boolean(tag),
     },

--- a/src/features/projectsV2/ProjectDetails/components/microComponents/PlantingDetails.tsx
+++ b/src/features/projectsV2/ProjectDetails/components/microComponents/PlantingDetails.tsx
@@ -21,9 +21,10 @@ const PlantingDetails = ({ plantingDensity, plantDate }: Props) => {
     {
       label: tProjectDetails('plantingDensity'),
       data: tProjectDetails('plantingDensityUnit', {
-        formattedCount: plantingDensity
-          ? localizedAbbreviatedNumber(locale, plantingDensity, 1)
-          : null,
+        formattedCount:
+          plantingDensity !== null
+            ? localizedAbbreviatedNumber(locale, plantingDensity, 1)
+            : '',
       }),
       shouldRender: plantingDensity !== null,
     },

--- a/src/features/projectsV2/ProjectListControls/microComponents/ProjectListTabForMobile.tsx
+++ b/src/features/projectsV2/ProjectListControls/microComponents/ProjectListTabForMobile.tsx
@@ -51,7 +51,7 @@ const ProjectListTabForMobile = ({
         selectedTab="topProjects"
         icon={<StarIcon width={'12px'} />}
         label={t.rich('top', {
-          noOfProjects: topProjectCount,
+          noOfProjects: topProjectCount ?? 0,
           projectCountContainer: (chunks) => (
             <span className={styles.projectCount}>{chunks}</span>
           ),
@@ -60,7 +60,7 @@ const ProjectListTabForMobile = ({
       <TabItem
         selectedTab="allProjects"
         label={t.rich('allProjects', {
-          noOfProjects: projectCount,
+          noOfProjects: projectCount ?? 0,
           projectCountContainer: (chunks) => (
             <span className={styles.projectCount}>{chunks}</span>
           ),

--- a/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/index.tsx
+++ b/src/features/projectsV2/ProjectsMap/ProjectSiteDropDown/index.tsx
@@ -106,7 +106,7 @@ const ProjectSiteDropdown = ({ activeDropdown, setActiveDropdown }: Props) => {
                   <label className={styles.sitesLabel}>
                     <span className={styles.siteId}>
                       {tProjectDetails('siteCount', {
-                        siteId: getId(selectedSiteData?.id),
+                        siteId: getId(selectedSiteData?.id) ?? 0,
                         totalCount: siteList.length,
                       })}
                     </span>

--- a/src/features/user/DonationReceipt/microComponents/DonorDetails.tsx
+++ b/src/features/user/DonationReceipt/microComponents/DonorDetails.tsx
@@ -25,11 +25,13 @@ const DonorName = ({ donor }: { donor: DonorView }) => {
   return (
     <div className={styles.donorName}>
       <span className={styles.header}>
-        {tReceipt('donorInfo.name', { type: donor.type })}
+        {tReceipt('donorInfo.name', { type: donor.type ?? '' })}
       </span>
       {!donor.name ? (
         <ErrorMessage
-          message={tReceipt('notifications.nameMissing', { type: donor.type })}
+          message={tReceipt('notifications.nameMissing', {
+            type: donor.type ?? '',
+          })}
         />
       ) : (
         <span>{donor.name}</span>

--- a/src/features/user/Settings/DeleteProfile/DeleteProfileForm.tsx
+++ b/src/features/user/Settings/DeleteProfile/DeleteProfileForm.tsx
@@ -100,7 +100,7 @@ export default function DeleteProfileForm() {
         </p>
         <p className={styles.deleteModalWarning}>
           {tCommon('deleteIrreversible', {
-            email: userEmail,
+            email: userEmail ?? '',
           })}
         </p>
       </div>


### PR DESCRIPTION
## Summary

next-intl v4 (PR #2955) narrowed the `TranslationValues` type from `string | number | boolean | Date | null | undefined` down to `string | number | Date`. Several call sites across the codebase were passing `null` or `undefined` interpolation values that typechecked fine under v3 but now fail under v4.

This PR sweeps the codebase for every such occurrence and coerces each value at the call site (`?? 0` / `?? ''`), matching the fallback the issue itself suggested for the known case.

## Changes

Found 10 occurrences across 8 files via `tsc --noEmit`:

- `ProjectSiteDropDown/index.tsx` - `getId(...)` returns `number | null`
- `MultiTreeInfoHeader.tsx` - `area` was `string | undefined`; the message's ICU `select` matches the literal string `"undefined"` to hide the area chunk, so the fallback is now the string `'undefined'` instead of the JS value
- `PlantInfoCard.tsx` - `tag` was `string | null | undefined`
- `PlantingDetails.tsx` - `plantingDensity` was `number | null` (also fixes a latent bug where a density of `0` rendered as `null`)
- `MultiTreeInfo.tsx` - `item.tag` was `string | null`
- `ProjectListTabForMobile.tsx` (x2) - `topProjectCount` / `projectCount` were `number | undefined`
- `DonorDetails.tsx` (x2) - `donor.type` was `'individual' | 'organization' | null`
- `DeleteProfileForm.tsx` - `userEmail` was `string | undefined`

## Why this approach

Coercing at the call site is the smallest possible diff and keeps runtime behavior identical (verified against each translation message - plain interpolation or ICU `select` with an `other` fallback). Widening next-intl's types back would undo the point of the v4 upgrade, and editing the translation JSON files (en/de) for the ICU-select case would require larger, riskier changes for no behavioral gain.

## Test plan

- [x] `tsc --noEmit` before/after diffed: exactly the 10 target errors are gone, no new errors introduced (116 pre-existing, unrelated errors remain)
- [ ] Manual verification of the affected UI (project sites, tree counts, planting details, donation receipt donor info, delete account) in a running app

Fixes #2967