### PR TITLE
fix: update project classification values for SDK 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@mui/x-date-pickers": "^5.0.15",
         "@netlify/plugin-nextjs": "^4.33.0",
         "@next/bundle-analyzer": "^10.2.3",
-        "@planet-sdk/common": "^0.2.4",
+        "@planet-sdk/common": "^0.3.0",
         "@sentry/browser": "^6.15.0",
         "@sentry/integrations": "^6.19.2",
         "@sentry/node": "^6.19.2",
@@ -4744,7 +4744,9 @@
       }
     },
     "node_modules/@planet-sdk/common": {
-      "version": "0.2.4",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@planet-sdk/common/-/common-0.3.0.tgz",
+      "integrity": "sha512-tch50IMeXkbU0+dobNQ4mKWInhvmSpC65zlbMENFt27Op5UzSkk19/FOt1gr3eFmbL2WAGDPIPPa1CsqgC5oMQ==",
       "license": "ISC",
       "dependencies": {
         "@types/geojson": "^7946.0.10"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@mui/x-date-pickers": "^5.0.15",
     "@netlify/plugin-nextjs": "^4.33.0",
     "@next/bundle-analyzer": "^10.2.3",
-    "@planet-sdk/common": "^0.2.4",
+    "@planet-sdk/common": "^0.3.0",
     "@sentry/browser": "^6.15.0",
     "@sentry/integrations": "^6.19.2",
     "@sentry/node": "^6.19.2",

--- a/public/static/locales/en/allProjects.json
+++ b/public/static/locales/en/allProjects.json
@@ -5,12 +5,12 @@
     "deforestation": "Deforestation",
     "projects": "Projects",
     "classificationTypes": {
-      "large-scale-planting": "Large Scale Restoration",
+      "restoration-tree-planting": "Large Scale Restoration",
       "agroforestry": "Agroforestry",
       "natural-regeneration": "Natural Regeneration",
       "managed-regeneration": "Managed Regeneration",
       "urban-planting": "Urban Planting",
-      "other-planting": "Other Planting",
+      "other-restoration": "Other Planting",
       "mangroves": "Mangroves"
     },
     "noFilterApplied": "No Filter Applied",

--- a/public/static/locales/en/project.json
+++ b/public/static/locales/en/project.json
@@ -3,9 +3,11 @@
     "classification": {
       "natural-regeneration": "Natural Regeneration",
       "managed-regeneration": "Managed Regeneration",
+      "restoration-tree-planting": "Large Scale Restoration",
       "large-scale-planting": "Large Scale Restoration",
       "agroforestry": "Agroforestry",
       "urban-planting": "Urban Restoration",
+      "other-restoration": "Restoration",
       "other-planting": "Restoration",
       "mangroves": "Mangroves",
       "conservation": "Conservation"

--- a/src/features/common/ProjectTypeIcon/index.tsx
+++ b/src/features/common/ProjectTypeIcon/index.tsx
@@ -23,8 +23,8 @@ const ProjectTypeIcon = ({ projectType }: Props) => {
       return <UrbanRestoration />;
     case 'conservation':
       return <Conservation />;
-    case 'large-scale-planting':
-    case 'other-planting':
+    case 'restoration-tree-planting':
+    case 'other-restoration':
       return <TreePlanting />;
     default:
       return null;

--- a/src/features/projectsV2/ProjectListControls/microComponents/ClassificationDropDown.tsx
+++ b/src/features/projectsV2/ProjectListControls/microComponents/ClassificationDropDown.tsx
@@ -18,12 +18,12 @@ import { clsx } from 'clsx';
 import { useProjectStore, useViewStore } from '../../../../stores';
 
 const classificationItemIcons = {
-  'large-scale-planting': <TreePlanting width={'20'} height={'20'} />,
+  'restoration-tree-planting': <TreePlanting width={'20'} height={'20'} />,
   agroforestry: <Agroforestry width={'20'} height={'20'} />,
   'natural-regeneration': <NaturalRegeneration width={'20'} height={'20'} />,
   'managed-regeneration': <ManagedRegeneration width={'20'} height={'20'} />,
   'urban-planting': <UrbanRestoration width={'20'} height={'20'} />,
-  'other-planting': <OtherPlanting width={'20'} height={'20'} />,
+  'other-restoration': <OtherPlanting width={'20'} height={'20'} />,
   mangroves: <Mangroves width={'20'} height={'20'} />,
 };
 

--- a/src/features/projectsV2/ProjectsMap/ProjectMarkers/markerImageRegistry.tsx
+++ b/src/features/projectsV2/ProjectsMap/ProjectMarkers/markerImageRegistry.tsx
@@ -39,8 +39,8 @@ const POINT_MARKER_MAP = {
   'managed-regeneration': ManagedRegeneration,
   agroforestry: Agroforestry,
   'urban-planting': UrbanRestoration,
-  'large-scale-planting': TreePlanting,
-  'other-planting': OtherPlanting,
+  'restoration-tree-planting': TreePlanting,
+  'other-restoration': OtherPlanting,
 } as const;
 
 type PointMarkerType = keyof typeof POINT_MARKER_MAP;

--- a/src/features/user/ManageProjects/components/BasicDetails.tsx
+++ b/src/features/user/ManageProjects/components/BasicDetails.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent, ReactElement } from 'react';
-import type { APIError } from '@planet-sdk/common';
+import type { APIError, TreeProjectClassification } from '@planet-sdk/common';
 import type {
   BasicDetailsProps,
   ExtendedProfileProjectProperties,
@@ -157,10 +157,13 @@ export default function BasicDetails({
       });
     }
   };
-  const classifications = [
+  const classifications: {
+    label: string;
+    value: TreeProjectClassification;
+  }[] = [
     {
       label: t('largeScalePlanting'),
-      value: 'large-scale-planting',
+      value: 'restoration-tree-planting',
     },
     {
       label: t('agroforestry'),
@@ -180,7 +183,7 @@ export default function BasicDetails({
     },
     {
       label: t('otherPlanting'),
-      value: 'other-planting',
+      value: 'other-restoration',
     },
   ];
 

--- a/src/features/user/Profile/ContributionsMap/Markers/ClusterIcon.tsx
+++ b/src/features/user/Profile/ContributionsMap/Markers/ClusterIcon.tsx
@@ -48,9 +48,9 @@ const ClusterIcon = ({
       return <AgroforestryClusterMarker {...IconProps} />;
     case 'urban-planting':
       return <UrbanRestorationClusterMarker {...IconProps} />;
-    case 'large-scale-planting':
+    case 'restoration-tree-planting':
       return <TreePlantingClusterMarker {...IconProps} />;
-    case 'other-planting':
+    case 'other-restoration':
       return <OtherPlantingClusterMarker {...IconProps} />;
     default:
       return null;

--- a/src/features/user/Profile/ContributionsMap/Markers/ProjectTypeIcon.tsx
+++ b/src/features/user/Profile/ContributionsMap/Markers/ProjectTypeIcon.tsx
@@ -60,9 +60,9 @@ const ProjectTypeIcon = ({
       return <Agroforestry {...IconProps} />;
     case 'urban-planting':
       return <UrbanRestoration {...IconProps} />;
-    case 'large-scale-planting':
+    case 'restoration-tree-planting':
       return <TreePlanting {...IconProps} />;
-    case 'other-planting':
+    case 'other-restoration':
       return <OtherPlanting {...IconProps} />;
     default:
       return null;

--- a/src/features/user/Profile/stories/MyContributions/ProjectItemCard.stories.tsx
+++ b/src/features/user/Profile/stories/MyContributions/ProjectItemCard.stories.tsx
@@ -18,7 +18,7 @@ const sampleProject: MyForestProject = {
   guid: 'proj_WZkyugryh35sMmZMmXCwq7YY',
   name: 'Yucatán Restoration',
   slug: 'yucatan',
-  classification: 'large-scale-planting',
+  classification: 'restoration-tree-planting',
   purpose: 'trees',
   unitType: 'tree',
   country: 'MX',

--- a/src/features/user/Profile/stories/MyContributions/RegistrationItemCard.stories.tsx
+++ b/src/features/user/Profile/stories/MyContributions/RegistrationItemCard.stories.tsx
@@ -20,7 +20,7 @@ const sampleProject: MyForestProject = {
   guid: 'proj_WZkyugryh35sMmZMmXCwq7YY',
   name: 'Yucatán Restoration',
   slug: 'yucatan',
-  classification: 'large-scale-planting',
+  classification: 'restoration-tree-planting',
   purpose: 'trees',
   unitType: 'tree',
   country: 'MX',

--- a/src/utils/projectV2.ts
+++ b/src/utils/projectV2.ts
@@ -129,13 +129,13 @@ export const getProjectCategory = (
 };
 
 export const availableFilters: TreeProjectClassification[] = [
-  'large-scale-planting',
+  'restoration-tree-planting',
   'agroforestry',
   'natural-regeneration',
   'managed-regeneration',
   'urban-planting',
   'mangroves',
-  'other-planting',
+  'other-restoration',
 ];
 
 export const isValidClassification = (


### PR DESCRIPTION
## What

Bumps `@planet-sdk/common` to 0.3.0 and updates the project classification values it renames.

- `large-scale-planting` → `restoration-tree-planting`
- `other-planting` → `other-restoration`

## Why

The API already serves only the new values. I checked both environments on `_scope=map`: 325 tree projects on staging and 332 on production, with zero old values on either.

This caused two visible bugs on develop:

- Project cards showed the raw key `Project.classification.restoration-tree-planting` instead of a label.
- The "Large Scale Restoration" and "Other Planting" filters returned no results, because `filterByClassification` does an exact string match against a filter list still holding the old spellings.
- About 47% of tree projects were missing from the map. `getPointMarkerImageKey` returns `''` for a classification that is not in `POINT_MARKER_MAP`, and `ProjectMarkersGL` drops those projects from the `FeatureCollection` before it reaches maplibre. So they were not just missing a pin, they were absent from the layer and could not be hovered or clicked. On production that was 157 of 332 tree projects: 136 `restoration-tree-planting` plus 21 `other-restoration`.

## Changes

- `package.json` — SDK to `^0.3.0`
- `projectV2.ts` — new values in `availableFilters`
- Icon maps and switch cases in `ClassificationDropDown`, `markerImageRegistry`, `ClusterIcon`, `ProjectTypeIcon`, `common/ProjectTypeIcon`
- Two storybook fixtures
- `en/allProjects.json` — renamed keys
- `en/project.json` — new keys, with the old ones kept as aliases in case a draft project still holds an old value

Only `en` locale files are touched. The rest sync through Lingohub.

## Testing

- `tsc --noEmit` reports 128 errors, identical to the develop baseline. The bump introduced 12 errors and all 12 are fixed here.
- ESLint clean on all changed files.
- `vitest run src/utils` — 45 pass.
- Verified in the browser: labels, filters, and map markers all render.

## Notes

The SDK 0.3.0 bump also reshapes donation types and drops the deprecated `treeCount` and `quantity` fields. This produced no errors, because the donation code uses local types in `src/features/common/types/` rather than the SDK's.

`feature/project-onboarding` already carries this rename as part of a much larger change. This PR takes only the classification part so develop is fixed without waiting for that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
