### PR TITLE
refactor: clean up _app.tsx types, effects, and early returns

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -116,7 +116,7 @@ const PlanetWeb = ({
 }: AppPropsWithLayout) => {
   const router = useRouter();
   const { tenantConfig } = pageProps;
-  const [browserCompatible, setBrowserCompatible] = useState(false);
+  const [isBrowserIncompatible, setIsBrowserIncompatible] = useState(false);
   const locale = (router.query?.locale as string) ?? 'en';
 
   useEffect(() => {
@@ -136,7 +136,7 @@ const PlanetWeb = ({
   }, []);
 
   useEffect(() => {
-    setBrowserCompatible(browserNotCompatible());
+    setIsBrowserIncompatible(browserNotCompatible());
   }, []);
 
   // `_document` sets `<html lang>` at SSR and on every full load, including language switches. This effect is purely defensive: it would re-sync lang if the locale ever changed without a document render, which doesn't happen today. Its `router.isReady` guard avoids overwriting the SSR value in Next's static case where query can be empty pre-hydration.
@@ -158,7 +158,7 @@ const PlanetWeb = ({
     pageComponentProps
   );
 
-  if (browserCompatible) {
+  if (isBrowserIncompatible) {
     return <BrowserNotSupported />;
   }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,11 +4,12 @@ import type { AppProps } from 'next/app';
 import type { Tenant } from '@planet-sdk/common/build/types/tenant';
 import type { AbstractIntlMessages } from 'next-intl';
 import type { NextPage } from 'next';
+import type { AppState } from '@auth0/auth0-react';
 
 import CssBaseline from '@mui/material/CssBaseline';
 import { CacheProvider } from '@emotion/react';
 import createEmotionCache from '../src/createEmotionCache';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import TagManager from 'react-gtm-module';
 import Router from 'next/router';
 import { Auth0Provider } from '@auth0/auth0-react';
@@ -73,7 +74,7 @@ if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
   });
 }
 
-const onRedirectCallback = (appState: any) => {
+const onRedirectCallback = (appState?: AppState) => {
   // Use Next.js's Router.replace method to replace the url
   if (appState) Router.replace(appState?.returnTo || '/');
 };
@@ -118,21 +119,19 @@ const PlanetWeb = ({
   const [browserCompatible, setBrowserCompatible] = useState(false);
   const locale = (router.query?.locale as string) ?? 'en';
 
-  const tagManagerArgs = {
-    gtmId: process.env.NEXT_PUBLIC_GA_TRACKING_ID,
-  };
-
-  if (process.env.NODE_ENV !== 'production') {
-    if (process.env.VERCEL_URL && typeof window !== 'undefined') {
-      if (process.env.VERCEL_URL !== window.location.hostname) {
-        router.replace(`https://${process.env.VERCEL_URL}`);
-      }
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.VERCEL_URL &&
+      process.env.VERCEL_URL !== window.location.hostname
+    ) {
+      router.replace(`https://${process.env.VERCEL_URL}`);
     }
-  }
+  }, [router]);
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_GA_TRACKING_ID) {
-      TagManager.initialize(tagManagerArgs);
+      TagManager.initialize({ gtmId: process.env.NEXT_PUBLIC_GA_TRACKING_ID });
     }
   }, []);
 
@@ -146,10 +145,7 @@ const PlanetWeb = ({
     document.documentElement.lang = locale;
   }, [locale, router.isReady]);
 
-  const isMobile = useMemo(() => {
-    if (typeof window === 'undefined') return false;
-    return window.innerWidth < 481;
-  }, [typeof window !== 'undefined' && window.innerWidth]);
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 481;
 
   const pageComponentProps = {
     pageProps,
@@ -164,39 +160,39 @@ const PlanetWeb = ({
 
   if (browserCompatible) {
     return <BrowserNotSupported />;
-  } else {
-    return tenantConfig ? (
-      <NextIntlClientProvider locale={locale} messages={pageProps.messages}>
-        <CacheProvider value={emotionCache}>
-          <Auth0Provider
-            domain={process.env.AUTH0_CUSTOM_DOMAIN!}
-            clientId={
-              tenantConfig.config?.auth0ClientId
-                ? tenantConfig.config.auth0ClientId
-                : process.env.AUTH0_CLIENT_ID
-            }
-            redirectUri={
-              typeof window !== 'undefined' ? window.location.origin : ''
-            }
-            audience={'urn:plant-for-the-planet'}
-            cacheLocation={'localstorage'}
-            onRedirectCallback={onRedirectCallback}
-            useRefreshTokens={true}
-          >
-            <StoreInitializer isMobile={isMobile} tenantConfig={tenantConfig} />
-            <ThemeProvider>
-              <MuiThemeProvider theme={materialTheme}>
-                <CssBaseline />
-                <Layout>{pageContent}</Layout>
-              </MuiThemeProvider>
-            </ThemeProvider>
-          </Auth0Provider>
-        </CacheProvider>
-      </NextIntlClientProvider>
-    ) : (
-      <></>
-    );
   }
+
+  if (!tenantConfig) {
+    return null;
+  }
+
+  return (
+    <NextIntlClientProvider locale={locale} messages={pageProps.messages}>
+      <CacheProvider value={emotionCache}>
+        <Auth0Provider
+          domain={process.env.AUTH0_CUSTOM_DOMAIN!}
+          clientId={
+            tenantConfig.config?.auth0ClientId || process.env.AUTH0_CLIENT_ID
+          }
+          redirectUri={
+            typeof window !== 'undefined' ? window.location.origin : ''
+          }
+          audience={'urn:plant-for-the-planet'}
+          cacheLocation={'localstorage'}
+          onRedirectCallback={onRedirectCallback}
+          useRefreshTokens={true}
+        >
+          <StoreInitializer isMobile={isMobile} tenantConfig={tenantConfig} />
+          <ThemeProvider>
+            <MuiThemeProvider theme={materialTheme}>
+              <CssBaseline />
+              <Layout>{pageContent}</Layout>
+            </MuiThemeProvider>
+          </ThemeProvider>
+        </Auth0Provider>
+      </CacheProvider>
+    </NextIntlClientProvider>
+  );
 };
 
 export default PlanetWeb;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -166,14 +166,25 @@ const PlanetWeb = ({
     pageComponentProps
   );
 
+  const domain = process.env.AUTH0_CUSTOM_DOMAIN;
+
+  if (!domain) {
+    throw new Error('AUTH0_CUSTOM_DOMAIN is not configured');
+  }
+
+  const clientId =
+    tenantConfig.config?.auth0ClientId || process.env.AUTH0_CLIENT_ID;
+
+  if (!clientId) {
+    throw new Error('AUTH0_CLIENT_ID is not configured');
+  }
+
   return (
     <NextIntlClientProvider locale={locale} messages={pageProps.messages}>
       <CacheProvider value={emotionCache}>
         <Auth0Provider
-          domain={process.env.AUTH0_CUSTOM_DOMAIN!}
-          clientId={
-            tenantConfig.config?.auth0ClientId || process.env.AUTH0_CLIENT_ID
-          }
+          domain={domain}
+          clientId={clientId}
           redirectUri={
             typeof window !== 'undefined' ? window.location.origin : ''
           }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -145,6 +145,14 @@ const PlanetWeb = ({
     document.documentElement.lang = locale;
   }, [locale, router.isReady]);
 
+  if (isBrowserIncompatible) {
+    return <BrowserNotSupported />;
+  }
+
+  if (!tenantConfig) {
+    return null;
+  }
+
   const isMobile = typeof window !== 'undefined' && window.innerWidth < 481;
 
   const pageComponentProps = {
@@ -157,14 +165,6 @@ const PlanetWeb = ({
     <Component {...pageComponentProps} />,
     pageComponentProps
   );
-
-  if (isBrowserIncompatible) {
-    return <BrowserNotSupported />;
-  }
-
-  if (!tenantConfig) {
-    return null;
-  }
 
   return (
     <NextIntlClientProvider locale={locale} messages={pageProps.messages}>


### PR DESCRIPTION
## Summary
- Type `onRedirectCallback` with `AppState` instead of `any`, move the Vercel URL redirect check into a `useEffect` so it doesn't run during render, and drop the `useMemo` around `isMobile` since it wasn't doing any real memoization.
- Rename `browserCompatible`/`setBrowserCompatible` to `isBrowserIncompatible`/`setIsBrowserIncompatible`. The state held the result of `browserNotCompatible()` and gated `BrowserNotSupported`, so the old name had the polarity backwards.
- Move the browser-incompatible and missing-`tenantConfig` early returns above the `pageContent` computation, so that work isn't done unnecessarily when either check bails out.
- Replace non-null assertions on `AUTH0_CUSTOM_DOMAIN` and `AUTH0_CLIENT_ID` with explicit checks that throw a clear error if either is missing, instead of silently passing `undefined` into `Auth0Provider`.

## Test plan
- [ ] `npm run build` / type-check passes
- [ ] App loads locally on an unsupported browser and shows `BrowserNotSupported`
- [ ] App loads locally on a supported browser and renders normally, with Auth0 login still working