### PR TITLE
fix(project-onboarding): handle the questionnaire's new percentage field type

### DIFF
--- a/public/static/locales/en/manageProjects.json
+++ b/public/static/locales/en/manageProjects.json
@@ -152,6 +152,7 @@
     "backToProjectSpending": "Back to Project Spending",
     "optionalFieldSuffix": "(optional)",
     "requiredField": "This field is required",
+    "percentageRange": "Enter a percentage between 0 and 100",
     "incompleteFieldsBanner": "You have not filled in all fields. You can come back later to provide the missing information.",
     "incompleteMedia": "Project Media is incomplete. Please upload at least one image before submitting.",
     "incompleteSites": "Project Sites is incomplete. Please add at least one site before submitting.",

--- a/public/static/locales/en/manageProjects.json
+++ b/public/static/locales/en/manageProjects.json
@@ -153,6 +153,7 @@
     "optionalFieldSuffix": "(optional)",
     "requiredField": "This field is required",
     "percentageRange": "Enter a percentage between 0 and 100",
+    "percentageRangeShort": "Should be between 0-100",
     "incompleteFieldsBanner": "You have not filled in all fields. You can come back later to provide the missing information.",
     "incompleteMedia": "Project Media is incomplete. Please upload at least one image before submitting.",
     "incompleteSites": "Project Sites is incomplete. Please add at least one site before submitting.",

--- a/src/features/common/types/project.d.ts
+++ b/src/features/common/types/project.d.ts
@@ -67,6 +67,7 @@ export interface RevisionRequest {
 export type QuestionnaireFieldType =
   | 'text'
   | 'number'
+  | 'percentage'
   | 'integer'
   | 'string'
   | 'choice'
@@ -82,7 +83,11 @@ export interface QuestionnaireFieldRow {
 }
 
 /** Per-column input type, sent for species_list columns only. */
-export type QuestionnaireColumnType = 'species' | 'number' | 'choice';
+export type QuestionnaireColumnType =
+  | 'species'
+  | 'number'
+  | 'percentage'
+  | 'choice';
 
 export interface QuestionnaireFieldColumn {
   key: string;

--- a/src/features/user/ManageProjects/components/ProjectQuestionnaire.tsx
+++ b/src/features/user/ManageProjects/components/ProjectQuestionnaire.tsx
@@ -4,6 +4,7 @@ import type {
   QuestionnaireProps,
   QuestionnaireSchema,
   QuestionnaireFieldSchema,
+  QuestionnaireFieldType,
   ExtendedProfileProjectProperties,
   ExtendedProfileProjectPropertiesTrees,
   QuestionnaireSpeciesRow,
@@ -20,6 +21,7 @@ import {
   FormGroup,
   FormHelperText,
   FormLabel,
+  InputAdornment,
   Table,
   TableBody,
   TableCell,
@@ -70,6 +72,11 @@ function humanizeLabel(value: string): string {
   return value.replace(/-/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase());
 }
 
+/** A percentage is a number that carries its own 0 to 100 bound, so it renders and loads like one. */
+function isNumericField(type: QuestionnaireFieldType): boolean {
+  return type === 'number' || type === 'integer' || type === 'percentage';
+}
+
 function buildDefaults(
   visibleFields: [string, QuestionnaireFieldSchema][],
   existing: Record<string, unknown> | null | undefined
@@ -86,7 +93,7 @@ function buildDefaults(
         const otherVal = existing?.[otherKey];
         defaults[otherKey] = typeof otherVal === 'string' ? otherVal : '';
       }
-    } else if (field.type === 'number' || field.type === 'integer') {
+    } else if (isNumericField(field.type)) {
       // Number('') is 0, so an untouched field saved as '' would come back as a real answer of zero.
       defaults[name] = isValueSet(val) ? Number(val) : '';
     } else if (field.type === 'row_list' && field.rows) {
@@ -389,8 +396,13 @@ export default function ProjectQuestionnaire({
       );
     }
 
-    // ── number / integer ──────────────────────────────────────────────────
-    if (field.type === 'number' || field.type === 'integer') {
+    // ── number / integer / percentage ─────────────────────────────────────
+    if (isNumericField(field.type)) {
+      const isPercentage = field.type === 'percentage';
+      // The backend rejects a percentage outside 0 to 100, and reports it as a
+      // banner rather than on the field, so the bound is enforced here too.
+      const outOfRange =
+        errors[name]?.type === 'min' || errors[name]?.type === 'max';
       return (
         <div key={name} id={fieldAnchorId(name)} className={fieldClassName}>
           <FormLabel component="legend" error={hasError} sx={{ mb: 0.5 }}>
@@ -402,7 +414,10 @@ export default function ProjectQuestionnaire({
           <Controller
             name={name}
             control={control}
-            rules={{ required: isRequired }}
+            rules={{
+              required: isRequired,
+              ...(isPercentage ? { min: 0, max: 100 } : {}),
+            }}
             render={({ field: { onChange, onBlur, value } }) => (
               <TextField
                 type="number"
@@ -411,7 +426,25 @@ export default function ProjectQuestionnaire({
                 onBlur={onBlur}
                 value={value}
                 error={hasError}
-                helperText={hasError ? t('requiredField') : undefined}
+                inputProps={
+                  isPercentage ? { min: 0, max: 100, step: 'any' } : undefined
+                }
+                InputProps={
+                  isPercentage
+                    ? {
+                        endAdornment: (
+                          <InputAdornment position="end">%</InputAdornment>
+                        ),
+                      }
+                    : undefined
+                }
+                helperText={
+                  outOfRange
+                    ? t('percentageRange')
+                    : hasError
+                    ? t('requiredField')
+                    : undefined
+                }
               />
             )}
           />

--- a/src/features/user/ManageProjects/components/microComponent/SpeciesListTable.tsx
+++ b/src/features/user/ManageProjects/components/microComponent/SpeciesListTable.tsx
@@ -11,6 +11,7 @@ import {
   Autocomplete,
   Button,
   IconButton,
+  InputAdornment,
   MenuItem,
   Table,
   TableBody,
@@ -235,6 +236,22 @@ export default function SpeciesListTable({
                         disabled={disabled}
                         onChange={(event) =>
                           updateCell(rowIndex, column.key, event.target.value)
+                        }
+                        inputProps={
+                          column.type === 'percentage'
+                            ? { min: 0, max: 100, step: 'any' }
+                            : undefined
+                        }
+                        InputProps={
+                          column.type === 'percentage'
+                            ? {
+                                endAdornment: (
+                                  <InputAdornment position="end">
+                                    %
+                                  </InputAdornment>
+                                ),
+                              }
+                            : undefined
                         }
                       />
                     )}

--- a/src/features/user/ManageProjects/components/microComponent/SpeciesListTable.tsx
+++ b/src/features/user/ManageProjects/components/microComponent/SpeciesListTable.tsx
@@ -200,6 +200,11 @@ export default function SpeciesListTable({
             <TableRow key={rowIndex}>
               {columns.map((column) => {
                 const cell = row[column.key] ?? '';
+                // The cell is not a react-hook-form field, so the column's 0 to 100 bound has nothing to enforce it. Checked here so a wrong value is visible rather than silent until the backend rejects the save.
+                const outOfRange =
+                  column.type === 'percentage' &&
+                  cell !== '' &&
+                  (Number(cell) < 0 || Number(cell) > 100);
                 return (
                   <TableCell key={column.key}>
                     {column.type === 'species' ? (
@@ -236,6 +241,10 @@ export default function SpeciesListTable({
                         disabled={disabled}
                         onChange={(event) =>
                           updateCell(rowIndex, column.key, event.target.value)
+                        }
+                        error={outOfRange}
+                        helperText={
+                          outOfRange ? t('percentageRangeShort') : undefined
                         }
                         inputProps={
                           column.type === 'percentage'

--- a/src/features/user/ManageProjects/stories/mockQuestionnaireSchema.ts
+++ b/src/features/user/ManageProjects/stories/mockQuestionnaireSchema.ts
@@ -10,7 +10,7 @@ export const listSpeciesColumns: QuestionnaireFieldColumn[] = [
   {
     key: 'percentage',
     label: 'Approximate % of total trees planted',
-    type: 'number',
+    type: 'percentage',
   },
   {
     key: 'origin',

--- a/src/features/user/ManageProjects/utils/completeness.test.ts
+++ b/src/features/user/ManageProjects/utils/completeness.test.ts
@@ -8,6 +8,7 @@ import {
   getDetailedAnalysisFlagged,
   getQuestionnaireFlagged,
   getQuestionnaireMissing,
+  isFieldFilled,
   isQuestionnaireFieldRequired,
 } from './completeness';
 
@@ -19,6 +20,33 @@ const textField = (
   description: null,
   classifications: null,
   ...overrides,
+});
+
+const percentageField = (
+  overrides: Partial<QuestionnaireFieldSchema> = {}
+): QuestionnaireFieldSchema => ({
+  type: 'percentage',
+  label: 'Survival Rate',
+  description: null,
+  classifications: null,
+  ...overrides,
+});
+
+describe('isFieldFilled for a percentage', () => {
+  // A survival rate of nought is a real answer, so it must not read as unanswered.
+  it('counts zero as answered', () => {
+    expect(isFieldFilled(percentageField(), 0)).toBe(true);
+  });
+
+  it('counts a value in range as answered', () => {
+    expect(isFieldFilled(percentageField(), 80)).toBe(true);
+  });
+
+  it('counts an untouched field as unanswered', () => {
+    expect(isFieldFilled(percentageField(), '')).toBe(false);
+    expect(isFieldFilled(percentageField(), null)).toBe(false);
+    expect(isFieldFilled(percentageField(), undefined)).toBe(false);
+  });
 });
 
 describe('isQuestionnaireFieldRequired', () => {
@@ -105,9 +133,9 @@ describe('getQuestionnaireFlagged', () => {
   ];
 
   it('is empty with no annotations', () => {
-    expect(
-      getQuestionnaireFlagged(fields, { projectGoals: 'done' })
-    ).toEqual([]);
+    expect(getQuestionnaireFlagged(fields, { projectGoals: 'done' })).toEqual(
+      []
+    );
   });
 
   it('lists an answered field a reviewer commented on', () => {


### PR DESCRIPTION
Based on `feature/project-onboarding`, so it can be merged, cherry-picked as a single commit, or just read and hand-applied, whichever suits #2927.

The backend now declares `survivalRate`, `patrolAccessibility` and the species table's share column as `percentage` rather than `number`. Backend side is merged: Plant-for-the-Planet-org/treecounter-platform#798, closing Plant-for-the-Planet-org/treecounter-platform#796.

## The urgent half is the unhandled type

`buildDefaults` and `renderField` both branch on the field type. An unrecognised type falls through to the text default, so before this change a percentage rendered as a three-row textarea, and `buildDefaults` kept only strings.

Values written by this form survive that, because MUI's `type="number"` yields a string and `patchQuestionnaire` stores it unchanged — so a saved `survivalRate` is `"80"` and the `else` branch preserved it. A value written as a JSON number by anything else would have been blanked. Either way the type should not be relying on that.

`percentage` now goes through the same branch as `number` and `integer`, via a small `isNumericField` helper so the three stay together.

## The input itself

A percentage renders as a number field bounded 0 to 100 with a `%` suffix, and shows `percentageRange` on blur when the value is out of range.

The species table's percentage columns get the suffix, the same native bounds, and a per-cell error with a short `0 to 100` helper text. Those cells are not react-hook-form fields — the whole table is one `Controller` — so nothing can attach a rule to them; the check is done where the cell is rendered.

## What this does not do

**It does not block the save.** Save and Continue still calls `trigger()` without awaiting it, so an out-of-range value is submitted and the backend refuses it. Awaiting `trigger()` would also make every blank required field block a save, which an owner must be able to do. That is #2927's A1, and real enforcement belongs with it.

Because of that, the backend's per-field rejections (`questionnaire.survivalRate`, `questionnaire.listSpecies.1.percentage`) are still flattened into a banner by `parseApiError`. Mapping those paths onto `setError` is worth doing once the client refuses the value.

**Numeric answers are still submitted as strings.** There is no `valueAsNumber` anywhere in this form, so `survivalRate` reaches the backend as `"80"`. Pre-existing for every number field, not something percentages introduce.

**Locale is English only.** `percentageRange` and `percentageRangeShort` fall back to English through `defaultMessages` in `i18n.ts`; the other locales come from the usual Lingohub pass.

## Checks

- `vitest run`: 71 passed, 6 files. Three new tests cover the percentage case in `isFieldFilled`, including that `0` counts as answered, since a survival rate of nought is a real answer.
- `tsc --noEmit`: 128 errors before this change and 128 after, none in the touched files.
- `eslint`: no new warnings in the touched files.
